### PR TITLE
Get the full path for the output file.

### DIFF
--- a/Solutions/Corvus.Json.SchemaGenerator/Program.cs
+++ b/Solutions/Corvus.Json.SchemaGenerator/Program.cs
@@ -88,7 +88,7 @@
                 }
                 else
                 {
-                    outputPath = Path.GetDirectoryName(schemaFile)!;
+                    outputPath = Path.GetDirectoryName(Path.GetFullPath(schemaFile))!;
                 }
 
                 string mapFile = string.IsNullOrEmpty(outputMapFile) ? outputMapFile: Path.Combine(outputPath, outputMapFile);

--- a/Solutions/Corvus.Json.Specs/appsettings.json
+++ b/Solutions/Corvus.Json.Specs/appsettings.json
@@ -1,11 +1,11 @@
 {
   "jsonSchemaBuilderDriverSettings": {
-    "remotesBaseDirectory": "C:\\Users\\matth\\source\\repos\\JSON-Schema-Test-Suite\\remotes\\"
+    "remotesBaseDirectory": "../../../../../JSON-Schema-Test-Suite/remotes/"
   },
   "jsonSchemaBuilder201909DriverSettings": {
-    "testBaseDirectory": "C:\\Users\\matth\\source\\repos\\JSON-Schema-Test-Suite\\tests\\draft2019-09"
+    "testBaseDirectory": "../../../../../JSON-Schema-Test-Suite/tests/draft2019-09"
   },
   "jsonSchemaBuilder202012DriverSettings": {
-    "testBaseDirectory": "C:\\Users\\matth\\source\\repos\\JSON-Schema-Test-Suite\\tests\\draft2020-12"
+    "testBaseDirectory": "../../../../../JSON-Schema-Test-Suite/tests/draft2020-12"
   }
 }

--- a/Solutions/Corvus.Json.Specs/appsettings.json
+++ b/Solutions/Corvus.Json.Specs/appsettings.json
@@ -1,11 +1,11 @@
 {
   "jsonSchemaBuilderDriverSettings": {
-    "remotesBaseDirectory": "../../../../../JSON-Schema-Test-Suite/remotes/"
+    "remotesBaseDirectory": "C:\\Users\\matth\\source\\repos\\JSON-Schema-Test-Suite\\remotes\\"
   },
   "jsonSchemaBuilder201909DriverSettings": {
-    "testBaseDirectory": "../../../../../JSON-Schema-Test-Suite/tests/draft2019-09"
+    "testBaseDirectory": "C:\\Users\\matth\\source\\repos\\JSON-Schema-Test-Suite\\tests\\draft2019-09"
   },
   "jsonSchemaBuilder202012DriverSettings": {
-    "testBaseDirectory": "../../../../../JSON-Schema-Test-Suite/tests/draft2020-12"
+    "testBaseDirectory": "C:\\Users\\matth\\source\\repos\\JSON-Schema-Test-Suite\\tests\\draft2020-12"
   }
 }


### PR DESCRIPTION
In the current version, the application will generate a default output path name from the input file name.
Unfortunately, it does not work if you specify a relative path name to the file, only a full path.
This fix gets the `FullPathName` of the input to generate the output.

Fixes #21 