### PR TITLE
Assume an entity may be an object if one of its constructor conversions has properties.

### DIFF
--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntityPartial201909.cs
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntityPartial201909.cs
@@ -2265,7 +2265,7 @@ public partial class SchemaEntity201909
         /// <summary>
         /// Gets a value indicating whether this is an object value.
         /// </summary>
-        public bool IsObject => this.typeDeclaration.Schema.IsObjectType();
+        public bool IsObject => this.typeDeclaration.Schema.IsObjectType() || this.typeDeclaration.Properties.Length > 0;
 
         /// <summary>
         /// Gets a value indicating whether this is an array value.

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntityPartial202012.cs
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntityPartial202012.cs
@@ -2265,7 +2265,7 @@ public partial class SchemaEntity202012
         /// <summary>
         /// Gets a value indicating whether this is an object value.
         /// </summary>
-        public bool IsObject => this.typeDeclaration.Schema.IsObjectType();
+        public bool IsObject => this.typeDeclaration.Schema.IsObjectType() || this.typeDeclaration.Properties.Length > 0;
 
         /// <summary>
         /// Gets a value indicating whether this is an array value.


### PR DESCRIPTION
- Conversions are "object"-like if _either_ the schema is naturally object-like _or_ the target type declaration is object-like (i.e. it has accrued properties from somewhere in its definition).