### PR TITLE
Fix issue with local files v. (absolute or relative) URIs.

### DIFF
--- a/Solutions/Corvus.Json.SchemaGenerator/Program.cs
+++ b/Solutions/Corvus.Json.SchemaGenerator/Program.cs
@@ -62,7 +62,7 @@
             rootCommand.Name = "generatejsonschematypes";
             rootCommand.Description = "Generate C# types from a JSON schema.";
 
-           
+
             rootCommand.AddArgument(schemaFile);
 
 
@@ -98,6 +98,17 @@
                         _ => new JsonSchema.TypeBuilder.Draft202012.JsonSchemaBuilder(walker)
                     };
 
+                if (!new JsonUri(schemaFile).IsValid())
+                {
+                    // If this is, in fact, a local file path, not a uri, then convert to a fullpath and URI-style separators.
+                    if (!Path.IsPathFullyQualified(schemaFile))
+                    {
+                        schemaFile = Path.GetFullPath(schemaFile);
+                    }
+
+                    schemaFile = schemaFile.Replace('\\', '/');
+                }
+
                 JsonReference reference = new JsonReference(schemaFile).Apply(new JsonReference(rootPath));
                 string resolvedReference = await walker.TryRebaseDocumentToPropertyValue(reference, "$id").ConfigureAwait(false);
 
@@ -109,7 +120,7 @@
                 }
                 else
                 {
-                    outputPath = Path.GetDirectoryName(Path.GetFullPath(schemaFile))!;
+                    outputPath = Path.GetDirectoryName(schemaFile)!;
                 }
 
                 string mapFile = string.IsNullOrEmpty(outputMapFile) ? outputMapFile : Path.Combine(outputPath, outputMapFile);


### PR DESCRIPTION
- Local paths need to be converted to the right format to be composable using URI composition semantics
- Relative local paths need to be converted to absolute local paths to get resolution right
- Leave JSON compatible URIs alone