### PR TITLE
Make the reported command name match the ToolCommand name.

### DIFF
--- a/Solutions/Corvus.Json.SchemaGenerator/Program.cs
+++ b/Solutions/Corvus.Json.SchemaGenerator/Program.cs
@@ -44,6 +44,7 @@
                     "If a --rootPath is specified, rebase the document as if it was rooted on the specified element."),
             };
 
+            rootCommand.Name = "generatejsonschematypes";
             rootCommand.Description = "Generate C# types from a JSON schema.";
 
             rootCommand.AddArgument(
@@ -138,9 +139,9 @@
                 }
 
             }
-            catch (Exception)
+            catch (Exception ex)
             {
-                Console.Error.WriteLine($"Unable to generate types.");
+                Console.Error.WriteLine(ex.Message);
                 return -1;
             }
 


### PR DESCRIPTION
- Improved the message when reporting errors.
- Updated the root command name to match the `ToolCommand` name in the csproj file.