### PR TITLE
Feature/47 deal with const properties in create

### DIFF
--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonPointer.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonPointer.cs
@@ -318,6 +318,12 @@ namespace Corvus.Json
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Applicator.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Applicator.cs
@@ -1258,6 +1258,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)
@@ -2479,6 +2485,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -3187,6 +3199,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -3709,6 +3727,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -4155,6 +4179,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
                 }
 
                 /// <inheritdoc/>
+                public override string ToString()
+                {
+                    return this.Serialize();
+                }
+
+                /// <inheritdoc/>
                 public override bool Equals(object? obj)
                 {
                     if (obj is IJsonValue jv)
@@ -4449,6 +4479,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static bool operator !=(DependentSchemasValue lhs, DependentSchemasValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -5047,6 +5083,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static SchemaArray From(Corvus.Json.JsonSchema.Draft201909.Schema item1, Corvus.Json.JsonSchema.Draft201909.Schema item2, Corvus.Json.JsonSchema.Draft201909.Schema item3, Corvus.Json.JsonSchema.Draft201909.Schema item4)
             {
                 return new SchemaArray(ImmutableList.Create((JsonAny)item1, (JsonAny)item2, (JsonAny)item3, (JsonAny)item4));
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Content.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Content.cs
@@ -459,6 +459,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Core.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Core.cs
@@ -802,6 +802,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)
@@ -1507,6 +1513,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -1913,6 +1925,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -2246,6 +2264,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -2570,6 +2594,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static bool operator !=(VocabularyValue lhs, VocabularyValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -3098,6 +3128,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static bool operator !=(DefsValue lhs, DefsValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Format.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Format.cs
@@ -345,6 +345,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/MetaData.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/MetaData.cs
@@ -688,6 +688,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)
@@ -1323,6 +1329,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -1650,6 +1662,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -1974,6 +1992,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static bool operator !=(WriteOnlyValue lhs, WriteOnlyValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -2371,6 +2395,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static JsonAnyArray From(JsonAny item1, JsonAny item2, JsonAny item3, JsonAny item4)
             {
                 return new JsonAnyArray(ImmutableList.Create(item1, item2, item3, item4));
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Schema.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Schema.cs
@@ -4162,6 +4162,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)
@@ -4917,6 +4923,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -5436,6 +5448,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static bool operator !=(DependenciesValue lhs, DependenciesValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -6474,6 +6492,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
                 public static AdditionalPropertiesEntity From(JsonAny item1, JsonAny item2, JsonAny item3, JsonAny item4)
                 {
                     return new AdditionalPropertiesEntity(ImmutableList.Create(item1, item2, item3, item4));
+                }
+
+                /// <inheritdoc/>
+                public override string ToString()
+                {
+                    return this.Serialize();
                 }
 
                 /// <inheritdoc/>

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Validation.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft201909/Validation.cs
@@ -1429,6 +1429,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)
@@ -2242,6 +2248,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -2656,6 +2668,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static bool operator !=(NonNegativeIntegerValue lhs, NonNegativeIntegerValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -3146,6 +3164,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -3482,6 +3506,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static bool operator !=(UniqueItemsValue lhs, UniqueItemsValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -3966,6 +3996,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -4378,6 +4414,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static JsonStringArray From(Corvus.Json.JsonString item1, Corvus.Json.JsonString item2, Corvus.Json.JsonString item3, Corvus.Json.JsonString item4)
             {
                 return new JsonStringArray(ImmutableList.Create((JsonAny)item1, (JsonAny)item2, (JsonAny)item3, (JsonAny)item4));
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -4916,6 +4958,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static bool operator !=(DependentRequiredValue lhs, DependentRequiredValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -5508,6 +5556,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static JsonAnyArray From(JsonAny item1, JsonAny item2, JsonAny item3, JsonAny item4)
             {
                 return new JsonAnyArray(ImmutableList.Create(item1, item2, item3, item4));
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -6365,6 +6419,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -6985,6 +7045,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
                 }
 
                 /// <inheritdoc/>
+                public override string ToString()
+                {
+                    return this.Serialize();
+                }
+
+                /// <inheritdoc/>
                 public override bool Equals(object? obj)
                 {
                     if (obj is IJsonValue jv)
@@ -7593,6 +7659,12 @@ namespace Corvus.Json.JsonSchema.Draft201909
             public static bool operator !=(SimpleTypesEntity lhs, SimpleTypesEntity rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Applicator.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Applicator.cs
@@ -1145,6 +1145,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)
@@ -1912,6 +1918,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -2440,6 +2452,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -2962,6 +2980,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -3408,6 +3432,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
                 }
 
                 /// <inheritdoc/>
+                public override string ToString()
+                {
+                    return this.Serialize();
+                }
+
+                /// <inheritdoc/>
                 public override bool Equals(object? obj)
                 {
                     if (obj is IJsonValue jv)
@@ -3702,6 +3732,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             public static bool operator !=(DependentSchemasValue lhs, DependentSchemasValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Content.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Content.cs
@@ -460,6 +460,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Core.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Core.cs
@@ -802,6 +802,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)
@@ -1463,6 +1469,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -1853,6 +1865,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -2195,6 +2213,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             public static bool operator !=(VocabularyValue lhs, VocabularyValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -2723,6 +2747,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             public static bool operator !=(DefsValue lhs, DefsValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/FormatAnnotation.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/FormatAnnotation.cs
@@ -346,6 +346,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/MetaData.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/MetaData.cs
@@ -689,6 +689,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)
@@ -1324,6 +1330,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -1651,6 +1663,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -1975,6 +1993,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             public static bool operator !=(WriteOnlyValue lhs, WriteOnlyValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -2372,6 +2396,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             public static JsonAnyArray From(JsonAny item1, JsonAny item2, JsonAny item3, JsonAny item4)
             {
                 return new JsonAnyArray(ImmutableList.Create(item1, item2, item3, item4));
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Schema.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Schema.cs
@@ -4362,6 +4362,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)
@@ -5153,6 +5159,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -5672,6 +5684,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             public static bool operator !=(DependenciesValue lhs, DependenciesValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -6728,6 +6746,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
                 public static AdditionalPropertiesEntity From(JsonAny item1, JsonAny item2, JsonAny item3, JsonAny item4)
                 {
                     return new AdditionalPropertiesEntity(ImmutableList.Create(item1, item2, item3, item4));
+                }
+
+                /// <inheritdoc/>
+                public override string ToString()
+                {
+                    return this.Serialize();
                 }
 
                 /// <inheritdoc/>

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Unevaluated.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Unevaluated.cs
@@ -403,6 +403,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Validation.cs
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema/Draft202012/Validation.cs
@@ -1430,6 +1430,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
         }
 
         /// <inheritdoc/>
+        public override string ToString()
+        {
+            return this.Serialize();
+        }
+
+        /// <inheritdoc/>
         public override bool Equals(object? obj)
         {
             if (obj is IJsonValue jv)
@@ -2519,6 +2525,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -3136,6 +3148,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
                 public static SimpleTypesEntityArray From(Corvus.Json.JsonSchema.Draft202012.Validation.SimpleTypesEntity item1, Corvus.Json.JsonSchema.Draft202012.Validation.SimpleTypesEntity item2, Corvus.Json.JsonSchema.Draft202012.Validation.SimpleTypesEntity item3, Corvus.Json.JsonSchema.Draft202012.Validation.SimpleTypesEntity item4)
                 {
                     return new SimpleTypesEntityArray(ImmutableList.Create((JsonAny)item1, (JsonAny)item2, (JsonAny)item3, (JsonAny)item4));
+                }
+
+                /// <inheritdoc/>
+                public override string ToString()
+                {
+                    return this.Serialize();
                 }
 
                 /// <inheritdoc/>
@@ -3764,6 +3782,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -4342,6 +4366,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -4756,6 +4786,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             public static bool operator !=(NonNegativeIntegerValue lhs, NonNegativeIntegerValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -5246,6 +5282,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -5582,6 +5624,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             public static bool operator !=(UniqueItemsValue lhs, UniqueItemsValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -6066,6 +6114,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             }
 
             /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
+            }
+
+            /// <inheritdoc/>
             public override bool Equals(object? obj)
             {
                 if (obj is IJsonValue jv)
@@ -6478,6 +6532,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             public static JsonStringArray From(Corvus.Json.JsonString item1, Corvus.Json.JsonString item2, Corvus.Json.JsonString item3, Corvus.Json.JsonString item4)
             {
                 return new JsonStringArray(ImmutableList.Create((JsonAny)item1, (JsonAny)item2, (JsonAny)item3, (JsonAny)item4));
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -7016,6 +7076,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             public static bool operator !=(DependentRequiredValue lhs, DependentRequiredValue rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>
@@ -7594,6 +7660,12 @@ namespace Corvus.Json.JsonSchema.Draft202012
             public static bool operator !=(SimpleTypesEntity lhs, SimpleTypesEntity rhs)
             {
                 return !lhs.Equals(rhs);
+            }
+
+            /// <inheritdoc/>
+            public override string ToString()
+            {
+                return this.Serialize();
             }
 
             /// <inheritdoc/>

--- a/Solutions/Corvus.Json.SchemaGenerator/Program.cs
+++ b/Solutions/Corvus.Json.SchemaGenerator/Program.cs
@@ -98,7 +98,8 @@
                         _ => new JsonSchema.TypeBuilder.Draft202012.JsonSchemaBuilder(walker)
                     };
 
-                if (!new JsonUri(schemaFile).IsValid())
+                var uri = new JsonUri(schemaFile);
+                if (!uri.IsValid() || uri.GetUri().IsFile)
                 {
                     // If this is, in fact, a local file path, not a uri, then convert to a fullpath and URI-style separators.
                     if (!Path.IsPathFullyQualified(schemaFile))

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntity201909.cs
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntity201909.cs
@@ -7885,59 +7885,19 @@ namespace ");
         
         #line 2431 "SchemaEntity201909.tt"
 
-            if (IsConst(property.Type))
-            {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 2435 "SchemaEntity201909.tt"
-        this.Write("            else\r\n            {\r\n                builder.Add(");
-        
-        #line default
-        #line hidden
-        
-        #line 2437 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName));
-        
-        #line default
-        #line hidden
-        
-        #line 2437 "SchemaEntity201909.tt"
-        this.Write("JsonPropertyName, new ");
-        
-        #line default
-        #line hidden
-        
-        #line 2437 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 2437 "SchemaEntity201909.tt"
-        this.Write("());\r\n            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 2439 "SchemaEntity201909.tt"
-
-            }
         }
         
         
         #line default
         #line hidden
         
-        #line 2443 "SchemaEntity201909.tt"
+        #line 2434 "SchemaEntity201909.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2446 "SchemaEntity201909.tt"
+        #line 2437 "SchemaEntity201909.tt"
 
         foreach(var property in Properties)
         {
@@ -7950,19 +7910,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2454 "SchemaEntity201909.tt"
+        #line 2445 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Sets ");
         
         #line default
         #line hidden
         
-        #line 2456 "SchemaEntity201909.tt"
+        #line 2447 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(property.JsonPropertyName, true).Trim('"') ));
         
         #line default
         #line hidden
         
-        #line 2456 "SchemaEntity201909.tt"
+        #line 2447 "SchemaEntity201909.tt"
         this.Write(".\r\n        /// </summary>\r\n        /// <param name=\"value\">The value to set.</par" +
                 "am>\r\n        /// <returns>The entity with the updated property.</returns>\r\n     " +
                 "   public ");
@@ -7970,55 +7930,55 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2460 "SchemaEntity201909.tt"
+        #line 2451 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2460 "SchemaEntity201909.tt"
+        #line 2451 "SchemaEntity201909.tt"
         this.Write(" With");
         
         #line default
         #line hidden
         
-        #line 2460 "SchemaEntity201909.tt"
+        #line 2451 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 2460 "SchemaEntity201909.tt"
+        #line 2451 "SchemaEntity201909.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 2460 "SchemaEntity201909.tt"
+        #line 2451 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2460 "SchemaEntity201909.tt"
+        #line 2451 "SchemaEntity201909.tt"
         this.Write(" value)\r\n        {\r\n            return this.SetProperty(");
         
         #line default
         #line hidden
         
-        #line 2462 "SchemaEntity201909.tt"
+        #line 2453 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 2462 "SchemaEntity201909.tt"
+        #line 2453 "SchemaEntity201909.tt"
         this.Write("JsonPropertyName, value);\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2465 "SchemaEntity201909.tt"
+        #line 2456 "SchemaEntity201909.tt"
 
         }
         
@@ -8026,13 +7986,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2468 "SchemaEntity201909.tt"
+        #line 2459 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2469 "SchemaEntity201909.tt"
+        #line 2460 "SchemaEntity201909.tt"
 
     }
     
@@ -8040,7 +8000,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2472 "SchemaEntity201909.tt"
+        #line 2463 "SchemaEntity201909.tt"
         this.Write(@"
         /// <inheritdoc/>
         public override string ToString()
@@ -8071,7 +8031,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2497 "SchemaEntity201909.tt"
+        #line 2488 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -8080,13 +8040,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2501 "SchemaEntity201909.tt"
+        #line 2492 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2502 "SchemaEntity201909.tt"
+        #line 2493 "SchemaEntity201909.tt"
 
     }
     else
@@ -8096,13 +8056,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2507 "SchemaEntity201909.tt"
+        #line 2498 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2508 "SchemaEntity201909.tt"
+        #line 2499 "SchemaEntity201909.tt"
 
     }
     
@@ -8110,13 +8070,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2511 "SchemaEntity201909.tt"
+        #line 2502 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2511 "SchemaEntity201909.tt"
+        #line 2502 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -8125,13 +8085,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2515 "SchemaEntity201909.tt"
+        #line 2506 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2516 "SchemaEntity201909.tt"
+        #line 2507 "SchemaEntity201909.tt"
 
     }
     else
@@ -8141,13 +8101,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2521 "SchemaEntity201909.tt"
+        #line 2512 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2522 "SchemaEntity201909.tt"
+        #line 2513 "SchemaEntity201909.tt"
 
     }
     
@@ -8155,13 +8115,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2525 "SchemaEntity201909.tt"
+        #line 2516 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2525 "SchemaEntity201909.tt"
+        #line 2516 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -8170,13 +8130,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2529 "SchemaEntity201909.tt"
+        #line 2520 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2530 "SchemaEntity201909.tt"
+        #line 2521 "SchemaEntity201909.tt"
 
     }
     else
@@ -8186,13 +8146,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2535 "SchemaEntity201909.tt"
+        #line 2526 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2536 "SchemaEntity201909.tt"
+        #line 2527 "SchemaEntity201909.tt"
 
     }
     
@@ -8200,13 +8160,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2539 "SchemaEntity201909.tt"
+        #line 2530 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2539 "SchemaEntity201909.tt"
+        #line 2530 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -8215,13 +8175,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2543 "SchemaEntity201909.tt"
+        #line 2534 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2544 "SchemaEntity201909.tt"
+        #line 2535 "SchemaEntity201909.tt"
 
     }
     else
@@ -8231,13 +8191,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2549 "SchemaEntity201909.tt"
+        #line 2540 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2550 "SchemaEntity201909.tt"
+        #line 2541 "SchemaEntity201909.tt"
 
     }
     
@@ -8245,13 +8205,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2553 "SchemaEntity201909.tt"
+        #line 2544 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2553 "SchemaEntity201909.tt"
+        #line 2544 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -8260,14 +8220,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2557 "SchemaEntity201909.tt"
+        #line 2548 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.GetHa" +
                 "shCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2558 "SchemaEntity201909.tt"
+        #line 2549 "SchemaEntity201909.tt"
 
     }
     else
@@ -8277,14 +8237,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2563 "SchemaEntity201909.tt"
+        #line 2554 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Get" +
                 "HashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2564 "SchemaEntity201909.tt"
+        #line 2555 "SchemaEntity201909.tt"
 
     }
     
@@ -8292,7 +8252,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2567 "SchemaEntity201909.tt"
+        #line 2558 "SchemaEntity201909.tt"
         this.Write(@"                JsonValueKind.Null => JsonNull.NullHashCode,
                 _ => JsonAny.UndefinedHashCode,
             };
@@ -8309,7 +8269,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2578 "SchemaEntity201909.tt"
+        #line 2569 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -8318,7 +8278,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2582 "SchemaEntity201909.tt"
+        #line 2573 "SchemaEntity201909.tt"
         this.Write("            if (this.objectBacking is ImmutableDictionary<string, JsonAny> object" +
                 "Backing)\r\n            {\r\n                JsonObject.WriteProperties(objectBackin" +
                 "g, writer);\r\n                return;\r\n            }\r\n\r\n    ");
@@ -8326,7 +8286,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2588 "SchemaEntity201909.tt"
+        #line 2579 "SchemaEntity201909.tt"
 
     }
     
@@ -8334,13 +8294,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2591 "SchemaEntity201909.tt"
+        #line 2582 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2592 "SchemaEntity201909.tt"
+        #line 2583 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -8349,7 +8309,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2596 "SchemaEntity201909.tt"
+        #line 2587 "SchemaEntity201909.tt"
         this.Write("            if (this.arrayBacking is ImmutableList<JsonAny> arrayBacking)\r\n      " +
                 "      {\r\n                JsonArray.WriteItems(arrayBacking, writer);\r\n          " +
                 "      return;\r\n            }\r\n\r\n    ");
@@ -8357,7 +8317,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2602 "SchemaEntity201909.tt"
+        #line 2593 "SchemaEntity201909.tt"
 
     }
     
@@ -8365,13 +8325,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2605 "SchemaEntity201909.tt"
+        #line 2596 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2606 "SchemaEntity201909.tt"
+        #line 2597 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -8380,7 +8340,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2610 "SchemaEntity201909.tt"
+        #line 2601 "SchemaEntity201909.tt"
         this.Write("            if (this.numberBacking is double numberBacking)\r\n            {\r\n     " +
                 "           writer.WriteNumberValue(numberBacking);\r\n                return;\r\n   " +
                 "         }\r\n\r\n    ");
@@ -8388,7 +8348,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2616 "SchemaEntity201909.tt"
+        #line 2607 "SchemaEntity201909.tt"
 
     }
     
@@ -8396,13 +8356,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2619 "SchemaEntity201909.tt"
+        #line 2610 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2620 "SchemaEntity201909.tt"
+        #line 2611 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -8411,7 +8371,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2624 "SchemaEntity201909.tt"
+        #line 2615 "SchemaEntity201909.tt"
         this.Write("            if (this.stringBacking is string stringBacking)\r\n            {\r\n     " +
                 "           writer.WriteStringValue(stringBacking);\r\n                return;\r\n   " +
                 "         }\r\n\r\n    ");
@@ -8419,7 +8379,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2630 "SchemaEntity201909.tt"
+        #line 2621 "SchemaEntity201909.tt"
 
     }
     
@@ -8427,13 +8387,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2633 "SchemaEntity201909.tt"
+        #line 2624 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2634 "SchemaEntity201909.tt"
+        #line 2625 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -8442,7 +8402,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2638 "SchemaEntity201909.tt"
+        #line 2629 "SchemaEntity201909.tt"
         this.Write("            if (this.booleanBacking is bool booleanBacking)\r\n            {\r\n     " +
                 "           writer.WriteBooleanValue(booleanBacking);\r\n                return;\r\n " +
                 "           }\r\n    ");
@@ -8450,7 +8410,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2643 "SchemaEntity201909.tt"
+        #line 2634 "SchemaEntity201909.tt"
 
     }
     
@@ -8458,7 +8418,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2646 "SchemaEntity201909.tt"
+        #line 2637 "SchemaEntity201909.tt"
         this.Write("\r\n            if (this.jsonElementBacking.ValueKind != JsonValueKind.Undefined)\r\n" +
                 "            {\r\n                this.jsonElementBacking.WriteTo(writer);\r\n       " +
                 "         return;\r\n            }\r\n\r\n            writer.WriteNullValue();\r\n       " +
@@ -8467,7 +8427,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2656 "SchemaEntity201909.tt"
+        #line 2647 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -8476,13 +8436,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2660 "SchemaEntity201909.tt"
+        #line 2651 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2661 "SchemaEntity201909.tt"
+        #line 2652 "SchemaEntity201909.tt"
 
         if (HasAdditionalPropertiesObject && !HasUnevaluatedPropertiesObject)
         {
@@ -8491,20 +8451,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2665 "SchemaEntity201909.tt"
+        #line 2656 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the object as the given item type\r\n " +
                 "       /// </summary>\r\n        public JsonObjectEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2668 "SchemaEntity201909.tt"
+        #line 2659 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2668 "SchemaEntity201909.tt"
+        #line 2659 "SchemaEntity201909.tt"
         this.Write("> EnumerateProperties()\r\n        {\r\n            if (this.objectBacking is Immutab" +
                 "leDictionary<string, JsonAny> properties)\r\n            {\r\n                return" +
                 " new JsonObjectEnumerator<");
@@ -8512,13 +8472,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2672 "SchemaEntity201909.tt"
+        #line 2663 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2672 "SchemaEntity201909.tt"
+        #line 2663 "SchemaEntity201909.tt"
         this.Write(">(properties);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKin" +
                 "d == JsonValueKind.Object)\r\n            {\r\n                return new JsonObject" +
                 "Enumerator<");
@@ -8526,20 +8486,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2677 "SchemaEntity201909.tt"
+        #line 2668 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2677 "SchemaEntity201909.tt"
+        #line 2668 "SchemaEntity201909.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n\r\n    " +
                 "    }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2683 "SchemaEntity201909.tt"
+        #line 2674 "SchemaEntity201909.tt"
 
         }
         
@@ -8547,13 +8507,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2686 "SchemaEntity201909.tt"
+        #line 2677 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2687 "SchemaEntity201909.tt"
+        #line 2678 "SchemaEntity201909.tt"
 
         if (!HasAdditionalPropertiesObject && HasUnevaluatedPropertiesObject)
         {
@@ -8562,20 +8522,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2691 "SchemaEntity201909.tt"
+        #line 2682 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the object as the given item type\r\n " +
                 "       /// </summary>\r\n        public JsonObjectEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2694 "SchemaEntity201909.tt"
+        #line 2685 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2694 "SchemaEntity201909.tt"
+        #line 2685 "SchemaEntity201909.tt"
         this.Write("> EnumerateProperties()\r\n        {\r\n            if (this.objectBacking is Immutab" +
                 "leDictionary<string, JsonAny> properties)\r\n            {\r\n                return" +
                 " new JsonObjectEnumerator<");
@@ -8583,13 +8543,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2698 "SchemaEntity201909.tt"
+        #line 2689 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2698 "SchemaEntity201909.tt"
+        #line 2689 "SchemaEntity201909.tt"
         this.Write(">(properties);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKin" +
                 "d == JsonValueKind.Object)\r\n            {\r\n                return new JsonObject" +
                 "Enumerator<");
@@ -8597,20 +8557,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2703 "SchemaEntity201909.tt"
+        #line 2694 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2703 "SchemaEntity201909.tt"
+        #line 2694 "SchemaEntity201909.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n\r\n    " +
                 "    }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2709 "SchemaEntity201909.tt"
+        #line 2700 "SchemaEntity201909.tt"
 
         }
         
@@ -8618,7 +8578,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2712 "SchemaEntity201909.tt"
+        #line 2703 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public JsonObjectEnumerator EnumerateObject(" +
                 ")\r\n        {\r\n            return this.AsObject.EnumerateObject();\r\n        }\r\n\r\n" +
                 "    ");
@@ -8626,7 +8586,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2719 "SchemaEntity201909.tt"
+        #line 2710 "SchemaEntity201909.tt"
 
     }
     
@@ -8634,13 +8594,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2722 "SchemaEntity201909.tt"
+        #line 2713 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2723 "SchemaEntity201909.tt"
+        #line 2714 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -8649,13 +8609,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2727 "SchemaEntity201909.tt"
+        #line 2718 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2728 "SchemaEntity201909.tt"
+        #line 2719 "SchemaEntity201909.tt"
 
         if (CanEnumerateAsSpecificType)
         {
@@ -8664,32 +8624,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2732 "SchemaEntity201909.tt"
+        #line 2723 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the items in the array as a <see cre" +
                 "f=\"");
         
         #line default
         #line hidden
         
-        #line 2733 "SchemaEntity201909.tt"
+        #line 2724 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2733 "SchemaEntity201909.tt"
+        #line 2724 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public JsonArrayEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2735 "SchemaEntity201909.tt"
+        #line 2726 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2735 "SchemaEntity201909.tt"
+        #line 2726 "SchemaEntity201909.tt"
         this.Write("> EnumerateItems()\r\n        {\r\n            if (this.arrayBacking is ImmutableList" +
                 "<JsonAny> items)\r\n            {\r\n                return new JsonArrayEnumerator<" +
                 "");
@@ -8697,13 +8657,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2739 "SchemaEntity201909.tt"
+        #line 2730 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2739 "SchemaEntity201909.tt"
+        #line 2730 "SchemaEntity201909.tt"
         this.Write(">(items);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKind == " +
                 "JsonValueKind.Array)\r\n            {\r\n                return new JsonArrayEnumera" +
                 "tor<");
@@ -8711,20 +8671,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2744 "SchemaEntity201909.tt"
+        #line 2735 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2744 "SchemaEntity201909.tt"
+        #line 2735 "SchemaEntity201909.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n      " +
                 "  }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2749 "SchemaEntity201909.tt"
+        #line 2740 "SchemaEntity201909.tt"
 
         }
         
@@ -8732,14 +8692,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2752 "SchemaEntity201909.tt"
+        #line 2743 "SchemaEntity201909.tt"
         this.Write("        /// <inheritdoc/>\r\n        public JsonArrayEnumerator EnumerateArray()\r\n " +
                 "       {\r\n            return this.AsArray.EnumerateArray();\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2757 "SchemaEntity201909.tt"
+        #line 2748 "SchemaEntity201909.tt"
 
     }
     
@@ -8747,13 +8707,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2760 "SchemaEntity201909.tt"
+        #line 2751 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2761 "SchemaEntity201909.tt"
+        #line 2752 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -8762,7 +8722,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2765 "SchemaEntity201909.tt"
+        #line 2756 "SchemaEntity201909.tt"
         this.Write(@"
         /// <inheritdoc/>
         public bool TryGetProperty(string name, out JsonAny value)
@@ -8787,7 +8747,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2784 "SchemaEntity201909.tt"
+        #line 2775 "SchemaEntity201909.tt"
 
         if (HasDefaults)
         {
@@ -8796,7 +8756,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2788 "SchemaEntity201909.tt"
+        #line 2779 "SchemaEntity201909.tt"
         this.Write(@"        /// <inheritdoc/>
         public bool TryGetDefault(string name, out JsonAny value)
         {
@@ -8838,7 +8798,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2824 "SchemaEntity201909.tt"
+        #line 2815 "SchemaEntity201909.tt"
 
         }
         
@@ -8846,13 +8806,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2827 "SchemaEntity201909.tt"
+        #line 2818 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2828 "SchemaEntity201909.tt"
+        #line 2819 "SchemaEntity201909.tt"
 
     }
     
@@ -8860,7 +8820,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2831 "SchemaEntity201909.tt"
+        #line 2822 "SchemaEntity201909.tt"
         this.Write(@"
         /// <inheritdoc/>
         public bool Equals<T>(T other)
@@ -8880,7 +8840,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2845 "SchemaEntity201909.tt"
+        #line 2836 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -8889,14 +8849,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2849 "SchemaEntity201909.tt"
+        #line 2840 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.Equals(other.AsObject()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2850 "SchemaEntity201909.tt"
+        #line 2841 "SchemaEntity201909.tt"
 
     }
     else
@@ -8906,14 +8866,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2855 "SchemaEntity201909.tt"
+        #line 2846 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().Equals(other.AsObject())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2856 "SchemaEntity201909.tt"
+        #line 2847 "SchemaEntity201909.tt"
 
     }
     
@@ -8921,13 +8881,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2859 "SchemaEntity201909.tt"
+        #line 2850 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2859 "SchemaEntity201909.tt"
+        #line 2850 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -8936,14 +8896,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2863 "SchemaEntity201909.tt"
+        #line 2854 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.Equals(other.AsArray()),\r\n   " +
                 " ");
         
         #line default
         #line hidden
         
-        #line 2864 "SchemaEntity201909.tt"
+        #line 2855 "SchemaEntity201909.tt"
 
     }
     else
@@ -8953,14 +8913,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2869 "SchemaEntity201909.tt"
+        #line 2860 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().Equals(other.AsArray()),\r\n " +
                 "   ");
         
         #line default
         #line hidden
         
-        #line 2870 "SchemaEntity201909.tt"
+        #line 2861 "SchemaEntity201909.tt"
 
     }
     
@@ -8968,13 +8928,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2873 "SchemaEntity201909.tt"
+        #line 2864 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2873 "SchemaEntity201909.tt"
+        #line 2864 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -8983,14 +8943,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2877 "SchemaEntity201909.tt"
+        #line 2868 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.Equals(other.AsNumber()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2878 "SchemaEntity201909.tt"
+        #line 2869 "SchemaEntity201909.tt"
 
     }
     else
@@ -9000,14 +8960,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2883 "SchemaEntity201909.tt"
+        #line 2874 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().Equals(other.AsNumber())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2884 "SchemaEntity201909.tt"
+        #line 2875 "SchemaEntity201909.tt"
 
     }
     
@@ -9015,13 +8975,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2887 "SchemaEntity201909.tt"
+        #line 2878 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2887 "SchemaEntity201909.tt"
+        #line 2878 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -9030,14 +8990,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2891 "SchemaEntity201909.tt"
+        #line 2882 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString.Equals(other.AsString()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2892 "SchemaEntity201909.tt"
+        #line 2883 "SchemaEntity201909.tt"
 
     }
     else
@@ -9047,14 +9007,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2897 "SchemaEntity201909.tt"
+        #line 2888 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString().Equals(other.AsString())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2898 "SchemaEntity201909.tt"
+        #line 2889 "SchemaEntity201909.tt"
 
     }
     
@@ -9062,13 +9022,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2901 "SchemaEntity201909.tt"
+        #line 2892 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2901 "SchemaEntity201909.tt"
+        #line 2892 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -9077,14 +9037,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2905 "SchemaEntity201909.tt"
+        #line 2896 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.Equal" +
                 "s(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2906 "SchemaEntity201909.tt"
+        #line 2897 "SchemaEntity201909.tt"
 
     }
     else
@@ -9094,14 +9054,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2911 "SchemaEntity201909.tt"
+        #line 2902 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Equ" +
                 "als(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2912 "SchemaEntity201909.tt"
+        #line 2903 "SchemaEntity201909.tt"
 
     }
     
@@ -9109,20 +9069,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2915 "SchemaEntity201909.tt"
+        #line 2906 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Null => true,\r\n                _ => false,\r\n       " +
                 "     };\r\n        }\r\n\r\n        /// <inheritdoc/>\r\n        public bool Equals(");
         
         #line default
         #line hidden
         
-        #line 2921 "SchemaEntity201909.tt"
+        #line 2912 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2921 "SchemaEntity201909.tt"
+        #line 2912 "SchemaEntity201909.tt"
         this.Write(" other)\r\n        {\r\n            JsonValueKind valueKind = this.ValueKind;\r\n\r\n    " +
                 "        if (other.ValueKind != valueKind)\r\n            {\r\n                return" +
                 " false;\r\n            }\r\n\r\n            return valueKind switch\r\n            {\r\n  " +
@@ -9131,7 +9091,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2932 "SchemaEntity201909.tt"
+        #line 2923 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -9140,14 +9100,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2936 "SchemaEntity201909.tt"
+        #line 2927 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.Equals(other.AsObject),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2937 "SchemaEntity201909.tt"
+        #line 2928 "SchemaEntity201909.tt"
 
     }
     else
@@ -9157,14 +9117,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2942 "SchemaEntity201909.tt"
+        #line 2933 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().Equals(other.AsObject())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2943 "SchemaEntity201909.tt"
+        #line 2934 "SchemaEntity201909.tt"
 
     }
     
@@ -9172,13 +9132,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2946 "SchemaEntity201909.tt"
+        #line 2937 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2946 "SchemaEntity201909.tt"
+        #line 2937 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -9187,13 +9147,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2950 "SchemaEntity201909.tt"
+        #line 2941 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.Equals(other.AsArray),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2951 "SchemaEntity201909.tt"
+        #line 2942 "SchemaEntity201909.tt"
 
     }
     else
@@ -9203,14 +9163,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2956 "SchemaEntity201909.tt"
+        #line 2947 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().Equals(other.AsArray()),\r\n " +
                 "   ");
         
         #line default
         #line hidden
         
-        #line 2957 "SchemaEntity201909.tt"
+        #line 2948 "SchemaEntity201909.tt"
 
     }
     
@@ -9218,13 +9178,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2960 "SchemaEntity201909.tt"
+        #line 2951 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2960 "SchemaEntity201909.tt"
+        #line 2951 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -9233,14 +9193,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2964 "SchemaEntity201909.tt"
+        #line 2955 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.Equals(other.AsNumber),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2965 "SchemaEntity201909.tt"
+        #line 2956 "SchemaEntity201909.tt"
 
     }
     else
@@ -9250,14 +9210,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2970 "SchemaEntity201909.tt"
+        #line 2961 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().Equals(other.AsNumber())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2971 "SchemaEntity201909.tt"
+        #line 2962 "SchemaEntity201909.tt"
 
     }
     
@@ -9265,13 +9225,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2974 "SchemaEntity201909.tt"
+        #line 2965 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2974 "SchemaEntity201909.tt"
+        #line 2965 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -9280,14 +9240,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2978 "SchemaEntity201909.tt"
+        #line 2969 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString.Equals(other.AsString),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2979 "SchemaEntity201909.tt"
+        #line 2970 "SchemaEntity201909.tt"
 
     }
     else
@@ -9297,14 +9257,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2984 "SchemaEntity201909.tt"
+        #line 2975 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString().Equals(other.AsString())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2985 "SchemaEntity201909.tt"
+        #line 2976 "SchemaEntity201909.tt"
 
     }
     
@@ -9312,13 +9272,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2988 "SchemaEntity201909.tt"
+        #line 2979 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2988 "SchemaEntity201909.tt"
+        #line 2979 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -9327,14 +9287,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2992 "SchemaEntity201909.tt"
+        #line 2983 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.Equal" +
                 "s(other.AsBoolean),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2993 "SchemaEntity201909.tt"
+        #line 2984 "SchemaEntity201909.tt"
 
     }
     else
@@ -9344,14 +9304,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2998 "SchemaEntity201909.tt"
+        #line 2989 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Equ" +
                 "als(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2999 "SchemaEntity201909.tt"
+        #line 2990 "SchemaEntity201909.tt"
 
     }
     
@@ -9359,14 +9319,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3002 "SchemaEntity201909.tt"
+        #line 2993 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Null => true,\r\n                _ => false,\r\n       " +
                 "     };\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3007 "SchemaEntity201909.tt"
+        #line 2998 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -9375,7 +9335,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3011 "SchemaEntity201909.tt"
+        #line 3002 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public bool HasProperty(string name)\r\n      " +
                 "  {\r\n            if (this.objectBacking is ImmutableDictionary<string, JsonAny> " +
                 "properties)\r\n            {\r\n                return properties.TryGetValue(name, " +
@@ -9401,13 +9361,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3059 "SchemaEntity201909.tt"
+        #line 3050 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3059 "SchemaEntity201909.tt"
+        #line 3050 "SchemaEntity201909.tt"
         this.Write(@" SetProperty<TValue>(string name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9425,13 +9385,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3071 "SchemaEntity201909.tt"
+        #line 3062 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3071 "SchemaEntity201909.tt"
+        #line 3062 "SchemaEntity201909.tt"
         this.Write(@" SetProperty<TValue>(ReadOnlySpan<char> name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9449,13 +9409,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3083 "SchemaEntity201909.tt"
+        #line 3074 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3083 "SchemaEntity201909.tt"
+        #line 3074 "SchemaEntity201909.tt"
         this.Write(@" SetProperty<TValue>(ReadOnlySpan<byte> utf8name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9473,13 +9433,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3095 "SchemaEntity201909.tt"
+        #line 3086 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3095 "SchemaEntity201909.tt"
+        #line 3086 "SchemaEntity201909.tt"
         this.Write(@" RemoveProperty(string name)
         {
             if (this.ValueKind == JsonValueKind.Object)
@@ -9496,13 +9456,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3106 "SchemaEntity201909.tt"
+        #line 3097 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3106 "SchemaEntity201909.tt"
+        #line 3097 "SchemaEntity201909.tt"
         this.Write(@" RemoveProperty(ReadOnlySpan<char> name)
         {
             if (this.ValueKind == JsonValueKind.Object)
@@ -9519,13 +9479,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3117 "SchemaEntity201909.tt"
+        #line 3108 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3117 "SchemaEntity201909.tt"
+        #line 3108 "SchemaEntity201909.tt"
         this.Write(" RemoveProperty(ReadOnlySpan<byte> utf8Name)\r\n        {\r\n            if (this.Val" +
                 "ueKind == JsonValueKind.Object)\r\n            {\r\n                return this.AsOb" +
                 "ject.RemoveProperty(utf8Name);\r\n            }\r\n\r\n            return this;\r\n     " +
@@ -9534,7 +9494,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3127 "SchemaEntity201909.tt"
+        #line 3118 "SchemaEntity201909.tt"
 
     }
     
@@ -9542,13 +9502,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3130 "SchemaEntity201909.tt"
+        #line 3121 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3131 "SchemaEntity201909.tt"
+        #line 3122 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -9557,19 +9517,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3135 "SchemaEntity201909.tt"
+        #line 3126 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 3137 "SchemaEntity201909.tt"
+        #line 3128 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3137 "SchemaEntity201909.tt"
+        #line 3128 "SchemaEntity201909.tt"
         this.Write(@" Add<TItem>(TItem item)
             where TItem : struct, IJsonValue
         {
@@ -9587,13 +9547,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3149 "SchemaEntity201909.tt"
+        #line 3140 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3149 "SchemaEntity201909.tt"
+        #line 3140 "SchemaEntity201909.tt"
         this.Write(@" Add<TItem1, TItem2>(TItem1 item1, TItem2 item2)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9612,13 +9572,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3162 "SchemaEntity201909.tt"
+        #line 3153 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3162 "SchemaEntity201909.tt"
+        #line 3153 "SchemaEntity201909.tt"
         this.Write(@" Add<TItem1, TItem2, TItem3>(TItem1 item1, TItem2 item2, TItem3 item3)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9638,13 +9598,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3176 "SchemaEntity201909.tt"
+        #line 3167 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3176 "SchemaEntity201909.tt"
+        #line 3167 "SchemaEntity201909.tt"
         this.Write(@" Add<TItem1, TItem2, TItem3, TItem4>(TItem1 item1, TItem2 item2, TItem3 item3, TItem4 item4)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9665,13 +9625,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3191 "SchemaEntity201909.tt"
+        #line 3182 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3191 "SchemaEntity201909.tt"
+        #line 3182 "SchemaEntity201909.tt"
         this.Write(@" Add<TItem>(params TItem[] items)
             where TItem : struct, IJsonValue
         {
@@ -9689,13 +9649,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3203 "SchemaEntity201909.tt"
+        #line 3194 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3203 "SchemaEntity201909.tt"
+        #line 3194 "SchemaEntity201909.tt"
         this.Write(@" AddRange<TItem>(IEnumerable<TItem> items)
             where TItem : struct, IJsonValue
         {
@@ -9713,13 +9673,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3215 "SchemaEntity201909.tt"
+        #line 3206 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3215 "SchemaEntity201909.tt"
+        #line 3206 "SchemaEntity201909.tt"
         this.Write(@" Insert<TItem>(int index, TItem item)
             where TItem : struct, IJsonValue
         {
@@ -9737,13 +9697,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3227 "SchemaEntity201909.tt"
+        #line 3218 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3227 "SchemaEntity201909.tt"
+        #line 3218 "SchemaEntity201909.tt"
         this.Write(@" Replace<TItem>(TItem oldValue, TItem newValue)
             where TItem : struct, IJsonValue
         {
@@ -9761,13 +9721,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3239 "SchemaEntity201909.tt"
+        #line 3230 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3239 "SchemaEntity201909.tt"
+        #line 3230 "SchemaEntity201909.tt"
         this.Write(@" RemoveAt(int index)
         {
             if (this.ValueKind == JsonValueKind.Array)
@@ -9784,13 +9744,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3250 "SchemaEntity201909.tt"
+        #line 3241 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3250 "SchemaEntity201909.tt"
+        #line 3241 "SchemaEntity201909.tt"
         this.Write(@" RemoveRange(int index, int count)
         {
             if (this.ValueKind == JsonValueKind.Array)
@@ -9807,13 +9767,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3261 "SchemaEntity201909.tt"
+        #line 3252 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3261 "SchemaEntity201909.tt"
+        #line 3252 "SchemaEntity201909.tt"
         this.Write(@" SetItem<TItem>(int index, TItem value)
             where TItem : struct, IJsonValue
         {
@@ -9830,7 +9790,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3272 "SchemaEntity201909.tt"
+        #line 3263 "SchemaEntity201909.tt"
 
     }
     
@@ -9838,26 +9798,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3275 "SchemaEntity201909.tt"
+        #line 3266 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public T As<T>()\r\n            where T : stru" +
                 "ct, IJsonValue\r\n        {\r\n            return this.As<");
         
         #line default
         #line hidden
         
-        #line 3280 "SchemaEntity201909.tt"
+        #line 3271 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3280 "SchemaEntity201909.tt"
+        #line 3271 "SchemaEntity201909.tt"
         this.Write(", T>();\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3283 "SchemaEntity201909.tt"
+        #line 3274 "SchemaEntity201909.tt"
 
     if(HasPatternProperties)
     {
@@ -9866,13 +9826,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3287 "SchemaEntity201909.tt"
+        #line 3278 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3288 "SchemaEntity201909.tt"
+        #line 3279 "SchemaEntity201909.tt"
 
         foreach(var patternProperty in PatternProperties)
         {
@@ -9881,122 +9841,122 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3292 "SchemaEntity201909.tt"
+        #line 3283 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Determines if a property matches ");
         
         #line default
         #line hidden
         
-        #line 3293 "SchemaEntity201909.tt"
+        #line 3284 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                Formatting.FormatLiteralOrNull(patternProperty.Pattern, true).Trim('"')));
         
         #line default
         #line hidden
         
-        #line 3293 "SchemaEntity201909.tt"
+        #line 3284 "SchemaEntity201909.tt"
         this.Write(" producing a <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 3293 "SchemaEntity201909.tt"
+        #line 3284 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3293 "SchemaEntity201909.tt"
+        #line 3284 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public bool MatchesPattern");
         
         #line default
         #line hidden
         
-        #line 3295 "SchemaEntity201909.tt"
+        #line 3286 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3295 "SchemaEntity201909.tt"
+        #line 3286 "SchemaEntity201909.tt"
         this.Write("(in Property property)\r\n        {\r\n            return PatternProperty");
         
         #line default
         #line hidden
         
-        #line 3297 "SchemaEntity201909.tt"
+        #line 3288 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3297 "SchemaEntity201909.tt"
+        #line 3288 "SchemaEntity201909.tt"
         this.Write(".IsMatch(property.Name);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Get a p" +
                 "roperty as the matching property type ");
         
         #line default
         #line hidden
         
-        #line 3301 "SchemaEntity201909.tt"
+        #line 3292 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                Formatting.FormatLiteralOrNull(patternProperty.Pattern, true).Trim('"')));
         
         #line default
         #line hidden
         
-        #line 3301 "SchemaEntity201909.tt"
+        #line 3292 "SchemaEntity201909.tt"
         this.Write(" as a <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 3301 "SchemaEntity201909.tt"
+        #line 3292 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3301 "SchemaEntity201909.tt"
+        #line 3292 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 3303 "SchemaEntity201909.tt"
+        #line 3294 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3303 "SchemaEntity201909.tt"
+        #line 3294 "SchemaEntity201909.tt"
         this.Write(" AsPattern");
         
         #line default
         #line hidden
         
-        #line 3303 "SchemaEntity201909.tt"
+        #line 3294 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3303 "SchemaEntity201909.tt"
+        #line 3294 "SchemaEntity201909.tt"
         this.Write("(in Property property)\r\n        {\r\n            return property.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 3305 "SchemaEntity201909.tt"
+        #line 3296 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3305 "SchemaEntity201909.tt"
+        #line 3296 "SchemaEntity201909.tt"
         this.Write(">();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3308 "SchemaEntity201909.tt"
+        #line 3299 "SchemaEntity201909.tt"
 
         }
         
@@ -10004,13 +9964,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3311 "SchemaEntity201909.tt"
+        #line 3302 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 3311 "SchemaEntity201909.tt"
+        #line 3302 "SchemaEntity201909.tt"
 
     }
     
@@ -10018,7 +9978,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3314 "SchemaEntity201909.tt"
+        #line 3305 "SchemaEntity201909.tt"
         this.Write(@"
         /// <inheritdoc/>
         public ValidationContext Validate(in ValidationContext? validationContext = null, ValidationLevel level = ValidationLevel.Flag)
@@ -10035,7 +9995,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3325 "SchemaEntity201909.tt"
+        #line 3316 "SchemaEntity201909.tt"
 
         if (HasAdditionalProperties || HasUnevaluatedProperties)
         {
@@ -10044,8 +10004,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3329 "SchemaEntity201909.tt"
+        #line 3320 "SchemaEntity201909.tt"
         this.Write("            result = result.UsingEvaluatedProperties();\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3321 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3324 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3325 "SchemaEntity201909.tt"
+
+        if (HasAdditionalItems || HasUnevaluatedItems)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3329 "SchemaEntity201909.tt"
+        this.Write("            result = result.UsingEvaluatedItems();\r\n        ");
         
         #line default
         #line hidden
@@ -10059,41 +10048,12 @@ namespace ");
         #line hidden
         
         #line 3333 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3334 "SchemaEntity201909.tt"
-
-        if (HasAdditionalItems || HasUnevaluatedItems)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3338 "SchemaEntity201909.tt"
-        this.Write("            result = result.UsingEvaluatedItems();\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3339 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3342 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3343 "SchemaEntity201909.tt"
+        #line 3334 "SchemaEntity201909.tt"
 
     if (HasRef)
     {    
@@ -10102,10 +10062,39 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3347 "SchemaEntity201909.tt"
+        #line 3338 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateRef(result, level);\r\n            if (level == V" +
                 "alidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return r" +
                 "esult;\r\n            }\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3343 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3346 "SchemaEntity201909.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3347 "SchemaEntity201909.tt"
+
+    if ((HasExplicitType || HasFormat || HasMediaTypeOrEncoding) || (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasAdditionalItems) || (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties || HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)))))
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3351 "SchemaEntity201909.tt"
+        this.Write("            JsonValueKind valueKind = this.ValueKind;\r\n    ");
         
         #line default
         #line hidden
@@ -10126,35 +10115,6 @@ namespace ");
         
         #line 3356 "SchemaEntity201909.tt"
 
-    if ((HasExplicitType || HasFormat || HasMediaTypeOrEncoding) || (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasAdditionalItems) || (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties || HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)))))
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3360 "SchemaEntity201909.tt"
-        this.Write("            JsonValueKind valueKind = this.ValueKind;\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3361 "SchemaEntity201909.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3364 "SchemaEntity201909.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3365 "SchemaEntity201909.tt"
-
     if (HasExplicitType || HasFormat || HasMediaTypeOrEncoding)
     {
     
@@ -10162,13 +10122,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3369 "SchemaEntity201909.tt"
+        #line 3360 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3370 "SchemaEntity201909.tt"
+        #line 3361 "SchemaEntity201909.tt"
 
         if (HasExplicitType)
         {
@@ -10177,7 +10137,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3374 "SchemaEntity201909.tt"
+        #line 3365 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateType(valueKind, result, level);\r\n            if" +
                 " (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n            " +
                 "    return result;\r\n            }\r\n        ");
@@ -10185,7 +10145,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3379 "SchemaEntity201909.tt"
+        #line 3370 "SchemaEntity201909.tt"
 
         }
         
@@ -10193,13 +10153,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3382 "SchemaEntity201909.tt"
+        #line 3373 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3383 "SchemaEntity201909.tt"
+        #line 3374 "SchemaEntity201909.tt"
 
         if (HasFormat)
         {
@@ -10208,7 +10168,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3387 "SchemaEntity201909.tt"
+        #line 3378 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateFormat(valueKind, result, level);\r\n            " +
                 "if (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n          " +
                 "      return result;\r\n            }\r\n        ");
@@ -10216,7 +10176,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3392 "SchemaEntity201909.tt"
+        #line 3383 "SchemaEntity201909.tt"
 
         }
         
@@ -10224,13 +10184,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3395 "SchemaEntity201909.tt"
+        #line 3386 "SchemaEntity201909.tt"
         this.Write("\r\n        \r\n        ");
         
         #line default
         #line hidden
         
-        #line 3397 "SchemaEntity201909.tt"
+        #line 3388 "SchemaEntity201909.tt"
 
         if (HasMediaTypeOrEncoding)
         {
@@ -10239,7 +10199,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3401 "SchemaEntity201909.tt"
+        #line 3392 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateMediaTypeAndEncoding(valueKind, result, level);" +
                 "\r\n            if (level == ValidationLevel.Flag && !result.IsValid)\r\n           " +
                 " {\r\n                return result;\r\n            }\r\n        ");
@@ -10247,7 +10207,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3406 "SchemaEntity201909.tt"
+        #line 3397 "SchemaEntity201909.tt"
 
         }
         
@@ -10255,13 +10215,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3409 "SchemaEntity201909.tt"
+        #line 3400 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3410 "SchemaEntity201909.tt"
+        #line 3401 "SchemaEntity201909.tt"
 
     }
     
@@ -10269,13 +10229,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3413 "SchemaEntity201909.tt"
+        #line 3404 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3414 "SchemaEntity201909.tt"
+        #line 3405 "SchemaEntity201909.tt"
 
     if (HasConst)
     {
@@ -10284,7 +10244,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3418 "SchemaEntity201909.tt"
+        #line 3409 "SchemaEntity201909.tt"
         this.Write("            result = Corvus.Json.Validate.ValidateConst(this, result, level, __Co" +
                 "rvusConstValue);\r\n            if (level == ValidationLevel.Flag && !result.IsVal" +
                 "id)\r\n            {\r\n                return result;\r\n            }\r\n\r\n    ");
@@ -10292,7 +10252,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3424 "SchemaEntity201909.tt"
+        #line 3415 "SchemaEntity201909.tt"
 
     }
     
@@ -10300,13 +10260,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3427 "SchemaEntity201909.tt"
+        #line 3418 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3428 "SchemaEntity201909.tt"
+        #line 3419 "SchemaEntity201909.tt"
 
     if (HasEnum)
     {
@@ -10315,14 +10275,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3432 "SchemaEntity201909.tt"
+        #line 3423 "SchemaEntity201909.tt"
         this.Write("            result = Corvus.Json.Validate.ValidateEnum(\r\n                this,\r\n " +
                 "               result,\r\n                level\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3436 "SchemaEntity201909.tt"
+        #line 3427 "SchemaEntity201909.tt"
 
         for(int enumIndex = 0; enumIndex < EnumValues.Length; ++enumIndex)
         {
@@ -10331,25 +10291,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3440 "SchemaEntity201909.tt"
+        #line 3431 "SchemaEntity201909.tt"
         this.Write("                , EnumValues.Item");
         
         #line default
         #line hidden
         
-        #line 3440 "SchemaEntity201909.tt"
+        #line 3431 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( enumIndex ));
         
         #line default
         #line hidden
         
-        #line 3440 "SchemaEntity201909.tt"
+        #line 3431 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3441 "SchemaEntity201909.tt"
+        #line 3432 "SchemaEntity201909.tt"
 
         }
         
@@ -10357,14 +10317,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3444 "SchemaEntity201909.tt"
+        #line 3435 "SchemaEntity201909.tt"
         this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
                 "Valid)\r\n            {\r\n                return result;\r\n            }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3450 "SchemaEntity201909.tt"
+        #line 3441 "SchemaEntity201909.tt"
 
     }
     
@@ -10372,13 +10332,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3453 "SchemaEntity201909.tt"
+        #line 3444 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3454 "SchemaEntity201909.tt"
+        #line 3445 "SchemaEntity201909.tt"
 
     if (HasMultipleOf || HasMaximum || HasExclusiveMaximum|| HasMinimum || HasExclusiveMinimum)
     {
@@ -10387,14 +10347,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3458 "SchemaEntity201909.tt"
+        #line 3449 "SchemaEntity201909.tt"
         this.Write("            result = Corvus.Json.Validate.ValidateNumber(\r\n                this,\r" +
                 "\n                result,\r\n                level,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3462 "SchemaEntity201909.tt"
+        #line 3453 "SchemaEntity201909.tt"
 
         if (HasMultipleOf)
         {
@@ -10403,25 +10363,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3466 "SchemaEntity201909.tt"
+        #line 3457 "SchemaEntity201909.tt"
         this.Write("                ");
         
         #line default
         #line hidden
         
-        #line 3466 "SchemaEntity201909.tt"
+        #line 3457 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MultipleOf ));
         
         #line default
         #line hidden
         
-        #line 3466 "SchemaEntity201909.tt"
+        #line 3457 "SchemaEntity201909.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3467 "SchemaEntity201909.tt"
+        #line 3458 "SchemaEntity201909.tt"
 
         }
         else
@@ -10431,13 +10391,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3472 "SchemaEntity201909.tt"
+        #line 3463 "SchemaEntity201909.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3473 "SchemaEntity201909.tt"
+        #line 3464 "SchemaEntity201909.tt"
 
         }
         
@@ -10445,13 +10405,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3476 "SchemaEntity201909.tt"
+        #line 3467 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3476 "SchemaEntity201909.tt"
+        #line 3467 "SchemaEntity201909.tt"
 
         if (HasMaximum)
         {
@@ -10460,25 +10420,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3480 "SchemaEntity201909.tt"
+        #line 3471 "SchemaEntity201909.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3480 "SchemaEntity201909.tt"
+        #line 3471 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Maximum ));
         
         #line default
         #line hidden
         
-        #line 3480 "SchemaEntity201909.tt"
+        #line 3471 "SchemaEntity201909.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3481 "SchemaEntity201909.tt"
+        #line 3472 "SchemaEntity201909.tt"
 
         }
         else
@@ -10488,13 +10448,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3486 "SchemaEntity201909.tt"
+        #line 3477 "SchemaEntity201909.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3487 "SchemaEntity201909.tt"
+        #line 3478 "SchemaEntity201909.tt"
 
         }
         
@@ -10502,13 +10462,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3490 "SchemaEntity201909.tt"
+        #line 3481 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3490 "SchemaEntity201909.tt"
+        #line 3481 "SchemaEntity201909.tt"
 
         if (HasExclusiveMaximum)
         {
@@ -10517,25 +10477,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3494 "SchemaEntity201909.tt"
+        #line 3485 "SchemaEntity201909.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3494 "SchemaEntity201909.tt"
+        #line 3485 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ExclusiveMaximum ));
         
         #line default
         #line hidden
         
-        #line 3494 "SchemaEntity201909.tt"
+        #line 3485 "SchemaEntity201909.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3495 "SchemaEntity201909.tt"
+        #line 3486 "SchemaEntity201909.tt"
 
         }
         else
@@ -10545,13 +10505,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3500 "SchemaEntity201909.tt"
+        #line 3491 "SchemaEntity201909.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3501 "SchemaEntity201909.tt"
+        #line 3492 "SchemaEntity201909.tt"
 
         }
         
@@ -10559,13 +10519,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3504 "SchemaEntity201909.tt"
+        #line 3495 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3504 "SchemaEntity201909.tt"
+        #line 3495 "SchemaEntity201909.tt"
 
         if (HasMinimum)
         {
@@ -10574,25 +10534,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3508 "SchemaEntity201909.tt"
+        #line 3499 "SchemaEntity201909.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3508 "SchemaEntity201909.tt"
+        #line 3499 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Minimum ));
         
         #line default
         #line hidden
         
-        #line 3508 "SchemaEntity201909.tt"
+        #line 3499 "SchemaEntity201909.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3509 "SchemaEntity201909.tt"
+        #line 3500 "SchemaEntity201909.tt"
 
         }
         else
@@ -10602,13 +10562,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3514 "SchemaEntity201909.tt"
+        #line 3505 "SchemaEntity201909.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3515 "SchemaEntity201909.tt"
+        #line 3506 "SchemaEntity201909.tt"
 
         }
         
@@ -10616,13 +10576,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3518 "SchemaEntity201909.tt"
+        #line 3509 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3518 "SchemaEntity201909.tt"
+        #line 3509 "SchemaEntity201909.tt"
 
         if (HasExclusiveMinimum)
         {
@@ -10631,25 +10591,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3522 "SchemaEntity201909.tt"
+        #line 3513 "SchemaEntity201909.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3522 "SchemaEntity201909.tt"
+        #line 3513 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ExclusiveMinimum ));
         
         #line default
         #line hidden
         
-        #line 3522 "SchemaEntity201909.tt"
+        #line 3513 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3523 "SchemaEntity201909.tt"
+        #line 3514 "SchemaEntity201909.tt"
 
         }
         else
@@ -10659,13 +10619,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3528 "SchemaEntity201909.tt"
+        #line 3519 "SchemaEntity201909.tt"
         this.Write("                null\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3529 "SchemaEntity201909.tt"
+        #line 3520 "SchemaEntity201909.tt"
 
         }
         
@@ -10673,14 +10633,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3532 "SchemaEntity201909.tt"
+        #line 3523 "SchemaEntity201909.tt"
         this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
                 "Valid)\r\n            {\r\n                return result;\r\n            }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3539 "SchemaEntity201909.tt"
+        #line 3530 "SchemaEntity201909.tt"
 
     }
     
@@ -10688,13 +10648,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3542 "SchemaEntity201909.tt"
+        #line 3533 "SchemaEntity201909.tt"
         this.Write("    \r\n    ");
         
         #line default
         #line hidden
         
-        #line 3543 "SchemaEntity201909.tt"
+        #line 3534 "SchemaEntity201909.tt"
 
     if (HasMaxLength || HasMinLength || HasPattern)
     {
@@ -10703,14 +10663,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3547 "SchemaEntity201909.tt"
+        #line 3538 "SchemaEntity201909.tt"
         this.Write("            result = Corvus.Json.Validate.ValidateString(\r\n                this,\r" +
                 "\n                result,\r\n                level,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3551 "SchemaEntity201909.tt"
+        #line 3542 "SchemaEntity201909.tt"
 
         if (HasMaxLength)
         {
@@ -10719,25 +10679,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3555 "SchemaEntity201909.tt"
+        #line 3546 "SchemaEntity201909.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3555 "SchemaEntity201909.tt"
+        #line 3546 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxLength ));
         
         #line default
         #line hidden
         
-        #line 3555 "SchemaEntity201909.tt"
+        #line 3546 "SchemaEntity201909.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3556 "SchemaEntity201909.tt"
+        #line 3547 "SchemaEntity201909.tt"
 
         }
         else
@@ -10747,13 +10707,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3561 "SchemaEntity201909.tt"
+        #line 3552 "SchemaEntity201909.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3562 "SchemaEntity201909.tt"
+        #line 3553 "SchemaEntity201909.tt"
 
         }
         
@@ -10761,13 +10721,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3565 "SchemaEntity201909.tt"
+        #line 3556 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3565 "SchemaEntity201909.tt"
+        #line 3556 "SchemaEntity201909.tt"
 
         if (HasMinLength)
         {
@@ -10776,25 +10736,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3569 "SchemaEntity201909.tt"
+        #line 3560 "SchemaEntity201909.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3569 "SchemaEntity201909.tt"
+        #line 3560 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinLength ));
         
         #line default
         #line hidden
         
-        #line 3569 "SchemaEntity201909.tt"
+        #line 3560 "SchemaEntity201909.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3570 "SchemaEntity201909.tt"
+        #line 3561 "SchemaEntity201909.tt"
 
         }
         else
@@ -10804,13 +10764,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3575 "SchemaEntity201909.tt"
+        #line 3566 "SchemaEntity201909.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3576 "SchemaEntity201909.tt"
+        #line 3567 "SchemaEntity201909.tt"
 
         }
         
@@ -10818,13 +10778,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3579 "SchemaEntity201909.tt"
+        #line 3570 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3579 "SchemaEntity201909.tt"
+        #line 3570 "SchemaEntity201909.tt"
 
         if (HasPattern)
         {
@@ -10833,13 +10793,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3583 "SchemaEntity201909.tt"
+        #line 3574 "SchemaEntity201909.tt"
         this.Write("                __CorvusPatternExpression\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3584 "SchemaEntity201909.tt"
+        #line 3575 "SchemaEntity201909.tt"
 
         }
         else
@@ -10849,13 +10809,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3589 "SchemaEntity201909.tt"
+        #line 3580 "SchemaEntity201909.tt"
         this.Write("                null\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3590 "SchemaEntity201909.tt"
+        #line 3581 "SchemaEntity201909.tt"
 
         }
         
@@ -10863,14 +10823,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3593 "SchemaEntity201909.tt"
+        #line 3584 "SchemaEntity201909.tt"
         this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
                 "Valid)\r\n            {\r\n                return result;\r\n            }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3599 "SchemaEntity201909.tt"
+        #line 3590 "SchemaEntity201909.tt"
 
     }
     
@@ -10878,13 +10838,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3602 "SchemaEntity201909.tt"
+        #line 3593 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3603 "SchemaEntity201909.tt"
+        #line 3594 "SchemaEntity201909.tt"
 
     if (HasIfThenElse)
     {
@@ -10893,7 +10853,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3607 "SchemaEntity201909.tt"
+        #line 3598 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateIfThenElse(result, level);\r\n            if (lev" +
                 "el == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                r" +
                 "eturn result;\r\n            }\r\n\r\n    ");
@@ -10901,7 +10861,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3613 "SchemaEntity201909.tt"
+        #line 3604 "SchemaEntity201909.tt"
 
     }
     
@@ -10909,13 +10869,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3616 "SchemaEntity201909.tt"
+        #line 3607 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3617 "SchemaEntity201909.tt"
+        #line 3608 "SchemaEntity201909.tt"
 
     if (HasNot)
     {
@@ -10924,7 +10884,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3621 "SchemaEntity201909.tt"
+        #line 3612 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateNot(result, level);\r\n            if (level == V" +
                 "alidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return r" +
                 "esult;\r\n            }\r\n\r\n    ");
@@ -10932,7 +10892,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3627 "SchemaEntity201909.tt"
+        #line 3618 "SchemaEntity201909.tt"
 
     }
     
@@ -10940,13 +10900,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3630 "SchemaEntity201909.tt"
+        #line 3621 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3631 "SchemaEntity201909.tt"
+        #line 3622 "SchemaEntity201909.tt"
 
     if (HasAllOf)
     {
@@ -10955,7 +10915,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3635 "SchemaEntity201909.tt"
+        #line 3626 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateAllOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n    ");
@@ -10963,7 +10923,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3640 "SchemaEntity201909.tt"
+        #line 3631 "SchemaEntity201909.tt"
 
     }
     
@@ -10971,13 +10931,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3643 "SchemaEntity201909.tt"
+        #line 3634 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3644 "SchemaEntity201909.tt"
+        #line 3635 "SchemaEntity201909.tt"
 
     if (HasAnyOf)
     {
@@ -10986,7 +10946,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3648 "SchemaEntity201909.tt"
+        #line 3639 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateAnyOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n    ");
@@ -10994,7 +10954,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3653 "SchemaEntity201909.tt"
+        #line 3644 "SchemaEntity201909.tt"
 
     }
     
@@ -11002,13 +10962,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3656 "SchemaEntity201909.tt"
+        #line 3647 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3657 "SchemaEntity201909.tt"
+        #line 3648 "SchemaEntity201909.tt"
 
     if (HasOneOf)
     {
@@ -11017,7 +10977,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3661 "SchemaEntity201909.tt"
+        #line 3652 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateOneOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n\r\n    ");
@@ -11025,7 +10985,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3667 "SchemaEntity201909.tt"
+        #line 3658 "SchemaEntity201909.tt"
 
     }
     
@@ -11033,13 +10993,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3670 "SchemaEntity201909.tt"
+        #line 3661 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3671 "SchemaEntity201909.tt"
+        #line 3662 "SchemaEntity201909.tt"
 
     if (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties || HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)) || !AllowsAdditionalProperties))
     {
@@ -11048,7 +11008,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3675 "SchemaEntity201909.tt"
+        #line 3666 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateObject(valueKind, result, level);\r\n            " +
                 "if (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n          " +
                 "      return result;\r\n            }\r\n\r\n    ");
@@ -11056,7 +11016,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3681 "SchemaEntity201909.tt"
+        #line 3672 "SchemaEntity201909.tt"
 
     }
     
@@ -11064,13 +11024,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3684 "SchemaEntity201909.tt"
+        #line 3675 "SchemaEntity201909.tt"
         this.Write("\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3686 "SchemaEntity201909.tt"
+        #line 3677 "SchemaEntity201909.tt"
 
     if (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasAdditionalItems)
     {
@@ -11079,7 +11039,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3690 "SchemaEntity201909.tt"
+        #line 3681 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateArray(valueKind, result, level);\r\n            i" +
                 "f (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n           " +
                 "     return result;\r\n            }\r\n    ");
@@ -11087,7 +11047,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3695 "SchemaEntity201909.tt"
+        #line 3686 "SchemaEntity201909.tt"
 
     }
     
@@ -11095,13 +11055,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3698 "SchemaEntity201909.tt"
+        #line 3689 "SchemaEntity201909.tt"
         this.Write("            return result;\r\n        }\r\n\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3702 "SchemaEntity201909.tt"
+        #line 3693 "SchemaEntity201909.tt"
 
     if (HasPatternProperties)
     {
@@ -11110,7 +11070,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3706 "SchemaEntity201909.tt"
+        #line 3697 "SchemaEntity201909.tt"
         this.Write(@"        private static ImmutableDictionary<Regex, PatternPropertyValidator> CreatePatternPropertiesValidators()
         {
             ImmutableDictionary<Regex, PatternPropertyValidator>.Builder builder =
@@ -11121,7 +11081,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3711 "SchemaEntity201909.tt"
+        #line 3702 "SchemaEntity201909.tt"
 
         foreach (var patternProperty in PatternProperties)
         {
@@ -11130,37 +11090,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3715 "SchemaEntity201909.tt"
+        #line 3706 "SchemaEntity201909.tt"
         this.Write("            builder.Add(\r\n                PatternProperty");
         
         #line default
         #line hidden
         
-        #line 3716 "SchemaEntity201909.tt"
+        #line 3707 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3716 "SchemaEntity201909.tt"
+        #line 3707 "SchemaEntity201909.tt"
         this.Write(", __CorvusValidatePatternProperty");
         
         #line default
         #line hidden
         
-        #line 3716 "SchemaEntity201909.tt"
+        #line 3707 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3716 "SchemaEntity201909.tt"
+        #line 3707 "SchemaEntity201909.tt"
         this.Write(");\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3717 "SchemaEntity201909.tt"
+        #line 3708 "SchemaEntity201909.tt"
 
         }
         
@@ -11168,13 +11128,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3720 "SchemaEntity201909.tt"
+        #line 3711 "SchemaEntity201909.tt"
         this.Write("\r\n            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3724 "SchemaEntity201909.tt"
+        #line 3715 "SchemaEntity201909.tt"
 
         foreach (var patternProperty in PatternProperties)
         {
@@ -11183,38 +11143,38 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3728 "SchemaEntity201909.tt"
+        #line 3719 "SchemaEntity201909.tt"
         this.Write("        private static ValidationContext __CorvusValidatePatternProperty");
         
         #line default
         #line hidden
         
-        #line 3728 "SchemaEntity201909.tt"
+        #line 3719 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3728 "SchemaEntity201909.tt"
+        #line 3719 "SchemaEntity201909.tt"
         this.Write("(in Property that, in ValidationContext validationContext, ValidationLevel level)" +
                 "\r\n        {\r\n            return that.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 3730 "SchemaEntity201909.tt"
+        #line 3721 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3730 "SchemaEntity201909.tt"
+        #line 3721 "SchemaEntity201909.tt"
         this.Write(">().Validate(validationContext, level);\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3732 "SchemaEntity201909.tt"
+        #line 3723 "SchemaEntity201909.tt"
 
         }
         
@@ -11222,13 +11182,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3735 "SchemaEntity201909.tt"
+        #line 3726 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3736 "SchemaEntity201909.tt"
+        #line 3727 "SchemaEntity201909.tt"
 
     }
     
@@ -11236,13 +11196,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3739 "SchemaEntity201909.tt"
+        #line 3730 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3740 "SchemaEntity201909.tt"
+        #line 3731 "SchemaEntity201909.tt"
 
     if (HasDependentSchemas)
     {
@@ -11251,51 +11211,51 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3744 "SchemaEntity201909.tt"
+        #line 3735 "SchemaEntity201909.tt"
         this.Write("\r\n        private static ImmutableDictionary<string, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3745 "SchemaEntity201909.tt"
+        #line 3736 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3745 "SchemaEntity201909.tt"
+        #line 3736 "SchemaEntity201909.tt"
         this.Write(">> CreateDependentSchemaValidators()\r\n        {\r\n            ImmutableDictionary<" +
                 "string, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3747 "SchemaEntity201909.tt"
+        #line 3738 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3747 "SchemaEntity201909.tt"
+        #line 3738 "SchemaEntity201909.tt"
         this.Write(">>.Builder builder =\r\n                ImmutableDictionary.CreateBuilder<string, P" +
                 "ropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3748 "SchemaEntity201909.tt"
+        #line 3739 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3748 "SchemaEntity201909.tt"
+        #line 3739 "SchemaEntity201909.tt"
         this.Write(">>();\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3750 "SchemaEntity201909.tt"
+        #line 3741 "SchemaEntity201909.tt"
 
         int dsIndex = 0;
         foreach (var dependentSchema in DependentSchemas)
@@ -11306,37 +11266,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3756 "SchemaEntity201909.tt"
+        #line 3747 "SchemaEntity201909.tt"
         this.Write("            builder.Add(\r\n                \"");
         
         #line default
         #line hidden
         
-        #line 3757 "SchemaEntity201909.tt"
+        #line 3748 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dependentSchema.Name ));
         
         #line default
         #line hidden
         
-        #line 3757 "SchemaEntity201909.tt"
+        #line 3748 "SchemaEntity201909.tt"
         this.Write("\", __CorvusValidateDependentSchema");
         
         #line default
         #line hidden
         
-        #line 3757 "SchemaEntity201909.tt"
+        #line 3748 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dsIndex ));
         
         #line default
         #line hidden
         
-        #line 3757 "SchemaEntity201909.tt"
+        #line 3748 "SchemaEntity201909.tt"
         this.Write(");\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3759 "SchemaEntity201909.tt"
+        #line 3750 "SchemaEntity201909.tt"
 
         }
         
@@ -11344,13 +11304,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3762 "SchemaEntity201909.tt"
+        #line 3753 "SchemaEntity201909.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3765 "SchemaEntity201909.tt"
+        #line 3756 "SchemaEntity201909.tt"
 
         int dsIndexV = 0;
         foreach (var dependentSchema in DependentSchemas)
@@ -11361,50 +11321,50 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3771 "SchemaEntity201909.tt"
+        #line 3762 "SchemaEntity201909.tt"
         this.Write("        private static ValidationContext __CorvusValidateDependentSchema");
         
         #line default
         #line hidden
         
-        #line 3771 "SchemaEntity201909.tt"
+        #line 3762 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dsIndexV ));
         
         #line default
         #line hidden
         
-        #line 3771 "SchemaEntity201909.tt"
+        #line 3762 "SchemaEntity201909.tt"
         this.Write("(in ");
         
         #line default
         #line hidden
         
-        #line 3771 "SchemaEntity201909.tt"
+        #line 3762 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3771 "SchemaEntity201909.tt"
+        #line 3762 "SchemaEntity201909.tt"
         this.Write(" that, in ValidationContext validationContext, ValidationLevel level)\r\n        {\r" +
                 "\n            return that.As<");
         
         #line default
         #line hidden
         
-        #line 3773 "SchemaEntity201909.tt"
+        #line 3764 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dependentSchema.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3773 "SchemaEntity201909.tt"
+        #line 3764 "SchemaEntity201909.tt"
         this.Write(">().Validate(validationContext, level);\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3775 "SchemaEntity201909.tt"
+        #line 3766 "SchemaEntity201909.tt"
 
         }
         
@@ -11412,13 +11372,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3778 "SchemaEntity201909.tt"
+        #line 3769 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3779 "SchemaEntity201909.tt"
+        #line 3770 "SchemaEntity201909.tt"
 
     }
     
@@ -11426,13 +11386,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3782 "SchemaEntity201909.tt"
+        #line 3773 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3783 "SchemaEntity201909.tt"
+        #line 3774 "SchemaEntity201909.tt"
 
     if (HasDefaults)
     {
@@ -11441,7 +11401,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3787 "SchemaEntity201909.tt"
+        #line 3778 "SchemaEntity201909.tt"
         this.Write("        private static ImmutableDictionary<string, JsonAny> BuildDefaults()\r\n    " +
                 "    {\r\n            ImmutableDictionary<string, JsonAny>.Builder builder =\r\n     " +
                 "           ImmutableDictionary.CreateBuilder<string, JsonAny>();\r\n\r\n        ");
@@ -11449,7 +11409,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3792 "SchemaEntity201909.tt"
+        #line 3783 "SchemaEntity201909.tt"
 
         foreach (var property in Defaults)
         {
@@ -11458,37 +11418,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3796 "SchemaEntity201909.tt"
+        #line 3787 "SchemaEntity201909.tt"
         this.Write("            builder.Add(");
         
         #line default
         #line hidden
         
-        #line 3796 "SchemaEntity201909.tt"
+        #line 3787 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3796 "SchemaEntity201909.tt"
+        #line 3787 "SchemaEntity201909.tt"
         this.Write("JsonPropertyName, JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 3796 "SchemaEntity201909.tt"
+        #line 3787 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(property.DefaultValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3796 "SchemaEntity201909.tt"
+        #line 3787 "SchemaEntity201909.tt"
         this.Write("));\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3797 "SchemaEntity201909.tt"
+        #line 3788 "SchemaEntity201909.tt"
 
         }
         
@@ -11496,13 +11456,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3800 "SchemaEntity201909.tt"
+        #line 3791 "SchemaEntity201909.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3802 "SchemaEntity201909.tt"
+        #line 3793 "SchemaEntity201909.tt"
 
     }
     
@@ -11510,13 +11470,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3805 "SchemaEntity201909.tt"
+        #line 3796 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3806 "SchemaEntity201909.tt"
+        #line 3797 "SchemaEntity201909.tt"
 
     if (HasDependentRequired)
     {
@@ -11525,7 +11485,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3810 "SchemaEntity201909.tt"
+        #line 3801 "SchemaEntity201909.tt"
         this.Write(@"
         private static ImmutableDictionary<string, ImmutableArray<ReadOnlyMemory<byte>>> BuildDependentRequired()
         {
@@ -11537,7 +11497,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3816 "SchemaEntity201909.tt"
+        #line 3807 "SchemaEntity201909.tt"
 
         foreach (var dependentRequired in DependentRequired)
         {
@@ -11546,26 +11506,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3820 "SchemaEntity201909.tt"
+        #line 3811 "SchemaEntity201909.tt"
         this.Write("            builder.Add(\r\n                    ");
         
         #line default
         #line hidden
         
-        #line 3821 "SchemaEntity201909.tt"
+        #line 3812 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(dependentRequired.Name, true) ));
         
         #line default
         #line hidden
         
-        #line 3821 "SchemaEntity201909.tt"
+        #line 3812 "SchemaEntity201909.tt"
         this.Write(",\r\n                    ImmutableArray.Create<ReadOnlyMemory<byte>>(\r\n            " +
                 "");
         
         #line default
         #line hidden
         
-        #line 3823 "SchemaEntity201909.tt"
+        #line 3814 "SchemaEntity201909.tt"
 
             bool isFirst1 = true;
             foreach (var dependentRequiredValue in dependentRequired.RequiredNames)
@@ -11575,13 +11535,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3828 "SchemaEntity201909.tt"
+        #line 3819 "SchemaEntity201909.tt"
         this.Write("                ");
         
         #line default
         #line hidden
         
-        #line 3828 "SchemaEntity201909.tt"
+        #line 3819 "SchemaEntity201909.tt"
 
                 if (isFirst1)
                 {
@@ -11591,25 +11551,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3833 "SchemaEntity201909.tt"
+        #line 3824 "SchemaEntity201909.tt"
         this.Write("                        System.Text.Encoding.UTF8.GetBytes(");
         
         #line default
         #line hidden
         
-        #line 3833 "SchemaEntity201909.tt"
+        #line 3824 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  Formatting.FormatLiteralOrNull(dependentRequiredValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3833 "SchemaEntity201909.tt"
+        #line 3824 "SchemaEntity201909.tt"
         this.Write(").AsMemory()\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3834 "SchemaEntity201909.tt"
+        #line 3825 "SchemaEntity201909.tt"
 
                 }
                 else
@@ -11619,25 +11579,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3839 "SchemaEntity201909.tt"
+        #line 3830 "SchemaEntity201909.tt"
         this.Write("                        , System.Text.Encoding.UTF8.GetBytes(");
         
         #line default
         #line hidden
         
-        #line 3839 "SchemaEntity201909.tt"
+        #line 3830 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  Formatting.FormatLiteralOrNull(dependentRequiredValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3839 "SchemaEntity201909.tt"
+        #line 3830 "SchemaEntity201909.tt"
         this.Write(").AsMemory()\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3840 "SchemaEntity201909.tt"
+        #line 3831 "SchemaEntity201909.tt"
 
                 }
                 
@@ -11645,13 +11605,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3843 "SchemaEntity201909.tt"
+        #line 3834 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 3843 "SchemaEntity201909.tt"
+        #line 3834 "SchemaEntity201909.tt"
 
             }
             
@@ -11659,13 +11619,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3846 "SchemaEntity201909.tt"
+        #line 3837 "SchemaEntity201909.tt"
         this.Write("                        ));\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3847 "SchemaEntity201909.tt"
+        #line 3838 "SchemaEntity201909.tt"
 
         }
         
@@ -11673,13 +11633,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3850 "SchemaEntity201909.tt"
+        #line 3841 "SchemaEntity201909.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3853 "SchemaEntity201909.tt"
+        #line 3844 "SchemaEntity201909.tt"
 
     }
     
@@ -11687,13 +11647,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3856 "SchemaEntity201909.tt"
+        #line 3847 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3857 "SchemaEntity201909.tt"
+        #line 3848 "SchemaEntity201909.tt"
 
     if (HasLocalProperties)
     {
@@ -11702,51 +11662,51 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3861 "SchemaEntity201909.tt"
+        #line 3852 "SchemaEntity201909.tt"
         this.Write("\r\n        private static ImmutableDictionary<string, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3862 "SchemaEntity201909.tt"
+        #line 3853 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3862 "SchemaEntity201909.tt"
+        #line 3853 "SchemaEntity201909.tt"
         this.Write(">> CreateLocalPropertyValidators()\r\n        {\r\n            ImmutableDictionary<st" +
                 "ring, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3864 "SchemaEntity201909.tt"
+        #line 3855 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3864 "SchemaEntity201909.tt"
+        #line 3855 "SchemaEntity201909.tt"
         this.Write(">>.Builder builder =\r\n                ImmutableDictionary.CreateBuilder<string, P" +
                 "ropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3865 "SchemaEntity201909.tt"
+        #line 3856 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3865 "SchemaEntity201909.tt"
+        #line 3856 "SchemaEntity201909.tt"
         this.Write(">>();\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3867 "SchemaEntity201909.tt"
+        #line 3858 "SchemaEntity201909.tt"
 
         foreach (var property in LocalProperties)
         {
@@ -11755,37 +11715,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3871 "SchemaEntity201909.tt"
+        #line 3862 "SchemaEntity201909.tt"
         this.Write("            builder.Add(\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3872 "SchemaEntity201909.tt"
+        #line 3863 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3872 "SchemaEntity201909.tt"
+        #line 3863 "SchemaEntity201909.tt"
         this.Write("JsonPropertyName, __CorvusValidate");
         
         #line default
         #line hidden
         
-        #line 3872 "SchemaEntity201909.tt"
+        #line 3863 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3872 "SchemaEntity201909.tt"
+        #line 3863 "SchemaEntity201909.tt"
         this.Write(");\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3873 "SchemaEntity201909.tt"
+        #line 3864 "SchemaEntity201909.tt"
 
         }
         
@@ -11793,13 +11753,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3876 "SchemaEntity201909.tt"
+        #line 3867 "SchemaEntity201909.tt"
         this.Write("\r\n            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3880 "SchemaEntity201909.tt"
+        #line 3871 "SchemaEntity201909.tt"
 
         foreach (var property in LocalProperties)
         {
@@ -11808,63 +11768,63 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3884 "SchemaEntity201909.tt"
+        #line 3875 "SchemaEntity201909.tt"
         this.Write("        private static ValidationContext __CorvusValidate");
         
         #line default
         #line hidden
         
-        #line 3884 "SchemaEntity201909.tt"
+        #line 3875 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3884 "SchemaEntity201909.tt"
+        #line 3875 "SchemaEntity201909.tt"
         this.Write("(in ");
         
         #line default
         #line hidden
         
-        #line 3884 "SchemaEntity201909.tt"
+        #line 3875 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3884 "SchemaEntity201909.tt"
+        #line 3875 "SchemaEntity201909.tt"
         this.Write(" that, in ValidationContext validationContext, ValidationLevel level)\r\n        {\r" +
                 "\n            ");
         
         #line default
         #line hidden
         
-        #line 3886 "SchemaEntity201909.tt"
+        #line 3877 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3886 "SchemaEntity201909.tt"
+        #line 3877 "SchemaEntity201909.tt"
         this.Write(" property = that.");
         
         #line default
         #line hidden
         
-        #line 3886 "SchemaEntity201909.tt"
+        #line 3877 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3886 "SchemaEntity201909.tt"
+        #line 3877 "SchemaEntity201909.tt"
         this.Write(";\r\n            return property.Validate(validationContext, level);\r\n        }\r\n  " +
                 "      ");
         
         #line default
         #line hidden
         
-        #line 3889 "SchemaEntity201909.tt"
+        #line 3880 "SchemaEntity201909.tt"
 
         }
         
@@ -11872,13 +11832,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3892 "SchemaEntity201909.tt"
+        #line 3883 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 3892 "SchemaEntity201909.tt"
+        #line 3883 "SchemaEntity201909.tt"
 
     }
     
@@ -11886,13 +11846,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3895 "SchemaEntity201909.tt"
+        #line 3886 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3896 "SchemaEntity201909.tt"
+        #line 3887 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -11901,7 +11861,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3900 "SchemaEntity201909.tt"
+        #line 3891 "SchemaEntity201909.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonObject""/>.
         /// </summary>
@@ -11922,7 +11882,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3915 "SchemaEntity201909.tt"
+        #line 3906 "SchemaEntity201909.tt"
 
     }
     
@@ -11930,13 +11890,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3918 "SchemaEntity201909.tt"
+        #line 3909 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3919 "SchemaEntity201909.tt"
+        #line 3910 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -11945,7 +11905,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3923 "SchemaEntity201909.tt"
+        #line 3914 "SchemaEntity201909.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonArray""/>.
         /// </summary>
@@ -11966,7 +11926,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3938 "SchemaEntity201909.tt"
+        #line 3929 "SchemaEntity201909.tt"
 
     }
     
@@ -11974,13 +11934,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3941 "SchemaEntity201909.tt"
+        #line 3932 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3942 "SchemaEntity201909.tt"
+        #line 3933 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -11989,7 +11949,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3946 "SchemaEntity201909.tt"
+        #line 3937 "SchemaEntity201909.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonNumber""/>.
         /// </summary>
@@ -12010,7 +11970,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3961 "SchemaEntity201909.tt"
+        #line 3952 "SchemaEntity201909.tt"
 
     }
     
@@ -12018,13 +11978,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3964 "SchemaEntity201909.tt"
+        #line 3955 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3965 "SchemaEntity201909.tt"
+        #line 3956 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -12033,7 +11993,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3969 "SchemaEntity201909.tt"
+        #line 3960 "SchemaEntity201909.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonString""/>.
         /// </summary>
@@ -12054,7 +12014,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3984 "SchemaEntity201909.tt"
+        #line 3975 "SchemaEntity201909.tt"
 
     }
     
@@ -12062,13 +12022,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3987 "SchemaEntity201909.tt"
+        #line 3978 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3988 "SchemaEntity201909.tt"
+        #line 3979 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -12077,7 +12037,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3992 "SchemaEntity201909.tt"
+        #line 3983 "SchemaEntity201909.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonBoolean""/>.
         /// </summary>
@@ -12097,7 +12057,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4006 "SchemaEntity201909.tt"
+        #line 3997 "SchemaEntity201909.tt"
 
     }
     
@@ -12105,13 +12065,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4009 "SchemaEntity201909.tt"
+        #line 4000 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4010 "SchemaEntity201909.tt"
+        #line 4001 "SchemaEntity201909.tt"
 
     if (HasRef)
     {
@@ -12120,7 +12080,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4014 "SchemaEntity201909.tt"
+        #line 4005 "SchemaEntity201909.tt"
         this.Write("        private ValidationContext ValidateRef(in ValidationContext validationCont" +
                 "ext, ValidationLevel level)\r\n        {\r\n            ValidationContext result = v" +
                 "alidationContext;\r\n\r\n\r\n            ValidationContext refResult = this.As<");
@@ -12128,13 +12088,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4019 "SchemaEntity201909.tt"
+        #line 4010 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( RefDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4019 "SchemaEntity201909.tt"
+        #line 4010 "SchemaEntity201909.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
             if (!refResult.IsValid)
@@ -12169,7 +12129,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4048 "SchemaEntity201909.tt"
+        #line 4039 "SchemaEntity201909.tt"
 
     }
     
@@ -12177,13 +12137,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4051 "SchemaEntity201909.tt"
+        #line 4042 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4052 "SchemaEntity201909.tt"
+        #line 4043 "SchemaEntity201909.tt"
 
     if (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasAdditionalItems)
     {
@@ -12192,7 +12152,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4056 "SchemaEntity201909.tt"
+        #line 4047 "SchemaEntity201909.tt"
         this.Write(@"        private ValidationContext ValidateArray(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
             ValidationContext result = validationContext;
@@ -12207,7 +12167,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4065 "SchemaEntity201909.tt"
+        #line 4056 "SchemaEntity201909.tt"
 
         if (HasItems || HasContains || HasUniqueItems || HasUnevaluatedItems || HasAdditionalItems)
         {
@@ -12216,13 +12176,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4069 "SchemaEntity201909.tt"
+        #line 4060 "SchemaEntity201909.tt"
         this.Write("\r\n            int arrayLength = 0;\r\n         ");
         
         #line default
         #line hidden
         
-        #line 4071 "SchemaEntity201909.tt"
+        #line 4062 "SchemaEntity201909.tt"
 
         }
         else
@@ -12232,13 +12192,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4076 "SchemaEntity201909.tt"
+        #line 4067 "SchemaEntity201909.tt"
         this.Write("            int arrayLength = this.Length;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4077 "SchemaEntity201909.tt"
+        #line 4068 "SchemaEntity201909.tt"
 
         }
         
@@ -12246,13 +12206,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4080 "SchemaEntity201909.tt"
+        #line 4071 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4081 "SchemaEntity201909.tt"
+        #line 4072 "SchemaEntity201909.tt"
 
         if (HasContains)
         {
@@ -12261,13 +12221,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4085 "SchemaEntity201909.tt"
+        #line 4076 "SchemaEntity201909.tt"
         this.Write("            int containsCount = 0;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4087 "SchemaEntity201909.tt"
+        #line 4078 "SchemaEntity201909.tt"
 
         }
 
@@ -12276,13 +12236,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4091 "SchemaEntity201909.tt"
+        #line 4082 "SchemaEntity201909.tt"
         this.Write("\r\n         ");
         
         #line default
         #line hidden
         
-        #line 4092 "SchemaEntity201909.tt"
+        #line 4083 "SchemaEntity201909.tt"
 
         if (HasItems || HasContains || HasUniqueItems || HasUnevaluatedItems || HasAdditionalItems)
         {
@@ -12291,14 +12251,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4096 "SchemaEntity201909.tt"
+        #line 4087 "SchemaEntity201909.tt"
         this.Write("            JsonArrayEnumerator arrayEnumerator = this.EnumerateArray();\r\n\r\n     " +
                 "       while (arrayEnumerator.MoveNext())\r\n            {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4100 "SchemaEntity201909.tt"
+        #line 4091 "SchemaEntity201909.tt"
 
             if (HasUniqueItems)
             {
@@ -12307,7 +12267,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4104 "SchemaEntity201909.tt"
+        #line 4095 "SchemaEntity201909.tt"
         this.Write(@"                JsonArrayEnumerator innerEnumerator = this.EnumerateArray();
                 int innerIndex = -1;
                 while (innerIndex < arrayLength && innerEnumerator.MoveNext())
@@ -12339,7 +12299,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4130 "SchemaEntity201909.tt"
+        #line 4121 "SchemaEntity201909.tt"
 
             }
         
@@ -12347,13 +12307,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4133 "SchemaEntity201909.tt"
+        #line 4124 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4134 "SchemaEntity201909.tt"
+        #line 4125 "SchemaEntity201909.tt"
 
             if (HasContains)
             {
@@ -12362,19 +12322,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4138 "SchemaEntity201909.tt"
+        #line 4129 "SchemaEntity201909.tt"
         this.Write("                ValidationContext containsResult = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4138 "SchemaEntity201909.tt"
+        #line 4129 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     ContainsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4138 "SchemaEntity201909.tt"
+        #line 4129 "SchemaEntity201909.tt"
         this.Write(">().Validate(result.CreateChildContext(), level);\r\n\r\n                if (contains" +
                 "Result.IsValid)\r\n                {\r\n                    result = result.WithLoca" +
                 "lItemIndex(arrayLength);\r\n                    containsCount++;\r\n\r\n            ");
@@ -12382,7 +12342,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4145 "SchemaEntity201909.tt"
+        #line 4136 "SchemaEntity201909.tt"
 
                 if (HasMaxContains)
                 {
@@ -12391,26 +12351,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4149 "SchemaEntity201909.tt"
+        #line 4140 "SchemaEntity201909.tt"
         this.Write("                    if (level == ValidationLevel.Flag && containsCount > ");
         
         #line default
         #line hidden
         
-        #line 4149 "SchemaEntity201909.tt"
+        #line 4140 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4149 "SchemaEntity201909.tt"
+        #line 4140 "SchemaEntity201909.tt"
         this.Write(")\r\n                    {\r\n                        return result.WithResult(isVali" +
                 "d: false);\r\n                    }\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4153 "SchemaEntity201909.tt"
+        #line 4144 "SchemaEntity201909.tt"
 
                 }
             
@@ -12418,13 +12378,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4156 "SchemaEntity201909.tt"
+        #line 4147 "SchemaEntity201909.tt"
         this.Write("                }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4158 "SchemaEntity201909.tt"
+        #line 4149 "SchemaEntity201909.tt"
 
             }
         
@@ -12432,13 +12392,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4161 "SchemaEntity201909.tt"
+        #line 4152 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4162 "SchemaEntity201909.tt"
+        #line 4153 "SchemaEntity201909.tt"
 
             if (HasSingleItemsType)
             {
@@ -12447,19 +12407,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4166 "SchemaEntity201909.tt"
+        #line 4157 "SchemaEntity201909.tt"
         this.Write("                result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4166 "SchemaEntity201909.tt"
+        #line 4157 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4166 "SchemaEntity201909.tt"
+        #line 4157 "SchemaEntity201909.tt"
         this.Write(">().Validate(result, level);\r\n                if (level == ValidationLevel.Flag &" +
                 "& !result.IsValid)\r\n                {\r\n                    return result;\r\n     " +
                 "           }\r\n\r\n                result = result.WithLocalItemIndex(arrayLength);" +
@@ -12468,7 +12428,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4174 "SchemaEntity201909.tt"
+        #line 4165 "SchemaEntity201909.tt"
 
             }
             else if (HasMultipleItemsType)
@@ -12478,13 +12438,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4179 "SchemaEntity201909.tt"
+        #line 4170 "SchemaEntity201909.tt"
         this.Write("                switch (arrayLength)\r\n                {\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4181 "SchemaEntity201909.tt"
+        #line 4172 "SchemaEntity201909.tt"
 
                 int itemsIndex = 0;
                 foreach (var item in Items)
@@ -12494,31 +12454,31 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4186 "SchemaEntity201909.tt"
+        #line 4177 "SchemaEntity201909.tt"
         this.Write("                    case ");
         
         #line default
         #line hidden
         
-        #line 4186 "SchemaEntity201909.tt"
+        #line 4177 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  itemsIndex ));
         
         #line default
         #line hidden
         
-        #line 4186 "SchemaEntity201909.tt"
+        #line 4177 "SchemaEntity201909.tt"
         this.Write(":\r\n                        result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4187 "SchemaEntity201909.tt"
+        #line 4178 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  item ));
         
         #line default
         #line hidden
         
-        #line 4187 "SchemaEntity201909.tt"
+        #line 4178 "SchemaEntity201909.tt"
         this.Write(@">().Validate(result, level);
                         if (level == ValidationLevel.Flag && !result.IsValid)
                         {
@@ -12532,7 +12492,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4195 "SchemaEntity201909.tt"
+        #line 4186 "SchemaEntity201909.tt"
 
                     itemsIndex++;
                 }
@@ -12541,13 +12501,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4199 "SchemaEntity201909.tt"
+        #line 4190 "SchemaEntity201909.tt"
         this.Write("\r\n                    default:\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4201 "SchemaEntity201909.tt"
+        #line 4192 "SchemaEntity201909.tt"
 
                 if (!AllowsAdditionalItems)
                 {
@@ -12556,7 +12516,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4205 "SchemaEntity201909.tt"
+        #line 4196 "SchemaEntity201909.tt"
         this.Write(@"                        if (level >= ValidationLevel.Detailed)
                         {
                             result = result.WithResult(isValid: false, $""9.3.1.2. additionalItems - Additional items are not permitted at index {arrayLength}."");
@@ -12575,7 +12535,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4218 "SchemaEntity201909.tt"
+        #line 4209 "SchemaEntity201909.tt"
 
                 }
             
@@ -12583,13 +12543,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4221 "SchemaEntity201909.tt"
+        #line 4212 "SchemaEntity201909.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4222 "SchemaEntity201909.tt"
+        #line 4213 "SchemaEntity201909.tt"
 
                 if (AllowsAdditionalItems)
                 {
@@ -12598,13 +12558,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4226 "SchemaEntity201909.tt"
+        #line 4217 "SchemaEntity201909.tt"
         this.Write("                ");
         
         #line default
         #line hidden
         
-        #line 4226 "SchemaEntity201909.tt"
+        #line 4217 "SchemaEntity201909.tt"
 
                     if (HasAdditionalItems)
                     {
@@ -12613,13 +12573,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4230 "SchemaEntity201909.tt"
+        #line 4221 "SchemaEntity201909.tt"
         this.Write("                    ");
         
         #line default
         #line hidden
         
-        #line 4230 "SchemaEntity201909.tt"
+        #line 4221 "SchemaEntity201909.tt"
 
                         if (HasAdditionalItemsSchema)
                         {
@@ -12628,19 +12588,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4234 "SchemaEntity201909.tt"
+        #line 4225 "SchemaEntity201909.tt"
         this.Write("                        result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4234 "SchemaEntity201909.tt"
+        #line 4225 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(      AdditionalItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4234 "SchemaEntity201909.tt"
+        #line 4225 "SchemaEntity201909.tt"
         this.Write(">().Validate(result, level);\r\n                        if (level == ValidationLeve" +
                 "l.Flag && !result.IsValid)\r\n                        {\r\n                         " +
                 "   return result;\r\n                        }\r\n                    ");
@@ -12648,7 +12608,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4239 "SchemaEntity201909.tt"
+        #line 4230 "SchemaEntity201909.tt"
 
                         }
                     
@@ -12656,14 +12616,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4242 "SchemaEntity201909.tt"
+        #line 4233 "SchemaEntity201909.tt"
         this.Write("                        \r\n                        result = result.WithLocalItemIn" +
                 "dex(arrayLength);\r\n\r\n                ");
         
         #line default
         #line hidden
         
-        #line 4245 "SchemaEntity201909.tt"
+        #line 4236 "SchemaEntity201909.tt"
 
                     }
                     else if (HasUnevaluatedItems)
@@ -12673,7 +12633,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4250 "SchemaEntity201909.tt"
+        #line 4241 "SchemaEntity201909.tt"
         this.Write("                        if (!result.HasEvaluatedLocalOrAppliedItemIndex(arrayLeng" +
                 "th))\r\n                        {\r\n\r\n                            result = arrayEnu" +
                 "merator.Current.As<");
@@ -12681,13 +12641,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4253 "SchemaEntity201909.tt"
+        #line 4244 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  UnevaluatedItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4253 "SchemaEntity201909.tt"
+        #line 4244 "SchemaEntity201909.tt"
         this.Write(@">().Validate(result, level);
 
                             if (level == ValidationLevel.Flag && !result.IsValid)
@@ -12702,7 +12662,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4262 "SchemaEntity201909.tt"
+        #line 4253 "SchemaEntity201909.tt"
 
                     }
                 
@@ -12710,13 +12670,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4265 "SchemaEntity201909.tt"
+        #line 4256 "SchemaEntity201909.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4266 "SchemaEntity201909.tt"
+        #line 4257 "SchemaEntity201909.tt"
 
                 }
             
@@ -12724,13 +12684,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4269 "SchemaEntity201909.tt"
+        #line 4260 "SchemaEntity201909.tt"
         this.Write("                        break;\r\n                }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4272 "SchemaEntity201909.tt"
+        #line 4263 "SchemaEntity201909.tt"
 
             }
             else
@@ -12740,13 +12700,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4277 "SchemaEntity201909.tt"
+        #line 4268 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4277 "SchemaEntity201909.tt"
+        #line 4268 "SchemaEntity201909.tt"
 
                 if (AllowsAdditionalItems)
                 {
@@ -12755,13 +12715,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4281 "SchemaEntity201909.tt"
+        #line 4272 "SchemaEntity201909.tt"
         this.Write("                ");
         
         #line default
         #line hidden
         
-        #line 4281 "SchemaEntity201909.tt"
+        #line 4272 "SchemaEntity201909.tt"
 
                     if (!HasAdditionalItems && HasUnevaluatedItems)
                     {
@@ -12770,7 +12730,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4285 "SchemaEntity201909.tt"
+        #line 4276 "SchemaEntity201909.tt"
         this.Write("                        if (!result.HasEvaluatedLocalOrAppliedItemIndex(arrayLeng" +
                 "th))\r\n                        {\r\n                            result = arrayEnume" +
                 "rator.Current.As<");
@@ -12778,13 +12738,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4287 "SchemaEntity201909.tt"
+        #line 4278 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  UnevaluatedItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4287 "SchemaEntity201909.tt"
+        #line 4278 "SchemaEntity201909.tt"
         this.Write(@">().Validate(result, level);
 
                             if (level == ValidationLevel.Flag && !result.IsValid)
@@ -12800,7 +12760,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4297 "SchemaEntity201909.tt"
+        #line 4288 "SchemaEntity201909.tt"
 
                     }
                 
@@ -12808,13 +12768,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4300 "SchemaEntity201909.tt"
+        #line 4291 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4300 "SchemaEntity201909.tt"
+        #line 4291 "SchemaEntity201909.tt"
 
                 }
             
@@ -12822,13 +12782,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4303 "SchemaEntity201909.tt"
+        #line 4294 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4304 "SchemaEntity201909.tt"
+        #line 4295 "SchemaEntity201909.tt"
 
             }
         
@@ -12836,13 +12796,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4307 "SchemaEntity201909.tt"
+        #line 4298 "SchemaEntity201909.tt"
         this.Write("\r\n                arrayLength++;\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4310 "SchemaEntity201909.tt"
+        #line 4301 "SchemaEntity201909.tt"
 
         }
         
@@ -12850,13 +12810,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4313 "SchemaEntity201909.tt"
+        #line 4304 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4314 "SchemaEntity201909.tt"
+        #line 4305 "SchemaEntity201909.tt"
 
         if (HasMaxItems)
         {
@@ -12865,19 +12825,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4318 "SchemaEntity201909.tt"
+        #line 4309 "SchemaEntity201909.tt"
         this.Write("            if (arrayLength > ");
         
         #line default
         #line hidden
         
-        #line 4318 "SchemaEntity201909.tt"
+        #line 4309 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4318 "SchemaEntity201909.tt"
+        #line 4309 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".1. maxItems - {arrayLength} exceeds maximum number of items ");
@@ -12885,13 +12845,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4322 "SchemaEntity201909.tt"
+        #line 4313 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4322 "SchemaEntity201909.tt"
+        #line 4313 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.1. maxItems - item count exceeds maximum number of items ");
@@ -12899,13 +12859,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4326 "SchemaEntity201909.tt"
+        #line 4317 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4326 "SchemaEntity201909.tt"
+        #line 4317 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n\r\n           " +
                 " }\r\n        ");
@@ -12913,7 +12873,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4334 "SchemaEntity201909.tt"
+        #line 4325 "SchemaEntity201909.tt"
 
         }
         
@@ -12921,13 +12881,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4337 "SchemaEntity201909.tt"
+        #line 4328 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4338 "SchemaEntity201909.tt"
+        #line 4329 "SchemaEntity201909.tt"
 
         if (HasMinItems)
         {
@@ -12936,19 +12896,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4342 "SchemaEntity201909.tt"
+        #line 4333 "SchemaEntity201909.tt"
         this.Write("            if (arrayLength < ");
         
         #line default
         #line hidden
         
-        #line 4342 "SchemaEntity201909.tt"
+        #line 4333 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4342 "SchemaEntity201909.tt"
+        #line 4333 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".2. minItems - {arrayLength} is less than the minimum number of items ");
@@ -12956,13 +12916,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4346 "SchemaEntity201909.tt"
+        #line 4337 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4346 "SchemaEntity201909.tt"
+        #line 4337 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.2. minItems - item count is less than the minimum number of items ");
@@ -12970,13 +12930,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4350 "SchemaEntity201909.tt"
+        #line 4341 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4350 "SchemaEntity201909.tt"
+        #line 4341 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n\r\n           " +
                 " }\r\n        ");
@@ -12984,7 +12944,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4358 "SchemaEntity201909.tt"
+        #line 4349 "SchemaEntity201909.tt"
 
         }
         
@@ -12992,13 +12952,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4361 "SchemaEntity201909.tt"
+        #line 4352 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4362 "SchemaEntity201909.tt"
+        #line 4353 "SchemaEntity201909.tt"
 
         if (HasContains)
         {
@@ -13007,13 +12967,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4366 "SchemaEntity201909.tt"
+        #line 4357 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4366 "SchemaEntity201909.tt"
+        #line 4357 "SchemaEntity201909.tt"
 
             if (HasMaxContains)
             {
@@ -13022,19 +12982,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4370 "SchemaEntity201909.tt"
+        #line 4361 "SchemaEntity201909.tt"
         this.Write("\r\n            if (containsCount > ");
         
         #line default
         #line hidden
         
-        #line 4371 "SchemaEntity201909.tt"
+        #line 4362 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4371 "SchemaEntity201909.tt"
+        #line 4362 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".4. maxContains - {containsCount} exceeds maximum number of matching items ");
@@ -13042,13 +13002,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4375 "SchemaEntity201909.tt"
+        #line 4366 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4375 "SchemaEntity201909.tt"
+        #line 4366 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.4. maxContains - item count exceeds maximum number of matching items ");
@@ -13056,13 +13016,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4379 "SchemaEntity201909.tt"
+        #line 4370 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4379 "SchemaEntity201909.tt"
+        #line 4370 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n            ");
@@ -13070,7 +13030,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4387 "SchemaEntity201909.tt"
+        #line 4378 "SchemaEntity201909.tt"
 
             }
             
@@ -13078,13 +13038,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4390 "SchemaEntity201909.tt"
+        #line 4381 "SchemaEntity201909.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4391 "SchemaEntity201909.tt"
+        #line 4382 "SchemaEntity201909.tt"
 
             if (HasMinContains)
             {
@@ -13093,19 +13053,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4395 "SchemaEntity201909.tt"
+        #line 4386 "SchemaEntity201909.tt"
         this.Write("            if (containsCount < ");
         
         #line default
         #line hidden
         
-        #line 4395 "SchemaEntity201909.tt"
+        #line 4386 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4395 "SchemaEntity201909.tt"
+        #line 4386 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".5. minContains - {containsCount} is less than minimum number of matching items " +
@@ -13114,13 +13074,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4399 "SchemaEntity201909.tt"
+        #line 4390 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4399 "SchemaEntity201909.tt"
+        #line 4390 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.5. minContains - item count is less than minimum number of matching ite" +
@@ -13129,13 +13089,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4403 "SchemaEntity201909.tt"
+        #line 4394 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4403 "SchemaEntity201909.tt"
+        #line 4394 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n            ");
@@ -13143,7 +13103,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4411 "SchemaEntity201909.tt"
+        #line 4402 "SchemaEntity201909.tt"
 
             }
             else
@@ -13153,7 +13113,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4416 "SchemaEntity201909.tt"
+        #line 4407 "SchemaEntity201909.tt"
         this.Write(@"            if (containsCount == 0)
             {
                 if (level >= ValidationLevel.Detailed)
@@ -13175,7 +13135,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4432 "SchemaEntity201909.tt"
+        #line 4423 "SchemaEntity201909.tt"
 
             }
             
@@ -13183,13 +13143,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4435 "SchemaEntity201909.tt"
+        #line 4426 "SchemaEntity201909.tt"
         this.Write("\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4437 "SchemaEntity201909.tt"
+        #line 4428 "SchemaEntity201909.tt"
 
         }
         
@@ -13197,13 +13157,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4440 "SchemaEntity201909.tt"
+        #line 4431 "SchemaEntity201909.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4444 "SchemaEntity201909.tt"
+        #line 4435 "SchemaEntity201909.tt"
 
     }
     
@@ -13211,13 +13171,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4447 "SchemaEntity201909.tt"
+        #line 4438 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4448 "SchemaEntity201909.tt"
+        #line 4439 "SchemaEntity201909.tt"
 
     if (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties|| HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)) || !AllowsAdditionalProperties))
     {
@@ -13226,7 +13186,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4452 "SchemaEntity201909.tt"
+        #line 4443 "SchemaEntity201909.tt"
         this.Write(@"        private ValidationContext ValidateObject(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
             ValidationContext result = validationContext;
@@ -13241,7 +13201,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4461 "SchemaEntity201909.tt"
+        #line 4452 "SchemaEntity201909.tt"
 
         if (HasMaxProperties || HasMinProperties || HasLocalProperties || HasRequired || HasDependentSchemas || HasPatternProperties || HasAdditionalProperties || HasUnevaluatedProperties)
         {
@@ -13250,13 +13210,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4465 "SchemaEntity201909.tt"
+        #line 4456 "SchemaEntity201909.tt"
         this.Write("            int propertyCount = 0;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4466 "SchemaEntity201909.tt"
+        #line 4457 "SchemaEntity201909.tt"
 
         }
         
@@ -13264,13 +13224,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4469 "SchemaEntity201909.tt"
+        #line 4460 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4470 "SchemaEntity201909.tt"
+        #line 4461 "SchemaEntity201909.tt"
 
         if (HasRequired)
         {
@@ -13279,13 +13239,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4474 "SchemaEntity201909.tt"
+        #line 4465 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4474 "SchemaEntity201909.tt"
+        #line 4465 "SchemaEntity201909.tt"
  
             foreach(var property in RequiredProperties)
             {
@@ -13294,25 +13254,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4478 "SchemaEntity201909.tt"
+        #line 4469 "SchemaEntity201909.tt"
         this.Write("            bool found");
         
         #line default
         #line hidden
         
-        #line 4478 "SchemaEntity201909.tt"
+        #line 4469 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4478 "SchemaEntity201909.tt"
+        #line 4469 "SchemaEntity201909.tt"
         this.Write(" = false;\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4479 "SchemaEntity201909.tt"
+        #line 4470 "SchemaEntity201909.tt"
 
             }
             
@@ -13320,13 +13280,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4482 "SchemaEntity201909.tt"
+        #line 4473 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4482 "SchemaEntity201909.tt"
+        #line 4473 "SchemaEntity201909.tt"
 
         }
         
@@ -13334,14 +13294,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4485 "SchemaEntity201909.tt"
+        #line 4476 "SchemaEntity201909.tt"
         this.Write("\r\n            foreach (Property property in this.EnumerateObject())\r\n            " +
                 "{\r\n                string propertyName = property.Name;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4490 "SchemaEntity201909.tt"
+        #line 4481 "SchemaEntity201909.tt"
 
         if (HasDependentRequired)
         {
@@ -13350,7 +13310,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4494 "SchemaEntity201909.tt"
+        #line 4485 "SchemaEntity201909.tt"
         this.Write(@"                if (__CorvusDependentRequired.TryGetValue(propertyName, out ImmutableArray<ReadOnlyMemory<byte>> dependencies))
                 {
                     foreach (ReadOnlyMemory<byte> dependency in dependencies)
@@ -13361,7 +13321,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4499 "SchemaEntity201909.tt"
+        #line 4490 "SchemaEntity201909.tt"
 
             if (HasDefaults)
             {
@@ -13370,13 +13330,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4503 "SchemaEntity201909.tt"
+        #line 4494 "SchemaEntity201909.tt"
         this.Write("                        && !this.HasDefault(dependency.Span)\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4504 "SchemaEntity201909.tt"
+        #line 4495 "SchemaEntity201909.tt"
 
             }
             
@@ -13384,7 +13344,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4507 "SchemaEntity201909.tt"
+        #line 4498 "SchemaEntity201909.tt"
         this.Write(@"                        )
                         {
                             if (level >= ValidationLevel.Detailed)
@@ -13408,7 +13368,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4525 "SchemaEntity201909.tt"
+        #line 4516 "SchemaEntity201909.tt"
 
         }
         
@@ -13416,13 +13376,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4528 "SchemaEntity201909.tt"
+        #line 4519 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4529 "SchemaEntity201909.tt"
+        #line 4520 "SchemaEntity201909.tt"
 
         if (HasLocalProperties || HasRequired)
         {
@@ -13431,20 +13391,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4533 "SchemaEntity201909.tt"
+        #line 4524 "SchemaEntity201909.tt"
         this.Write("                if (__CorvusLocalProperties.TryGetValue(propertyName, out Propert" +
                 "yValidator<");
         
         #line default
         #line hidden
         
-        #line 4533 "SchemaEntity201909.tt"
+        #line 4524 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4533 "SchemaEntity201909.tt"
+        #line 4524 "SchemaEntity201909.tt"
         this.Write(@">? propertyValidator))
                 {
                     result = result.WithLocalProperty(propertyCount);
@@ -13460,7 +13420,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4543 "SchemaEntity201909.tt"
+        #line 4534 "SchemaEntity201909.tt"
 
             if (HasRequired)
             {
@@ -13474,13 +13434,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4552 "SchemaEntity201909.tt"
+        #line 4543 "SchemaEntity201909.tt"
         this.Write("                else \r\n                    ");
         
         #line default
         #line hidden
         
-        #line 4553 "SchemaEntity201909.tt"
+        #line 4544 "SchemaEntity201909.tt"
 
                     }
                     else
@@ -13492,38 +13452,38 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4560 "SchemaEntity201909.tt"
+        #line 4551 "SchemaEntity201909.tt"
         this.Write("\r\n                if (");
         
         #line default
         #line hidden
         
-        #line 4561 "SchemaEntity201909.tt"
+        #line 4552 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4561 "SchemaEntity201909.tt"
+        #line 4552 "SchemaEntity201909.tt"
         this.Write("JsonPropertyName.Equals(propertyName))\r\n                {\r\n                    fo" +
                 "und");
         
         #line default
         #line hidden
         
-        #line 4563 "SchemaEntity201909.tt"
+        #line 4554 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  property.DotnetPropertyName));
         
         #line default
         #line hidden
         
-        #line 4563 "SchemaEntity201909.tt"
+        #line 4554 "SchemaEntity201909.tt"
         this.Write(" = true;\r\n                }\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4565 "SchemaEntity201909.tt"
+        #line 4556 "SchemaEntity201909.tt"
 
                 }
             }
@@ -13532,13 +13492,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4569 "SchemaEntity201909.tt"
+        #line 4560 "SchemaEntity201909.tt"
         this.Write("\r\n                }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4571 "SchemaEntity201909.tt"
+        #line 4562 "SchemaEntity201909.tt"
 
         }
         
@@ -13546,13 +13506,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4574 "SchemaEntity201909.tt"
+        #line 4565 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4575 "SchemaEntity201909.tt"
+        #line 4566 "SchemaEntity201909.tt"
 
         if (HasDependentSchemas)
         {
@@ -13561,20 +13521,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4579 "SchemaEntity201909.tt"
+        #line 4570 "SchemaEntity201909.tt"
         this.Write("                if (__CorvusDependentSchema.TryGetValue(propertyName, out Propert" +
                 "yValidator<");
         
         #line default
         #line hidden
         
-        #line 4579 "SchemaEntity201909.tt"
+        #line 4570 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4579 "SchemaEntity201909.tt"
+        #line 4570 "SchemaEntity201909.tt"
         this.Write(@">? dependentSchemaValidator))
                 {
                     result = result.WithLocalProperty(propertyCount);
@@ -13589,7 +13549,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4588 "SchemaEntity201909.tt"
+        #line 4579 "SchemaEntity201909.tt"
 
         }
         
@@ -13597,13 +13557,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4591 "SchemaEntity201909.tt"
+        #line 4582 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4592 "SchemaEntity201909.tt"
+        #line 4583 "SchemaEntity201909.tt"
 
         if (HasPropertyNames || HasPatternProperties)
         {
@@ -13612,13 +13572,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4596 "SchemaEntity201909.tt"
+        #line 4587 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4596 "SchemaEntity201909.tt"
+        #line 4587 "SchemaEntity201909.tt"
 
             if (HasPropertyNames)
             {
@@ -13627,19 +13587,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4600 "SchemaEntity201909.tt"
+        #line 4591 "SchemaEntity201909.tt"
         this.Write("                result = new JsonString(propertyName).As<");
         
         #line default
         #line hidden
         
-        #line 4600 "SchemaEntity201909.tt"
+        #line 4591 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     PropertyNamesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4600 "SchemaEntity201909.tt"
+        #line 4591 "SchemaEntity201909.tt"
         this.Write(">().Validate(result, level);\r\n                if (level == ValidationLevel.Flag &" +
                 "& !result.IsValid)\r\n                {\r\n                    return result;\r\n     " +
                 "           }\r\n            ");
@@ -13647,7 +13607,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4605 "SchemaEntity201909.tt"
+        #line 4596 "SchemaEntity201909.tt"
 
             }
             
@@ -13655,13 +13615,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4608 "SchemaEntity201909.tt"
+        #line 4599 "SchemaEntity201909.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4609 "SchemaEntity201909.tt"
+        #line 4600 "SchemaEntity201909.tt"
 
             if (HasPatternProperties)
             {
@@ -13670,7 +13630,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4613 "SchemaEntity201909.tt"
+        #line 4604 "SchemaEntity201909.tt"
         this.Write(@"                foreach (System.Collections.Generic.KeyValuePair<Regex, PatternPropertyValidator> patternProperty in __CorvusPatternProperties)
                 {
                     if (patternProperty.Key.IsMatch(propertyName))
@@ -13689,7 +13649,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4626 "SchemaEntity201909.tt"
+        #line 4617 "SchemaEntity201909.tt"
 
             }
             
@@ -13697,13 +13657,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4629 "SchemaEntity201909.tt"
+        #line 4620 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4629 "SchemaEntity201909.tt"
+        #line 4620 "SchemaEntity201909.tt"
 
         }
         
@@ -13711,13 +13671,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4632 "SchemaEntity201909.tt"
+        #line 4623 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4633 "SchemaEntity201909.tt"
+        #line 4624 "SchemaEntity201909.tt"
 
         if (AllowsAdditionalProperties && HasAdditionalProperties)
         {
@@ -13726,20 +13686,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4637 "SchemaEntity201909.tt"
+        #line 4628 "SchemaEntity201909.tt"
         this.Write("                if (!result.HasEvaluatedLocalProperty(propertyCount))\r\n          " +
                 "      {\r\n                    result = property.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 4639 "SchemaEntity201909.tt"
+        #line 4630 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4639 "SchemaEntity201909.tt"
+        #line 4630 "SchemaEntity201909.tt"
         this.Write(@">().Validate(result, level);
                     if (level == ValidationLevel.Flag && !result.IsValid)
                     {
@@ -13752,7 +13712,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4646 "SchemaEntity201909.tt"
+        #line 4637 "SchemaEntity201909.tt"
 
         }
         
@@ -13760,13 +13720,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4649 "SchemaEntity201909.tt"
+        #line 4640 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4650 "SchemaEntity201909.tt"
+        #line 4641 "SchemaEntity201909.tt"
 
         if (AllowsAdditionalProperties && HasUnevaluatedProperties)
         {
@@ -13775,20 +13735,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4654 "SchemaEntity201909.tt"
+        #line 4645 "SchemaEntity201909.tt"
         this.Write("        \r\n                if (!result.HasEvaluatedLocalOrAppliedProperty(property" +
                 "Count))\r\n                {\r\n\r\n                    result = property.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 4658 "SchemaEntity201909.tt"
+        #line 4649 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4658 "SchemaEntity201909.tt"
+        #line 4649 "SchemaEntity201909.tt"
         this.Write(@">().Validate(result, level);
                     if (level == ValidationLevel.Flag && !result.IsValid)
                     {
@@ -13802,7 +13762,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4666 "SchemaEntity201909.tt"
+        #line 4657 "SchemaEntity201909.tt"
 
         }
         
@@ -13810,13 +13770,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4669 "SchemaEntity201909.tt"
+        #line 4660 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4670 "SchemaEntity201909.tt"
+        #line 4661 "SchemaEntity201909.tt"
 
         if (!AllowsAdditionalProperties)
         {
@@ -13825,7 +13785,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4674 "SchemaEntity201909.tt"
+        #line 4665 "SchemaEntity201909.tt"
         this.Write(@"        
                 if (!result.HasEvaluatedLocalProperty(propertyCount))
                 {
@@ -13848,7 +13808,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4691 "SchemaEntity201909.tt"
+        #line 4682 "SchemaEntity201909.tt"
 
         }
         
@@ -13856,13 +13816,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4694 "SchemaEntity201909.tt"
+        #line 4685 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4695 "SchemaEntity201909.tt"
+        #line 4686 "SchemaEntity201909.tt"
 
         if (HasMaxProperties || HasMinProperties || HasLocalProperties || HasRequired || HasDependentSchemas || HasPatternProperties || HasAdditionalProperties || HasUnevaluatedProperties)
         {
@@ -13871,13 +13831,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4699 "SchemaEntity201909.tt"
+        #line 4690 "SchemaEntity201909.tt"
         this.Write("        \r\n                propertyCount++;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4702 "SchemaEntity201909.tt"
+        #line 4693 "SchemaEntity201909.tt"
 
         }
         
@@ -13885,13 +13845,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4705 "SchemaEntity201909.tt"
+        #line 4696 "SchemaEntity201909.tt"
         this.Write("            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4707 "SchemaEntity201909.tt"
+        #line 4698 "SchemaEntity201909.tt"
 
         if (HasRequired)
         {
@@ -13900,13 +13860,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4711 "SchemaEntity201909.tt"
+        #line 4702 "SchemaEntity201909.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4712 "SchemaEntity201909.tt"
+        #line 4703 "SchemaEntity201909.tt"
 
             foreach (var property in RequiredProperties)
             {
@@ -13917,19 +13877,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4718 "SchemaEntity201909.tt"
+        #line 4709 "SchemaEntity201909.tt"
         this.Write("            if (!found");
         
         #line default
         #line hidden
         
-        #line 4718 "SchemaEntity201909.tt"
+        #line 4709 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4718 "SchemaEntity201909.tt"
+        #line 4709 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".3. required - required property \\\"");
@@ -13937,13 +13897,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4722 "SchemaEntity201909.tt"
+        #line 4713 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                        Formatting.FormatLiteralOrNull(property.JsonPropertyName, true).Trim('"') ));
         
         #line default
         #line hidden
         
-        #line 4722 "SchemaEntity201909.tt"
+        #line 4713 "SchemaEntity201909.tt"
         this.Write(@"\"" not present."");
                 }
                 else if (level >= ValidationLevel.Basic)
@@ -13960,7 +13920,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4733 "SchemaEntity201909.tt"
+        #line 4724 "SchemaEntity201909.tt"
 
                 }
             }
@@ -13969,13 +13929,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4737 "SchemaEntity201909.tt"
+        #line 4728 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4737 "SchemaEntity201909.tt"
+        #line 4728 "SchemaEntity201909.tt"
 
         }
         
@@ -13983,13 +13943,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4740 "SchemaEntity201909.tt"
+        #line 4731 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4741 "SchemaEntity201909.tt"
+        #line 4732 "SchemaEntity201909.tt"
 
         if (HasMaxProperties)
         {
@@ -13998,19 +13958,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4745 "SchemaEntity201909.tt"
+        #line 4736 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (propertyCount > ");
         
         #line default
         #line hidden
         
-        #line 4746 "SchemaEntity201909.tt"
+        #line 4737 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4746 "SchemaEntity201909.tt"
+        #line 4737 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".1. maxProperties - property count of {propertyCount} is greater than ");
@@ -14018,13 +13978,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4750 "SchemaEntity201909.tt"
+        #line 4741 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4750 "SchemaEntity201909.tt"
+        #line 4741 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.5.1. maxProperties - property count greater than ");
@@ -14032,13 +13992,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4754 "SchemaEntity201909.tt"
+        #line 4745 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4754 "SchemaEntity201909.tt"
+        #line 4745 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n        ");
@@ -14046,7 +14006,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4761 "SchemaEntity201909.tt"
+        #line 4752 "SchemaEntity201909.tt"
 
         }
         
@@ -14054,13 +14014,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4764 "SchemaEntity201909.tt"
+        #line 4755 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4765 "SchemaEntity201909.tt"
+        #line 4756 "SchemaEntity201909.tt"
 
         if (HasMinProperties)
         {
@@ -14069,19 +14029,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4769 "SchemaEntity201909.tt"
+        #line 4760 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (propertyCount < ");
         
         #line default
         #line hidden
         
-        #line 4770 "SchemaEntity201909.tt"
+        #line 4761 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4770 "SchemaEntity201909.tt"
+        #line 4761 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".2. minProperties - property count of {propertyCount} is lezs than ");
@@ -14089,13 +14049,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4774 "SchemaEntity201909.tt"
+        #line 4765 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4774 "SchemaEntity201909.tt"
+        #line 4765 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.5.2. minProperties - property count less than ");
@@ -14103,13 +14063,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4778 "SchemaEntity201909.tt"
+        #line 4769 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4778 "SchemaEntity201909.tt"
+        #line 4769 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n        ");
@@ -14117,7 +14077,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4786 "SchemaEntity201909.tt"
+        #line 4777 "SchemaEntity201909.tt"
 
         }
         
@@ -14125,13 +14085,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4789 "SchemaEntity201909.tt"
+        #line 4780 "SchemaEntity201909.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4793 "SchemaEntity201909.tt"
+        #line 4784 "SchemaEntity201909.tt"
 
     }
     
@@ -14139,13 +14099,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4796 "SchemaEntity201909.tt"
+        #line 4787 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4797 "SchemaEntity201909.tt"
+        #line 4788 "SchemaEntity201909.tt"
 
     if (HasOneOf)
     {
@@ -14154,7 +14114,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4801 "SchemaEntity201909.tt"
+        #line 4792 "SchemaEntity201909.tt"
         this.Write("        \r\n        private ValidationContext ValidateOneOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n            int oneOfCount = 0;\r\n\r\n        ");
@@ -14162,7 +14122,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4808 "SchemaEntity201909.tt"
+        #line 4799 "SchemaEntity201909.tt"
 
         int oneOfIndex = 0;
         foreach (var oneOf in OneOf)
@@ -14172,64 +14132,64 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4813 "SchemaEntity201909.tt"
+        #line 4804 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n            ValidationContext oneOfResult");
         
         #line default
         #line hidden
         
-        #line 4815 "SchemaEntity201909.tt"
+        #line 4806 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex));
         
         #line default
         #line hidden
         
-        #line 4815 "SchemaEntity201909.tt"
+        #line 4806 "SchemaEntity201909.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 4815 "SchemaEntity201909.tt"
+        #line 4806 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOf ));
         
         #line default
         #line hidden
         
-        #line 4815 "SchemaEntity201909.tt"
+        #line 4806 "SchemaEntity201909.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (o" +
                 "neOfResult");
         
         #line default
         #line hidden
         
-        #line 4817 "SchemaEntity201909.tt"
+        #line 4808 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4817 "SchemaEntity201909.tt"
+        #line 4808 "SchemaEntity201909.tt"
         this.Write(".IsValid)\r\n            {\r\n                result = result.MergeChildContext(oneOf" +
                 "Result");
         
         #line default
         #line hidden
         
-        #line 4819 "SchemaEntity201909.tt"
+        #line 4810 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4819 "SchemaEntity201909.tt"
+        #line 4810 "SchemaEntity201909.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n                oneOfCount += 1;\r\n        " +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 4821 "SchemaEntity201909.tt"
+        #line 4812 "SchemaEntity201909.tt"
 
             if (!HasUnevaluatedItems && !HasUnevaluatedProperties)
             {
@@ -14238,7 +14198,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4825 "SchemaEntity201909.tt"
+        #line 4816 "SchemaEntity201909.tt"
         this.Write("                if (oneOfCount > 1 && level == ValidationLevel.Flag)\r\n           " +
                 "     {\r\n                    result = result.WithResult(isValid: false);\r\n       " +
                 "             return result;\r\n                }\r\n            ");
@@ -14246,7 +14206,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4830 "SchemaEntity201909.tt"
+        #line 4821 "SchemaEntity201909.tt"
 
             }
             
@@ -14254,7 +14214,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4833 "SchemaEntity201909.tt"
+        #line 4824 "SchemaEntity201909.tt"
         this.Write("            }\r\n            else\r\n            {\r\n                if (level >= Vali" +
                 "dationLevel.Detailed)\r\n                {\r\n                    result = result.Me" +
                 "rgeResults(result.IsValid, level, oneOfResult");
@@ -14262,13 +14222,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4838 "SchemaEntity201909.tt"
+        #line 4829 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4838 "SchemaEntity201909.tt"
+        #line 4829 "SchemaEntity201909.tt"
         this.Write(");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)\r\n" +
                 "                {\r\n                    result = result.MergeResults(result.IsVal" +
                 "id, level, oneOfResult");
@@ -14276,32 +14236,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4842 "SchemaEntity201909.tt"
+        #line 4833 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4842 "SchemaEntity201909.tt"
+        #line 4833 "SchemaEntity201909.tt"
         this.Write(");\r\n                }\r\n                else\r\n                {\r\n                 " +
                 "   result = result.MergeResults(result.IsValid, level, oneOfResult");
         
         #line default
         #line hidden
         
-        #line 4846 "SchemaEntity201909.tt"
+        #line 4837 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4846 "SchemaEntity201909.tt"
+        #line 4837 "SchemaEntity201909.tt"
         this.Write(");\r\n                }\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4850 "SchemaEntity201909.tt"
+        #line 4841 "SchemaEntity201909.tt"
 
             oneOfIndex++;
         }
@@ -14310,7 +14270,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4854 "SchemaEntity201909.tt"
+        #line 4845 "SchemaEntity201909.tt"
         this.Write("\r\n            if (oneOfCount == 1)\r\n            {\r\n                if (level >= V" +
                 "alidationLevel.Detailed)\r\n                {\r\n                    result = result" +
                 ".WithResult(isValid: true, \"Validation 10.2.1.3. onef - validated against the on" +
@@ -14337,7 +14297,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4896 "SchemaEntity201909.tt"
+        #line 4887 "SchemaEntity201909.tt"
 
     }
     
@@ -14345,13 +14305,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4899 "SchemaEntity201909.tt"
+        #line 4890 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4901 "SchemaEntity201909.tt"
+        #line 4892 "SchemaEntity201909.tt"
 
     if (HasAnyOf)
     {
@@ -14360,7 +14320,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4905 "SchemaEntity201909.tt"
+        #line 4896 "SchemaEntity201909.tt"
         this.Write("        \r\n        private ValidationContext ValidateAnyOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n            bool foundValid = false;\r\n\r\n       " +
@@ -14369,7 +14329,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4912 "SchemaEntity201909.tt"
+        #line 4903 "SchemaEntity201909.tt"
 
         int anyOfIndex = 0;
         foreach (var anyOf in AnyOf)
@@ -14379,63 +14339,63 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4917 "SchemaEntity201909.tt"
+        #line 4908 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n            ValidationContext anyOfResult");
         
         #line default
         #line hidden
         
-        #line 4919 "SchemaEntity201909.tt"
+        #line 4910 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4919 "SchemaEntity201909.tt"
+        #line 4910 "SchemaEntity201909.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 4919 "SchemaEntity201909.tt"
+        #line 4910 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOf ));
         
         #line default
         #line hidden
         
-        #line 4919 "SchemaEntity201909.tt"
+        #line 4910 "SchemaEntity201909.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (a" +
                 "nyOfResult");
         
         #line default
         #line hidden
         
-        #line 4921 "SchemaEntity201909.tt"
+        #line 4912 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4921 "SchemaEntity201909.tt"
+        #line 4912 "SchemaEntity201909.tt"
         this.Write(".IsValid)\r\n            {\r\n                result = result.MergeChildContext(anyOf" +
                 "Result");
         
         #line default
         #line hidden
         
-        #line 4923 "SchemaEntity201909.tt"
+        #line 4914 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4923 "SchemaEntity201909.tt"
+        #line 4914 "SchemaEntity201909.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4924 "SchemaEntity201909.tt"
+        #line 4915 "SchemaEntity201909.tt"
 
             if (!HasUnevaluatedItems && !HasUnevaluatedProperties)
             {
@@ -14444,7 +14404,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4928 "SchemaEntity201909.tt"
+        #line 4919 "SchemaEntity201909.tt"
         this.Write("                if (level == ValidationLevel.Flag)\r\n                {\r\n          " +
                 "          return result;\r\n                }\r\n                else\r\n             " +
                 "   {\r\n                    foundValid = true;\r\n                }\r\n            ");
@@ -14452,7 +14412,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4936 "SchemaEntity201909.tt"
+        #line 4927 "SchemaEntity201909.tt"
 
             }
             else
@@ -14462,13 +14422,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4941 "SchemaEntity201909.tt"
+        #line 4932 "SchemaEntity201909.tt"
         this.Write("                    foundValid = true;\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4942 "SchemaEntity201909.tt"
+        #line 4933 "SchemaEntity201909.tt"
 
             }
             
@@ -14476,7 +14436,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4945 "SchemaEntity201909.tt"
+        #line 4936 "SchemaEntity201909.tt"
         this.Write("            }\r\n            else\r\n            {\r\n                if (level >= Vali" +
                 "dationLevel.Detailed)\r\n                {\r\n                    result = result.Me" +
                 "rgeResults(result.IsValid, level, anyOfResult");
@@ -14484,13 +14444,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4950 "SchemaEntity201909.tt"
+        #line 4941 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4950 "SchemaEntity201909.tt"
+        #line 4941 "SchemaEntity201909.tt"
         this.Write(");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)\r\n" +
                 "                {\r\n                    result = result.MergeResults(result.IsVal" +
                 "id, level, anyOfResult");
@@ -14498,19 +14458,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4954 "SchemaEntity201909.tt"
+        #line 4945 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4954 "SchemaEntity201909.tt"
+        #line 4945 "SchemaEntity201909.tt"
         this.Write(");\r\n                }\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4958 "SchemaEntity201909.tt"
+        #line 4949 "SchemaEntity201909.tt"
 
             anyOfIndex++;
         }
@@ -14519,7 +14479,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4962 "SchemaEntity201909.tt"
+        #line 4953 "SchemaEntity201909.tt"
         this.Write(@"
             if (foundValid)
             {
@@ -14552,7 +14512,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4989 "SchemaEntity201909.tt"
+        #line 4980 "SchemaEntity201909.tt"
 
     }
     
@@ -14560,13 +14520,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4992 "SchemaEntity201909.tt"
+        #line 4983 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4994 "SchemaEntity201909.tt"
+        #line 4985 "SchemaEntity201909.tt"
 
     if (HasAllOf)
     {
@@ -14575,7 +14535,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4998 "SchemaEntity201909.tt"
+        #line 4989 "SchemaEntity201909.tt"
         this.Write("        \r\n        private ValidationContext ValidateAllOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n        ");
@@ -14583,7 +14543,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5003 "SchemaEntity201909.tt"
+        #line 4994 "SchemaEntity201909.tt"
 
         int allOfIndex = 0;
         foreach (var allOf in AllOf)
@@ -14593,44 +14553,44 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5008 "SchemaEntity201909.tt"
+        #line 4999 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n            ValidationContext allOfResult");
         
         #line default
         #line hidden
         
-        #line 5010 "SchemaEntity201909.tt"
+        #line 5001 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 5010 "SchemaEntity201909.tt"
+        #line 5001 "SchemaEntity201909.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 5010 "SchemaEntity201909.tt"
+        #line 5001 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOf ));
         
         #line default
         #line hidden
         
-        #line 5010 "SchemaEntity201909.tt"
+        #line 5001 "SchemaEntity201909.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (!" +
                 "allOfResult");
         
         #line default
         #line hidden
         
-        #line 5012 "SchemaEntity201909.tt"
+        #line 5003 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 5012 "SchemaEntity201909.tt"
+        #line 5003 "SchemaEntity201909.tt"
         this.Write(".IsValid)\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r" +
                 "\n                {\r\n                    result = result.MergeChildContext(allOfR" +
                 "esult");
@@ -14638,13 +14598,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5016 "SchemaEntity201909.tt"
+        #line 5007 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 5016 "SchemaEntity201909.tt"
+        #line 5007 "SchemaEntity201909.tt"
         this.Write(@", true).WithResult(isValid: false, ""Validation 10.2.1.1. allOf - failed to validate against the allOf schema."");
                 }
                 else if (level >= ValidationLevel.Basic)
@@ -14654,13 +14614,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5020 "SchemaEntity201909.tt"
+        #line 5011 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 5020 "SchemaEntity201909.tt"
+        #line 5011 "SchemaEntity201909.tt"
         this.Write(", true).WithResult(isValid: false, \"Validation 10.2.1.1. allOf - failed to valida" +
                 "te against the allOf schema.\");\r\n                }\r\n                else\r\n      " +
                 "          {\r\n                    result = result.MergeChildContext(allOfResult");
@@ -14668,13 +14628,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5024 "SchemaEntity201909.tt"
+        #line 5015 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 5024 "SchemaEntity201909.tt"
+        #line 5015 "SchemaEntity201909.tt"
         this.Write(", false).WithResult(isValid: false);\r\n                    return result;\r\n       " +
                 "         }\r\n            }\r\n            else\r\n            {\r\n                resu" +
                 "lt = result.MergeChildContext(allOfResult");
@@ -14682,19 +14642,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5030 "SchemaEntity201909.tt"
+        #line 5021 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 5030 "SchemaEntity201909.tt"
+        #line 5021 "SchemaEntity201909.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5033 "SchemaEntity201909.tt"
+        #line 5024 "SchemaEntity201909.tt"
 
             allOfIndex++;
         }
@@ -14703,13 +14663,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5037 "SchemaEntity201909.tt"
+        #line 5028 "SchemaEntity201909.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5041 "SchemaEntity201909.tt"
+        #line 5032 "SchemaEntity201909.tt"
 
     }
     
@@ -14717,13 +14677,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5044 "SchemaEntity201909.tt"
+        #line 5035 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5046 "SchemaEntity201909.tt"
+        #line 5037 "SchemaEntity201909.tt"
 
     if (HasNot)
     {
@@ -14732,7 +14692,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5050 "SchemaEntity201909.tt"
+        #line 5041 "SchemaEntity201909.tt"
         this.Write("        \r\n        private ValidationContext ValidateNot(ValidationContext validat" +
                 "ionContext, ValidationLevel level)\r\n        {\r\n            ValidationContext res" +
                 "ult = validationContext;\r\n\r\n            ValidationContext notResult = this.As<");
@@ -14740,13 +14700,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5055 "SchemaEntity201909.tt"
+        #line 5046 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( NotDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5055 "SchemaEntity201909.tt"
+        #line 5046 "SchemaEntity201909.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
             if (notResult.IsValid)
             {
@@ -14776,7 +14736,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5079 "SchemaEntity201909.tt"
+        #line 5070 "SchemaEntity201909.tt"
 
     }
     
@@ -14784,13 +14744,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5082 "SchemaEntity201909.tt"
+        #line 5073 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5084 "SchemaEntity201909.tt"
+        #line 5075 "SchemaEntity201909.tt"
 
     if (HasIfThenElse)
     {
@@ -14799,7 +14759,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5088 "SchemaEntity201909.tt"
+        #line 5079 "SchemaEntity201909.tt"
         this.Write("        \r\n        private ValidationContext ValidateIfThenElse(in ValidationConte" +
                 "xt validationContext, ValidationLevel level)\r\n        {\r\n            ValidationC" +
                 "ontext result = validationContext;\r\n\r\n            ValidationContext ifResult = t" +
@@ -14808,13 +14768,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5093 "SchemaEntity201909.tt"
+        #line 5084 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( IfFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5093 "SchemaEntity201909.tt"
+        #line 5084 "SchemaEntity201909.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
             if (!ifResult.IsValid)
@@ -14844,7 +14804,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5117 "SchemaEntity201909.tt"
+        #line 5108 "SchemaEntity201909.tt"
 
         if (HasThen)
         {
@@ -14853,20 +14813,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5121 "SchemaEntity201909.tt"
+        #line 5112 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (ifResult.IsValid)\r\n            {\r\n                Valid" +
                 "ationContext thenResult = this.As<");
         
         #line default
         #line hidden
         
-        #line 5124 "SchemaEntity201909.tt"
+        #line 5115 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ThenFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5124 "SchemaEntity201909.tt"
+        #line 5115 "SchemaEntity201909.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
                 if (!thenResult.IsValid)
@@ -14900,7 +14860,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5152 "SchemaEntity201909.tt"
+        #line 5143 "SchemaEntity201909.tt"
 
         }
         
@@ -14908,13 +14868,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5155 "SchemaEntity201909.tt"
+        #line 5146 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5156 "SchemaEntity201909.tt"
+        #line 5147 "SchemaEntity201909.tt"
 
         if (HasElse)
         {
@@ -14923,20 +14883,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5160 "SchemaEntity201909.tt"
+        #line 5151 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (!ifResult.IsValid)\r\n            {\r\n                Vali" +
                 "dationContext elseResult = this.As<");
         
         #line default
         #line hidden
         
-        #line 5163 "SchemaEntity201909.tt"
+        #line 5154 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ElseFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5163 "SchemaEntity201909.tt"
+        #line 5154 "SchemaEntity201909.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
                 if (!elseResult.IsValid)
@@ -14970,7 +14930,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5191 "SchemaEntity201909.tt"
+        #line 5182 "SchemaEntity201909.tt"
 
         }
         
@@ -14978,13 +14938,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5194 "SchemaEntity201909.tt"
+        #line 5185 "SchemaEntity201909.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5198 "SchemaEntity201909.tt"
+        #line 5189 "SchemaEntity201909.tt"
 
     }
     
@@ -14992,13 +14952,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5201 "SchemaEntity201909.tt"
+        #line 5192 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5202 "SchemaEntity201909.tt"
+        #line 5193 "SchemaEntity201909.tt"
 
     if (HasMediaTypeOrEncoding)
     {
@@ -15007,14 +14967,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5206 "SchemaEntity201909.tt"
+        #line 5197 "SchemaEntity201909.tt"
         this.Write("        private ValidationContext ValidateMediaTypeAndEncoding(JsonValueKind valu" +
                 "eKind, ValidationContext result, ValidationLevel level)\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5208 "SchemaEntity201909.tt"
+        #line 5199 "SchemaEntity201909.tt"
 
         if (IsJsonBase64Content)
         {
@@ -15023,7 +14983,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5212 "SchemaEntity201909.tt"
+        #line 5203 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return this.As<JsonBase64Content>().Validate(result, level);\r\n      " +
                 "      }\r\n        ");
@@ -15031,7 +14991,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5217 "SchemaEntity201909.tt"
+        #line 5208 "SchemaEntity201909.tt"
 
         }
         
@@ -15039,13 +14999,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5220 "SchemaEntity201909.tt"
+        #line 5211 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5221 "SchemaEntity201909.tt"
+        #line 5212 "SchemaEntity201909.tt"
 
         if (IsJsonBase64String)
         {
@@ -15054,7 +15014,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5225 "SchemaEntity201909.tt"
+        #line 5216 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return this.As<JsonBase64String>().Validate(result, level);\r\n       " +
                 "     }\r\n\r\n        ");
@@ -15062,7 +15022,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5231 "SchemaEntity201909.tt"
+        #line 5222 "SchemaEntity201909.tt"
 
         }
         
@@ -15070,13 +15030,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5234 "SchemaEntity201909.tt"
+        #line 5225 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5235 "SchemaEntity201909.tt"
+        #line 5226 "SchemaEntity201909.tt"
 
         if (IsJsonContent)
         {
@@ -15085,7 +15045,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5239 "SchemaEntity201909.tt"
+        #line 5230 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return this.As<JsonContent>().Validate(result, level);\r\n            " +
                 "}\r\n        ");
@@ -15093,7 +15053,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5244 "SchemaEntity201909.tt"
+        #line 5235 "SchemaEntity201909.tt"
 
         }
         
@@ -15101,13 +15061,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5247 "SchemaEntity201909.tt"
+        #line 5238 "SchemaEntity201909.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5251 "SchemaEntity201909.tt"
+        #line 5242 "SchemaEntity201909.tt"
 
     }
     
@@ -15115,13 +15075,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5254 "SchemaEntity201909.tt"
+        #line 5245 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5255 "SchemaEntity201909.tt"
+        #line 5246 "SchemaEntity201909.tt"
 
     if (HasFormat)
     {
@@ -15130,14 +15090,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5259 "SchemaEntity201909.tt"
+        #line 5250 "SchemaEntity201909.tt"
         this.Write("        \r\n        private ValidationContext ValidateFormat(JsonValueKind valueKin" +
                 "d, ValidationContext result, ValidationLevel level)\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5262 "SchemaEntity201909.tt"
+        #line 5253 "SchemaEntity201909.tt"
 
         if (IsJsonRelativePointer)
         {
@@ -15146,7 +15106,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5266 "SchemaEntity201909.tt"
+        #line 5257 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
                 "vel);\r\n            }\r\n        ");
@@ -15154,7 +15114,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5271 "SchemaEntity201909.tt"
+        #line 5262 "SchemaEntity201909.tt"
 
         }
         
@@ -15162,13 +15122,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5274 "SchemaEntity201909.tt"
+        #line 5265 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5275 "SchemaEntity201909.tt"
+        #line 5266 "SchemaEntity201909.tt"
 
         if (IsJsonDate)
         {
@@ -15177,7 +15137,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5279 "SchemaEntity201909.tt"
+        #line 5270 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeDate(this, result, level);\r\n        " +
                 "    }\r\n\r\n        ");
@@ -15185,7 +15145,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5285 "SchemaEntity201909.tt"
+        #line 5276 "SchemaEntity201909.tt"
 
         }
         
@@ -15193,13 +15153,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5288 "SchemaEntity201909.tt"
+        #line 5279 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5289 "SchemaEntity201909.tt"
+        #line 5280 "SchemaEntity201909.tt"
 
         if (IsJsonDateTime)
         {
@@ -15208,7 +15168,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5293 "SchemaEntity201909.tt"
+        #line 5284 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeDateTime(this, result, level);\r\n    " +
                 "        }\r\n        ");
@@ -15216,7 +15176,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5298 "SchemaEntity201909.tt"
+        #line 5289 "SchemaEntity201909.tt"
 
         }
         
@@ -15224,13 +15184,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5301 "SchemaEntity201909.tt"
+        #line 5292 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5302 "SchemaEntity201909.tt"
+        #line 5293 "SchemaEntity201909.tt"
 
         if (IsJsonDuration)
         {
@@ -15239,7 +15199,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5306 "SchemaEntity201909.tt"
+        #line 5297 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeDuration(this, result, level);\r\n    " +
                 "        }\r\n        ");
@@ -15247,7 +15207,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5311 "SchemaEntity201909.tt"
+        #line 5302 "SchemaEntity201909.tt"
 
         }
         
@@ -15255,13 +15215,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5314 "SchemaEntity201909.tt"
+        #line 5305 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5315 "SchemaEntity201909.tt"
+        #line 5306 "SchemaEntity201909.tt"
 
         if (IsJsonTime)
         {
@@ -15270,7 +15230,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5319 "SchemaEntity201909.tt"
+        #line 5310 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeTime(this, result, level);\r\n        " +
                 "    }\r\n        ");
@@ -15278,7 +15238,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5324 "SchemaEntity201909.tt"
+        #line 5315 "SchemaEntity201909.tt"
 
         }
         
@@ -15286,13 +15246,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5327 "SchemaEntity201909.tt"
+        #line 5318 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5328 "SchemaEntity201909.tt"
+        #line 5319 "SchemaEntity201909.tt"
 
         if (IsJsonEmail)
         {
@@ -15301,7 +15261,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5332 "SchemaEntity201909.tt"
+        #line 5323 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeEmail(this, result, level);\r\n       " +
                 "     }\r\n        ");
@@ -15309,7 +15269,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5337 "SchemaEntity201909.tt"
+        #line 5328 "SchemaEntity201909.tt"
 
         }
         
@@ -15317,13 +15277,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5340 "SchemaEntity201909.tt"
+        #line 5331 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5341 "SchemaEntity201909.tt"
+        #line 5332 "SchemaEntity201909.tt"
 
         if (IsJsonHostname)
         {
@@ -15332,7 +15292,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5345 "SchemaEntity201909.tt"
+        #line 5336 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeHostname(this, result, level);\r\n    " +
                 "        }\r\n        ");
@@ -15340,7 +15300,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5350 "SchemaEntity201909.tt"
+        #line 5341 "SchemaEntity201909.tt"
 
         }
         
@@ -15348,13 +15308,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5353 "SchemaEntity201909.tt"
+        #line 5344 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5354 "SchemaEntity201909.tt"
+        #line 5345 "SchemaEntity201909.tt"
 
         if (IsJsonIdnEmail)
         {
@@ -15363,7 +15323,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5358 "SchemaEntity201909.tt"
+        #line 5349 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIdnEmail(this, result, level);\r\n    " +
                 "        }\r\n\r\n        ");
@@ -15371,7 +15331,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5364 "SchemaEntity201909.tt"
+        #line 5355 "SchemaEntity201909.tt"
 
         }
         
@@ -15379,13 +15339,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5367 "SchemaEntity201909.tt"
+        #line 5358 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5368 "SchemaEntity201909.tt"
+        #line 5359 "SchemaEntity201909.tt"
 
         if (IsJsonIdnHostname)
         {
@@ -15394,7 +15354,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5372 "SchemaEntity201909.tt"
+        #line 5363 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIdnHostname(this, result, level);\r\n " +
                 "           }\r\n        ");
@@ -15402,7 +15362,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5377 "SchemaEntity201909.tt"
+        #line 5368 "SchemaEntity201909.tt"
 
         }
         
@@ -15410,13 +15370,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5380 "SchemaEntity201909.tt"
+        #line 5371 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5381 "SchemaEntity201909.tt"
+        #line 5372 "SchemaEntity201909.tt"
 
         if (IsJsonInteger)
         {
@@ -15425,7 +15385,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5385 "SchemaEntity201909.tt"
+        #line 5376 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.Number)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeInteger(this, result, level);\r\n     " +
                 "       }\r\n        ");
@@ -15433,7 +15393,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5390 "SchemaEntity201909.tt"
+        #line 5381 "SchemaEntity201909.tt"
 
         }
         
@@ -15441,13 +15401,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5393 "SchemaEntity201909.tt"
+        #line 5384 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5394 "SchemaEntity201909.tt"
+        #line 5385 "SchemaEntity201909.tt"
 
         if (IsJsonIpV4)
         {
@@ -15456,7 +15416,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5398 "SchemaEntity201909.tt"
+        #line 5389 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIpV4(this, result, level);\r\n        " +
                 "    }\r\n\r\n        ");
@@ -15464,7 +15424,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5404 "SchemaEntity201909.tt"
+        #line 5395 "SchemaEntity201909.tt"
 
         }
         
@@ -15472,13 +15432,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5407 "SchemaEntity201909.tt"
+        #line 5398 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5408 "SchemaEntity201909.tt"
+        #line 5399 "SchemaEntity201909.tt"
 
         if (IsJsonIpV6)
         {
@@ -15487,7 +15447,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5412 "SchemaEntity201909.tt"
+        #line 5403 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIpV6(this, result, level);\r\n        " +
                 "    }\r\n\r\n        ");
@@ -15495,7 +15455,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5418 "SchemaEntity201909.tt"
+        #line 5409 "SchemaEntity201909.tt"
 
         }
         
@@ -15503,13 +15463,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5421 "SchemaEntity201909.tt"
+        #line 5412 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5422 "SchemaEntity201909.tt"
+        #line 5413 "SchemaEntity201909.tt"
 
         if (IsJsonIri)
         {
@@ -15518,7 +15478,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5426 "SchemaEntity201909.tt"
+        #line 5417 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIri(this, result, level);\r\n         " +
                 "   }\r\n        ");
@@ -15526,7 +15486,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5431 "SchemaEntity201909.tt"
+        #line 5422 "SchemaEntity201909.tt"
 
         }
         
@@ -15534,13 +15494,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5434 "SchemaEntity201909.tt"
+        #line 5425 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5435 "SchemaEntity201909.tt"
+        #line 5426 "SchemaEntity201909.tt"
 
         if (IsJsonIriReference)
         {
@@ -15549,7 +15509,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5439 "SchemaEntity201909.tt"
+        #line 5430 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIriReference(this, result, level);\r\n" +
                 "            }\r\n        ");
@@ -15557,7 +15517,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5444 "SchemaEntity201909.tt"
+        #line 5435 "SchemaEntity201909.tt"
 
         }
         
@@ -15565,13 +15525,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5447 "SchemaEntity201909.tt"
+        #line 5438 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5448 "SchemaEntity201909.tt"
+        #line 5439 "SchemaEntity201909.tt"
 
         if (IsJsonPointer)
         {
@@ -15580,7 +15540,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5452 "SchemaEntity201909.tt"
+        #line 5443 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeJsonPointer(this, result, level);\r\n " +
                 "           }\r\n        ");
@@ -15588,7 +15548,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5457 "SchemaEntity201909.tt"
+        #line 5448 "SchemaEntity201909.tt"
 
         }
         
@@ -15596,13 +15556,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5460 "SchemaEntity201909.tt"
+        #line 5451 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5461 "SchemaEntity201909.tt"
+        #line 5452 "SchemaEntity201909.tt"
 
         if (IsJsonRegex)
         {
@@ -15611,7 +15571,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5465 "SchemaEntity201909.tt"
+        #line 5456 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeRegex(this, result, level);\r\n       " +
                 "     }\r\n        ");
@@ -15619,7 +15579,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5470 "SchemaEntity201909.tt"
+        #line 5461 "SchemaEntity201909.tt"
 
         }
         
@@ -15627,13 +15587,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5473 "SchemaEntity201909.tt"
+        #line 5464 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5474 "SchemaEntity201909.tt"
+        #line 5465 "SchemaEntity201909.tt"
 
         if (IsJsonRelativePointer)
         {
@@ -15642,7 +15602,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5478 "SchemaEntity201909.tt"
+        #line 5469 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
                 "vel);\r\n            }\r\n        ");
@@ -15650,7 +15610,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5483 "SchemaEntity201909.tt"
+        #line 5474 "SchemaEntity201909.tt"
 
         }
         
@@ -15658,13 +15618,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5486 "SchemaEntity201909.tt"
+        #line 5477 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5487 "SchemaEntity201909.tt"
+        #line 5478 "SchemaEntity201909.tt"
 
         if (IsJsonTime)
         {
@@ -15673,7 +15633,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5491 "SchemaEntity201909.tt"
+        #line 5482 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeTime(this, result, level);\r\n        " +
                 "    }\r\n\r\n        ");
@@ -15681,7 +15641,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5497 "SchemaEntity201909.tt"
+        #line 5488 "SchemaEntity201909.tt"
 
         }
         
@@ -15689,13 +15649,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5500 "SchemaEntity201909.tt"
+        #line 5491 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5501 "SchemaEntity201909.tt"
+        #line 5492 "SchemaEntity201909.tt"
 
         if (IsJsonUri)
         {
@@ -15704,7 +15664,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5505 "SchemaEntity201909.tt"
+        #line 5496 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeUri(this, result, level);\r\n         " +
                 "   }\r\n\r\n        ");
@@ -15712,7 +15672,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5511 "SchemaEntity201909.tt"
+        #line 5502 "SchemaEntity201909.tt"
 
         }
         
@@ -15720,13 +15680,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5514 "SchemaEntity201909.tt"
+        #line 5505 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5515 "SchemaEntity201909.tt"
+        #line 5506 "SchemaEntity201909.tt"
 
         if (IsJsonUriReference)
         {
@@ -15735,7 +15695,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5519 "SchemaEntity201909.tt"
+        #line 5510 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeUriReference(this, result, level);\r\n" +
                 "            }\r\n        ");
@@ -15743,7 +15703,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5524 "SchemaEntity201909.tt"
+        #line 5515 "SchemaEntity201909.tt"
 
         }
         
@@ -15751,13 +15711,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5527 "SchemaEntity201909.tt"
+        #line 5518 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5528 "SchemaEntity201909.tt"
+        #line 5519 "SchemaEntity201909.tt"
 
         if (IsJsonUriTemplate)
         {
@@ -15766,7 +15726,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5532 "SchemaEntity201909.tt"
+        #line 5523 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeUriTemplate(this, result, level);\r\n " +
                 "           }\r\n\r\n        ");
@@ -15774,7 +15734,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5538 "SchemaEntity201909.tt"
+        #line 5529 "SchemaEntity201909.tt"
 
         }
         
@@ -15782,13 +15742,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5541 "SchemaEntity201909.tt"
+        #line 5532 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5542 "SchemaEntity201909.tt"
+        #line 5533 "SchemaEntity201909.tt"
 
         if (IsJsonUuid)
         {
@@ -15797,7 +15757,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5546 "SchemaEntity201909.tt"
+        #line 5537 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeUuid(this, result, level);\r\n        " +
                 "    }\r\n\r\n        ");
@@ -15805,7 +15765,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5552 "SchemaEntity201909.tt"
+        #line 5543 "SchemaEntity201909.tt"
 
         }
         
@@ -15813,13 +15773,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5555 "SchemaEntity201909.tt"
+        #line 5546 "SchemaEntity201909.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5559 "SchemaEntity201909.tt"
+        #line 5550 "SchemaEntity201909.tt"
 
     }
     
@@ -15827,13 +15787,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5562 "SchemaEntity201909.tt"
+        #line 5553 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5563 "SchemaEntity201909.tt"
+        #line 5554 "SchemaEntity201909.tt"
 
     if (HasType)
     {
@@ -15842,7 +15802,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5567 "SchemaEntity201909.tt"
+        #line 5558 "SchemaEntity201909.tt"
         this.Write(@"        
         private ValidationContext ValidateType(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
@@ -15854,7 +15814,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5573 "SchemaEntity201909.tt"
+        #line 5564 "SchemaEntity201909.tt"
 
         if (HasStringType)
         {
@@ -15863,7 +15823,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5577 "SchemaEntity201909.tt"
+        #line 5568 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultString = Corvus.Json.Validate.TypeString(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultString.IsValid)
@@ -15881,7 +15841,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5589 "SchemaEntity201909.tt"
+        #line 5580 "SchemaEntity201909.tt"
 
         }
         
@@ -15889,13 +15849,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5592 "SchemaEntity201909.tt"
+        #line 5583 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5593 "SchemaEntity201909.tt"
+        #line 5584 "SchemaEntity201909.tt"
 
         if (HasObjectType)
         {
@@ -15904,7 +15864,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5597 "SchemaEntity201909.tt"
+        #line 5588 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultObject = Corvus.Json.Validate.TypeObject(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultObject.IsValid)
@@ -15922,7 +15882,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5609 "SchemaEntity201909.tt"
+        #line 5600 "SchemaEntity201909.tt"
 
         }
         
@@ -15930,13 +15890,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5612 "SchemaEntity201909.tt"
+        #line 5603 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5613 "SchemaEntity201909.tt"
+        #line 5604 "SchemaEntity201909.tt"
 
         if (HasArrayType)
         {
@@ -15945,7 +15905,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5617 "SchemaEntity201909.tt"
+        #line 5608 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultArray = Corvus.Json.Validate.TypeArray(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultArray.IsValid)
@@ -15963,7 +15923,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5629 "SchemaEntity201909.tt"
+        #line 5620 "SchemaEntity201909.tt"
 
         }
         
@@ -15971,13 +15931,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5632 "SchemaEntity201909.tt"
+        #line 5623 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5633 "SchemaEntity201909.tt"
+        #line 5624 "SchemaEntity201909.tt"
 
         if (HasNumberType)
         {
@@ -15986,7 +15946,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5637 "SchemaEntity201909.tt"
+        #line 5628 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultNumber = Corvus.Json.Validate.TypeNumber(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultNumber.IsValid)
@@ -16004,7 +15964,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5649 "SchemaEntity201909.tt"
+        #line 5640 "SchemaEntity201909.tt"
 
         }
         
@@ -16012,13 +15972,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5652 "SchemaEntity201909.tt"
+        #line 5643 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5653 "SchemaEntity201909.tt"
+        #line 5644 "SchemaEntity201909.tt"
 
         if (HasIntegerType)
         {
@@ -16027,7 +15987,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5657 "SchemaEntity201909.tt"
+        #line 5648 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultInteger = Corvus.Json.Validate.TypeInteger(this, result, level);
             if (level == ValidationLevel.Flag && localResultInteger.IsValid)
@@ -16045,7 +16005,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5669 "SchemaEntity201909.tt"
+        #line 5660 "SchemaEntity201909.tt"
 
         }
         
@@ -16053,13 +16013,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5672 "SchemaEntity201909.tt"
+        #line 5663 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5673 "SchemaEntity201909.tt"
+        #line 5664 "SchemaEntity201909.tt"
 
         if (HasBooleanType)
         {
@@ -16068,7 +16028,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5677 "SchemaEntity201909.tt"
+        #line 5668 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultBoolean = Corvus.Json.Validate.TypeBoolean(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultBoolean.IsValid)
@@ -16086,7 +16046,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5689 "SchemaEntity201909.tt"
+        #line 5680 "SchemaEntity201909.tt"
 
         }
         
@@ -16094,13 +16054,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5692 "SchemaEntity201909.tt"
+        #line 5683 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5693 "SchemaEntity201909.tt"
+        #line 5684 "SchemaEntity201909.tt"
 
         if (HasNullType)
         {
@@ -16109,7 +16069,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5697 "SchemaEntity201909.tt"
+        #line 5688 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultNull = Corvus.Json.Validate.TypeNull(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultNull.IsValid)
@@ -16127,7 +16087,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5709 "SchemaEntity201909.tt"
+        #line 5700 "SchemaEntity201909.tt"
 
         }
         
@@ -16135,14 +16095,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5712 "SchemaEntity201909.tt"
+        #line 5703 "SchemaEntity201909.tt"
         this.Write("\r\n            result = result.MergeResults(\r\n                isValid,\r\n          " +
                 "      level\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5716 "SchemaEntity201909.tt"
+        #line 5707 "SchemaEntity201909.tt"
 
         if (HasStringType)
         {
@@ -16151,13 +16111,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5720 "SchemaEntity201909.tt"
+        #line 5711 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultString\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5722 "SchemaEntity201909.tt"
+        #line 5713 "SchemaEntity201909.tt"
 
         }
         
@@ -16165,13 +16125,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5725 "SchemaEntity201909.tt"
+        #line 5716 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5726 "SchemaEntity201909.tt"
+        #line 5717 "SchemaEntity201909.tt"
 
         if (HasObjectType)
         {
@@ -16180,13 +16140,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5730 "SchemaEntity201909.tt"
+        #line 5721 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultObject\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5732 "SchemaEntity201909.tt"
+        #line 5723 "SchemaEntity201909.tt"
 
         }
         
@@ -16194,13 +16154,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5735 "SchemaEntity201909.tt"
+        #line 5726 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5736 "SchemaEntity201909.tt"
+        #line 5727 "SchemaEntity201909.tt"
 
         if (HasArrayType)
         {
@@ -16209,13 +16169,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5740 "SchemaEntity201909.tt"
+        #line 5731 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultArray\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5742 "SchemaEntity201909.tt"
+        #line 5733 "SchemaEntity201909.tt"
 
         }
         
@@ -16223,13 +16183,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5745 "SchemaEntity201909.tt"
+        #line 5736 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5746 "SchemaEntity201909.tt"
+        #line 5737 "SchemaEntity201909.tt"
 
         if (HasNumberType)
         {
@@ -16238,13 +16198,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5750 "SchemaEntity201909.tt"
+        #line 5741 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultNumber\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5752 "SchemaEntity201909.tt"
+        #line 5743 "SchemaEntity201909.tt"
 
         }
         
@@ -16252,13 +16212,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5755 "SchemaEntity201909.tt"
+        #line 5746 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5756 "SchemaEntity201909.tt"
+        #line 5747 "SchemaEntity201909.tt"
 
         if (HasIntegerType)
         {
@@ -16267,13 +16227,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5760 "SchemaEntity201909.tt"
+        #line 5751 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultInteger\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5762 "SchemaEntity201909.tt"
+        #line 5753 "SchemaEntity201909.tt"
 
         }
         
@@ -16281,13 +16241,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5765 "SchemaEntity201909.tt"
+        #line 5756 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5766 "SchemaEntity201909.tt"
+        #line 5757 "SchemaEntity201909.tt"
 
         if (HasBooleanType)
         {
@@ -16296,13 +16256,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5770 "SchemaEntity201909.tt"
+        #line 5761 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultBoolean\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5772 "SchemaEntity201909.tt"
+        #line 5763 "SchemaEntity201909.tt"
 
         }
         
@@ -16310,13 +16270,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5775 "SchemaEntity201909.tt"
+        #line 5766 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5776 "SchemaEntity201909.tt"
+        #line 5767 "SchemaEntity201909.tt"
 
         if (HasNullType)
         {
@@ -16325,13 +16285,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5780 "SchemaEntity201909.tt"
+        #line 5771 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultNull\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5782 "SchemaEntity201909.tt"
+        #line 5773 "SchemaEntity201909.tt"
 
         }
         
@@ -16339,13 +16299,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5785 "SchemaEntity201909.tt"
+        #line 5776 "SchemaEntity201909.tt"
         this.Write("                );\r\n\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5790 "SchemaEntity201909.tt"
+        #line 5781 "SchemaEntity201909.tt"
 
     }
     
@@ -16353,13 +16313,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5793 "SchemaEntity201909.tt"
+        #line 5784 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5794 "SchemaEntity201909.tt"
+        #line 5785 "SchemaEntity201909.tt"
 
     if (HasEnum)
     {
@@ -16368,14 +16328,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5798 "SchemaEntity201909.tt"
+        #line 5789 "SchemaEntity201909.tt"
         this.Write("        \r\n        /// <summary>\r\n        /// Permitted values.\r\n        /// </sum" +
                 "mary>\r\n        public static class EnumValues\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5804 "SchemaEntity201909.tt"
+        #line 5795 "SchemaEntity201909.tt"
 
         int enumItemIndex = 0;
         foreach (var enumValue in EnumValues)
@@ -16385,13 +16345,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5809 "SchemaEntity201909.tt"
+        #line 5800 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 5809 "SchemaEntity201909.tt"
+        #line 5800 "SchemaEntity201909.tt"
 
             if (enumValue.IsString)
             {
@@ -16400,7 +16360,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5813 "SchemaEntity201909.tt"
+        #line 5804 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// enumValue.AsPropertyName.\r\n           " +
                 " /// </summary>\r\n            /// <remarks>\r\n            /// {Description}.\r\n    " +
                 "        /// </remarks>\r\n            public static readonly ");
@@ -16408,43 +16368,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5819 "SchemaEntity201909.tt"
+        #line 5810 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5819 "SchemaEntity201909.tt"
+        #line 5810 "SchemaEntity201909.tt"
         this.Write(" ");
         
         #line default
         #line hidden
         
-        #line 5819 "SchemaEntity201909.tt"
+        #line 5810 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    enumValue.AsPropertyName));
         
         #line default
         #line hidden
         
-        #line 5819 "SchemaEntity201909.tt"
+        #line 5810 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5819 "SchemaEntity201909.tt"
+        #line 5810 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5819 "SchemaEntity201909.tt"
+        #line 5810 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5820 "SchemaEntity201909.tt"
+        #line 5811 "SchemaEntity201909.tt"
 
             }
             else if (enumValue.IsBoolean)
@@ -16454,19 +16414,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5825 "SchemaEntity201909.tt"
+        #line 5816 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5826 "SchemaEntity201909.tt"
+        #line 5817 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5826 "SchemaEntity201909.tt"
+        #line 5817 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16474,43 +16434,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5831 "SchemaEntity201909.tt"
+        #line 5822 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5831 "SchemaEntity201909.tt"
+        #line 5822 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5831 "SchemaEntity201909.tt"
+        #line 5822 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5831 "SchemaEntity201909.tt"
+        #line 5822 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5831 "SchemaEntity201909.tt"
+        #line 5822 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5831 "SchemaEntity201909.tt"
+        #line 5822 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5832 "SchemaEntity201909.tt"
+        #line 5823 "SchemaEntity201909.tt"
 
             }
             else if (enumValue.IsNumber)
@@ -16520,19 +16480,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5837 "SchemaEntity201909.tt"
+        #line 5828 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5838 "SchemaEntity201909.tt"
+        #line 5829 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5838 "SchemaEntity201909.tt"
+        #line 5829 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16540,43 +16500,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5843 "SchemaEntity201909.tt"
+        #line 5834 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5843 "SchemaEntity201909.tt"
+        #line 5834 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5843 "SchemaEntity201909.tt"
+        #line 5834 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5843 "SchemaEntity201909.tt"
+        #line 5834 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5843 "SchemaEntity201909.tt"
+        #line 5834 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5843 "SchemaEntity201909.tt"
+        #line 5834 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5844 "SchemaEntity201909.tt"
+        #line 5835 "SchemaEntity201909.tt"
 
             }
             else if (enumValue.IsObject)
@@ -16586,19 +16546,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5849 "SchemaEntity201909.tt"
+        #line 5840 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5850 "SchemaEntity201909.tt"
+        #line 5841 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5850 "SchemaEntity201909.tt"
+        #line 5841 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16606,43 +16566,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5855 "SchemaEntity201909.tt"
+        #line 5846 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5855 "SchemaEntity201909.tt"
+        #line 5846 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5855 "SchemaEntity201909.tt"
+        #line 5846 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5855 "SchemaEntity201909.tt"
+        #line 5846 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5855 "SchemaEntity201909.tt"
+        #line 5846 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5855 "SchemaEntity201909.tt"
+        #line 5846 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5856 "SchemaEntity201909.tt"
+        #line 5847 "SchemaEntity201909.tt"
 
             }
             else if (enumValue.IsArray)
@@ -16652,19 +16612,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5861 "SchemaEntity201909.tt"
+        #line 5852 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5862 "SchemaEntity201909.tt"
+        #line 5853 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5862 "SchemaEntity201909.tt"
+        #line 5853 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16672,43 +16632,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5867 "SchemaEntity201909.tt"
+        #line 5858 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5867 "SchemaEntity201909.tt"
+        #line 5858 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5867 "SchemaEntity201909.tt"
+        #line 5858 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5867 "SchemaEntity201909.tt"
+        #line 5858 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5867 "SchemaEntity201909.tt"
+        #line 5858 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5867 "SchemaEntity201909.tt"
+        #line 5858 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5868 "SchemaEntity201909.tt"
+        #line 5859 "SchemaEntity201909.tt"
 
             }
             else if (enumValue.IsNull)
@@ -16718,19 +16678,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5873 "SchemaEntity201909.tt"
+        #line 5864 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5874 "SchemaEntity201909.tt"
+        #line 5865 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5874 "SchemaEntity201909.tt"
+        #line 5865 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16738,31 +16698,31 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5879 "SchemaEntity201909.tt"
+        #line 5870 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5879 "SchemaEntity201909.tt"
+        #line 5870 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5879 "SchemaEntity201909.tt"
+        #line 5870 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5879 "SchemaEntity201909.tt"
+        #line 5870 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(\"null\");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5880 "SchemaEntity201909.tt"
+        #line 5871 "SchemaEntity201909.tt"
 
             }
             
@@ -16770,13 +16730,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5883 "SchemaEntity201909.tt"
+        #line 5874 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5884 "SchemaEntity201909.tt"
+        #line 5875 "SchemaEntity201909.tt"
 
             ++enumItemIndex;
         }
@@ -16785,13 +16745,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5888 "SchemaEntity201909.tt"
+        #line 5879 "SchemaEntity201909.tt"
         this.Write("\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5890 "SchemaEntity201909.tt"
+        #line 5881 "SchemaEntity201909.tt"
 
         enumItemIndex = 0;
         foreach (var enumValue in EnumValues)
@@ -16801,13 +16761,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5895 "SchemaEntity201909.tt"
+        #line 5886 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 5895 "SchemaEntity201909.tt"
+        #line 5886 "SchemaEntity201909.tt"
 
             if (enumValue.IsString)
             {
@@ -16816,19 +16776,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5899 "SchemaEntity201909.tt"
+        #line 5890 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5900 "SchemaEntity201909.tt"
+        #line 5891 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5900 "SchemaEntity201909.tt"
+        #line 5891 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            inte" +
                 "rnal static readonly ");
@@ -16836,43 +16796,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5905 "SchemaEntity201909.tt"
+        #line 5896 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5905 "SchemaEntity201909.tt"
+        #line 5896 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5905 "SchemaEntity201909.tt"
+        #line 5896 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5905 "SchemaEntity201909.tt"
+        #line 5896 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5905 "SchemaEntity201909.tt"
+        #line 5896 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5905 "SchemaEntity201909.tt"
+        #line 5896 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5906 "SchemaEntity201909.tt"
+        #line 5897 "SchemaEntity201909.tt"
 
             }
             enumItemIndex++;
@@ -16882,13 +16842,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5911 "SchemaEntity201909.tt"
+        #line 5902 "SchemaEntity201909.tt"
         this.Write("        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5912 "SchemaEntity201909.tt"
+        #line 5903 "SchemaEntity201909.tt"
 
     }
     
@@ -16896,13 +16856,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5915 "SchemaEntity201909.tt"
+        #line 5906 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5916 "SchemaEntity201909.tt"
+        #line 5907 "SchemaEntity201909.tt"
 
     foreach(var nestedType in NestedTypes)
     {
@@ -16911,25 +16871,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5920 "SchemaEntity201909.tt"
+        #line 5911 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5921 "SchemaEntity201909.tt"
+        #line 5912 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( WriteNestedType(nestedType) ));
         
         #line default
         #line hidden
         
-        #line 5921 "SchemaEntity201909.tt"
+        #line 5912 "SchemaEntity201909.tt"
         this.Write("\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5923 "SchemaEntity201909.tt"
+        #line 5914 "SchemaEntity201909.tt"
 
     }
     
@@ -16937,13 +16897,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5926 "SchemaEntity201909.tt"
+        #line 5917 "SchemaEntity201909.tt"
         this.Write("\r\n    }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5928 "SchemaEntity201909.tt"
+        #line 5919 "SchemaEntity201909.tt"
 
     if (!IsNested)
     {
@@ -16952,13 +16912,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5932 "SchemaEntity201909.tt"
+        #line 5923 "SchemaEntity201909.tt"
         this.Write("}\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5933 "SchemaEntity201909.tt"
+        #line 5924 "SchemaEntity201909.tt"
 
     }
     

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntity201909.cs
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntity201909.cs
@@ -1048,39 +1048,52 @@ namespace ");
         #line hidden
         
         #line 253 "SchemaEntity201909.tt"
-        this.Write("\r\n        /// <summary>\r\n        /// Initializes a new instance of the <see cref=" +
-                "\"");
+        this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 255 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 255 "SchemaEntity201909.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">The backing " +
-                "<see cref=\"JsonElement\"/>.</param>\r\n        public ");
+        #line 254 "SchemaEntity201909.tt"
+
+    if (HasConst)
+    {
+    
         
         #line default
         #line hidden
         
         #line 258 "SchemaEntity201909.tt"
+        this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 259 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 258 "SchemaEntity201909.tt"
-        this.Write("(JsonElement value)\r\n        {\r\n            this.jsonElementBacking = value;\r\n   " +
-                " ");
+        #line 259 "SchemaEntity201909.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        public ");
         
         #line default
         #line hidden
         
         #line 261 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 261 "SchemaEntity201909.tt"
+        this.Write("()\r\n        {\r\n            this.jsonElementBacking = __CorvusConstValue.jsonEleme" +
+                "ntBacking;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 264 "SchemaEntity201909.tt"
 
     if(IsImplicitObject)
     {
@@ -1089,13 +1102,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 265 "SchemaEntity201909.tt"
-        this.Write("            this.objectBacking = default;\r\n    ");
+        #line 268 "SchemaEntity201909.tt"
+        this.Write("            this.objectBacking = __CorvusConstValue.objectBacking;\r\n    ");
         
         #line default
         #line hidden
         
-        #line 266 "SchemaEntity201909.tt"
+        #line 269 "SchemaEntity201909.tt"
 
     }
     
@@ -1103,13 +1116,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 269 "SchemaEntity201909.tt"
+        #line 272 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 269 "SchemaEntity201909.tt"
+        #line 272 "SchemaEntity201909.tt"
 
     if(IsImplicitArray)
     {
@@ -1118,13 +1131,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 273 "SchemaEntity201909.tt"
-        this.Write("            this.arrayBacking = default;\r\n    ");
+        #line 276 "SchemaEntity201909.tt"
+        this.Write("            this.arrayBacking = __CorvusConstValue.arrayBacking;\r\n    ");
         
         #line default
         #line hidden
         
-        #line 274 "SchemaEntity201909.tt"
+        #line 277 "SchemaEntity201909.tt"
 
     }
     
@@ -1132,13 +1145,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 277 "SchemaEntity201909.tt"
+        #line 280 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 277 "SchemaEntity201909.tt"
+        #line 280 "SchemaEntity201909.tt"
 
     if(IsImplicitNumber)
     {
@@ -1147,13 +1160,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 281 "SchemaEntity201909.tt"
-        this.Write("            this.numberBacking = default;\r\n    ");
+        #line 284 "SchemaEntity201909.tt"
+        this.Write("            this.numberBacking = __CorvusConstValue.numberBacking;\r\n    ");
         
         #line default
         #line hidden
         
-        #line 282 "SchemaEntity201909.tt"
+        #line 285 "SchemaEntity201909.tt"
 
     }
     
@@ -1161,13 +1174,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 285 "SchemaEntity201909.tt"
+        #line 288 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 285 "SchemaEntity201909.tt"
+        #line 288 "SchemaEntity201909.tt"
 
     if(IsImplicitString)
     {
@@ -1176,13 +1189,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 289 "SchemaEntity201909.tt"
-        this.Write("            this.stringBacking = default;\r\n    ");
+        #line 292 "SchemaEntity201909.tt"
+        this.Write("            this.stringBacking = __CorvusConstValue.stringBacking;\r\n    ");
         
         #line default
         #line hidden
         
-        #line 290 "SchemaEntity201909.tt"
+        #line 293 "SchemaEntity201909.tt"
 
     }
     
@@ -1190,13 +1203,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 293 "SchemaEntity201909.tt"
+        #line 296 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 293 "SchemaEntity201909.tt"
+        #line 296 "SchemaEntity201909.tt"
 
     if(IsImplicitBoolean)
     {
@@ -1205,13 +1218,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 297 "SchemaEntity201909.tt"
-        this.Write("            this.booleanBacking = default;\r\n    ");
+        #line 300 "SchemaEntity201909.tt"
+        this.Write("            this.booleanBacking = __CorvusConstValue.booleanBacking;\r\n    ");
         
         #line default
         #line hidden
         
-        #line 298 "SchemaEntity201909.tt"
+        #line 301 "SchemaEntity201909.tt"
 
     }
     
@@ -1219,13 +1232,54 @@ namespace ");
         #line default
         #line hidden
         
-        #line 301 "SchemaEntity201909.tt"
+        #line 304 "SchemaEntity201909.tt"
         this.Write("        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 303 "SchemaEntity201909.tt"
+        #line 306 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 309 "SchemaEntity201909.tt"
+        this.Write("\r\n        /// <summary>\r\n        /// Initializes a new instance of the <see cref=" +
+                "\"");
+        
+        #line default
+        #line hidden
+        
+        #line 311 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 311 "SchemaEntity201909.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">The backing " +
+                "<see cref=\"JsonElement\"/>.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 314 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 314 "SchemaEntity201909.tt"
+        this.Write("(JsonElement value)\r\n        {\r\n            this.jsonElementBacking = value;\r\n   " +
+                " ");
+        
+        #line default
+        #line hidden
+        
+        #line 317 "SchemaEntity201909.tt"
 
     if(IsImplicitObject)
     {
@@ -1234,39 +1288,184 @@ namespace ");
         #line default
         #line hidden
         
-        #line 307 "SchemaEntity201909.tt"
+        #line 321 "SchemaEntity201909.tt"
+        this.Write("            this.objectBacking = default;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 322 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 325 "SchemaEntity201909.tt"
+        this.Write("    ");
+        
+        #line default
+        #line hidden
+        
+        #line 325 "SchemaEntity201909.tt"
+
+    if(IsImplicitArray)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 329 "SchemaEntity201909.tt"
+        this.Write("            this.arrayBacking = default;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 330 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 333 "SchemaEntity201909.tt"
+        this.Write("    ");
+        
+        #line default
+        #line hidden
+        
+        #line 333 "SchemaEntity201909.tt"
+
+    if(IsImplicitNumber)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 337 "SchemaEntity201909.tt"
+        this.Write("            this.numberBacking = default;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 338 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 341 "SchemaEntity201909.tt"
+        this.Write("    ");
+        
+        #line default
+        #line hidden
+        
+        #line 341 "SchemaEntity201909.tt"
+
+    if(IsImplicitString)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 345 "SchemaEntity201909.tt"
+        this.Write("            this.stringBacking = default;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 346 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 349 "SchemaEntity201909.tt"
+        this.Write("    ");
+        
+        #line default
+        #line hidden
+        
+        #line 349 "SchemaEntity201909.tt"
+
+    if(IsImplicitBoolean)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 353 "SchemaEntity201909.tt"
+        this.Write("            this.booleanBacking = default;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 354 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 357 "SchemaEntity201909.tt"
+        this.Write("        }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 359 "SchemaEntity201909.tt"
+
+    if(IsImplicitObject)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 363 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 308 "SchemaEntity201909.tt"
+        #line 364 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 308 "SchemaEntity201909.tt"
+        #line 364 "SchemaEntity201909.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A property d" +
                 "ictionary.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 311 "SchemaEntity201909.tt"
+        #line 367 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 311 "SchemaEntity201909.tt"
+        #line 367 "SchemaEntity201909.tt"
         this.Write("(ImmutableDictionary<string, JsonAny> value)\r\n        {\r\n            this.jsonEle" +
                 "mentBacking = default;\r\n            this.objectBacking = value;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 315 "SchemaEntity201909.tt"
+        #line 371 "SchemaEntity201909.tt"
 
         if(IsImplicitArray)
         {
@@ -1275,13 +1474,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 319 "SchemaEntity201909.tt"
+        #line 375 "SchemaEntity201909.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 320 "SchemaEntity201909.tt"
+        #line 376 "SchemaEntity201909.tt"
 
         }
         
@@ -1289,13 +1488,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 323 "SchemaEntity201909.tt"
+        #line 379 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 323 "SchemaEntity201909.tt"
+        #line 379 "SchemaEntity201909.tt"
 
         if(IsImplicitNumber)
         {
@@ -1304,13 +1503,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 327 "SchemaEntity201909.tt"
+        #line 383 "SchemaEntity201909.tt"
         this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 328 "SchemaEntity201909.tt"
+        #line 384 "SchemaEntity201909.tt"
 
         }
         
@@ -1318,13 +1517,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 331 "SchemaEntity201909.tt"
+        #line 387 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 331 "SchemaEntity201909.tt"
+        #line 387 "SchemaEntity201909.tt"
 
         if(IsImplicitString)
         {
@@ -1333,13 +1532,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 335 "SchemaEntity201909.tt"
+        #line 391 "SchemaEntity201909.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 336 "SchemaEntity201909.tt"
+        #line 392 "SchemaEntity201909.tt"
 
         }
         
@@ -1347,13 +1546,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 339 "SchemaEntity201909.tt"
+        #line 395 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 339 "SchemaEntity201909.tt"
+        #line 395 "SchemaEntity201909.tt"
 
         if(IsImplicitBoolean)
         {
@@ -1362,13 +1561,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 343 "SchemaEntity201909.tt"
+        #line 399 "SchemaEntity201909.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 344 "SchemaEntity201909.tt"
+        #line 400 "SchemaEntity201909.tt"
 
         }
         
@@ -1376,20 +1575,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 347 "SchemaEntity201909.tt"
+        #line 403 "SchemaEntity201909.tt"
         this.Write("        }\r\n\r\n        /// <summary>\r\n        /// Initializes a new instance of the" +
                 " <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 350 "SchemaEntity201909.tt"
+        #line 406 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 350 "SchemaEntity201909.tt"
+        #line 406 "SchemaEntity201909.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"jsonObject\">The <se" +
                 "e cref=\"JsonObject\"/> from which to construct the value.</param>\r\n        public" +
                 " ");
@@ -1397,13 +1596,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 353 "SchemaEntity201909.tt"
+        #line 409 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 353 "SchemaEntity201909.tt"
+        #line 409 "SchemaEntity201909.tt"
         this.Write(@"(JsonObject jsonObject)
         {
             if (jsonObject.HasJsonElement)
@@ -1422,7 +1621,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 366 "SchemaEntity201909.tt"
+        #line 422 "SchemaEntity201909.tt"
 
         if(IsImplicitArray)
         {
@@ -1431,208 +1630,8 @@ namespace ");
         #line default
         #line hidden
         
-        #line 370 "SchemaEntity201909.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 371 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 374 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 374 "SchemaEntity201909.tt"
-
-        if(IsImplicitNumber)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 378 "SchemaEntity201909.tt"
-        this.Write("            this.numberBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 379 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 382 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 382 "SchemaEntity201909.tt"
-
-        if(IsImplicitString)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 386 "SchemaEntity201909.tt"
-        this.Write("            this.stringBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 387 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 390 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 390 "SchemaEntity201909.tt"
-
-        if(IsImplicitBoolean)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 394 "SchemaEntity201909.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 395 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 398 "SchemaEntity201909.tt"
-        this.Write("        }\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 399 "SchemaEntity201909.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 402 "SchemaEntity201909.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 403 "SchemaEntity201909.tt"
-
-    if(IsImplicitArray)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 407 "SchemaEntity201909.tt"
-        this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 408 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 408 "SchemaEntity201909.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">An array lis" +
-                "t.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 411 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 411 "SchemaEntity201909.tt"
-        this.Write("(ImmutableList<JsonAny> value)\r\n        {\r\n            this.jsonElementBacking = " +
-                "default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 414 "SchemaEntity201909.tt"
-
-        if(IsImplicitObject)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 418 "SchemaEntity201909.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 419 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 422 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 422 "SchemaEntity201909.tt"
-
-        if(IsImplicitNumber)
-        {
-        
-        
-        #line default
-        #line hidden
-        
         #line 426 "SchemaEntity201909.tt"
-        this.Write("            this.numberBacking = default;\r\n        ");
+        this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
@@ -1653,7 +1652,7 @@ namespace ");
         
         #line 430 "SchemaEntity201909.tt"
 
-        if(IsImplicitString)
+        if(IsImplicitNumber)
         {
         
         
@@ -1661,7 +1660,7 @@ namespace ");
         #line hidden
         
         #line 434 "SchemaEntity201909.tt"
-        this.Write("            this.stringBacking = default;\r\n        ");
+        this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
@@ -1682,7 +1681,7 @@ namespace ");
         
         #line 438 "SchemaEntity201909.tt"
 
-        if(IsImplicitBoolean)
+        if(IsImplicitString)
         {
         
         
@@ -1690,7 +1689,7 @@ namespace ");
         #line hidden
         
         #line 442 "SchemaEntity201909.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
+        this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
@@ -1704,32 +1703,232 @@ namespace ");
         #line hidden
         
         #line 446 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 446 "SchemaEntity201909.tt"
+
+        if(IsImplicitBoolean)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 450 "SchemaEntity201909.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 451 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 454 "SchemaEntity201909.tt"
+        this.Write("        }\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 455 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 458 "SchemaEntity201909.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 459 "SchemaEntity201909.tt"
+
+    if(IsImplicitArray)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 463 "SchemaEntity201909.tt"
+        this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 464 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 464 "SchemaEntity201909.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">An array lis" +
+                "t.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 467 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 467 "SchemaEntity201909.tt"
+        this.Write("(ImmutableList<JsonAny> value)\r\n        {\r\n            this.jsonElementBacking = " +
+                "default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 470 "SchemaEntity201909.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 474 "SchemaEntity201909.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 475 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 478 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 478 "SchemaEntity201909.tt"
+
+        if(IsImplicitNumber)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 482 "SchemaEntity201909.tt"
+        this.Write("            this.numberBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 483 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 486 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 486 "SchemaEntity201909.tt"
+
+        if(IsImplicitString)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 490 "SchemaEntity201909.tt"
+        this.Write("            this.stringBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 491 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 494 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 494 "SchemaEntity201909.tt"
+
+        if(IsImplicitBoolean)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 498 "SchemaEntity201909.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 499 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 502 "SchemaEntity201909.tt"
         this.Write("            this.arrayBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n     " +
                 "   /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 450 "SchemaEntity201909.tt"
+        #line 506 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 450 "SchemaEntity201909.tt"
+        #line 506 "SchemaEntity201909.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"jsonArray\">The <see" +
                 " cref=\"JsonArray\"/> from which to construct the value.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 453 "SchemaEntity201909.tt"
+        #line 509 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 453 "SchemaEntity201909.tt"
+        #line 509 "SchemaEntity201909.tt"
         this.Write(@"(JsonArray jsonArray)
         {
             if (jsonArray.HasJsonElement)
@@ -1748,7 +1947,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 466 "SchemaEntity201909.tt"
+        #line 522 "SchemaEntity201909.tt"
 
         if(IsImplicitObject)
         {
@@ -1757,13 +1956,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 470 "SchemaEntity201909.tt"
+        #line 526 "SchemaEntity201909.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 471 "SchemaEntity201909.tt"
+        #line 527 "SchemaEntity201909.tt"
 
         }
         
@@ -1771,13 +1970,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 474 "SchemaEntity201909.tt"
+        #line 530 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 474 "SchemaEntity201909.tt"
+        #line 530 "SchemaEntity201909.tt"
 
         if(IsImplicitNumber)
         {
@@ -1786,13 +1985,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 478 "SchemaEntity201909.tt"
+        #line 534 "SchemaEntity201909.tt"
         this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 479 "SchemaEntity201909.tt"
+        #line 535 "SchemaEntity201909.tt"
 
         }
         
@@ -1800,13 +1999,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 482 "SchemaEntity201909.tt"
+        #line 538 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 482 "SchemaEntity201909.tt"
+        #line 538 "SchemaEntity201909.tt"
 
         if(IsImplicitString)
         {
@@ -1815,13 +2014,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 486 "SchemaEntity201909.tt"
+        #line 542 "SchemaEntity201909.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 487 "SchemaEntity201909.tt"
+        #line 543 "SchemaEntity201909.tt"
 
         }
         
@@ -1829,13 +2028,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 490 "SchemaEntity201909.tt"
+        #line 546 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 490 "SchemaEntity201909.tt"
+        #line 546 "SchemaEntity201909.tt"
 
         if(IsImplicitBoolean)
         {
@@ -1844,13 +2043,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 494 "SchemaEntity201909.tt"
+        #line 550 "SchemaEntity201909.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 495 "SchemaEntity201909.tt"
+        #line 551 "SchemaEntity201909.tt"
 
         }
         
@@ -1858,13 +2057,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 498 "SchemaEntity201909.tt"
+        #line 554 "SchemaEntity201909.tt"
         this.Write("        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 499 "SchemaEntity201909.tt"
+        #line 555 "SchemaEntity201909.tt"
 
     }
     
@@ -1872,13 +2071,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 502 "SchemaEntity201909.tt"
+        #line 558 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 503 "SchemaEntity201909.tt"
+        #line 559 "SchemaEntity201909.tt"
 
     if(IsImplicitNumber)
     {
@@ -1887,19 +2086,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 507 "SchemaEntity201909.tt"
+        #line 563 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 508 "SchemaEntity201909.tt"
+        #line 564 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 508 "SchemaEntity201909.tt"
+        #line 564 "SchemaEntity201909.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"jsonNumber\">The <se" +
                 "e cref=\"JsonNumber\"/> from which to construct the value.</param>\r\n        public" +
                 " ");
@@ -1907,13 +2106,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 511 "SchemaEntity201909.tt"
+        #line 567 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 511 "SchemaEntity201909.tt"
+        #line 567 "SchemaEntity201909.tt"
         this.Write(@"(JsonNumber jsonNumber)
         {
             if (jsonNumber.HasJsonElement)
@@ -1931,7 +2130,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 523 "SchemaEntity201909.tt"
+        #line 579 "SchemaEntity201909.tt"
 
         if(IsImplicitObject)
         {
@@ -1940,13 +2139,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 527 "SchemaEntity201909.tt"
+        #line 583 "SchemaEntity201909.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 528 "SchemaEntity201909.tt"
+        #line 584 "SchemaEntity201909.tt"
 
         }
         
@@ -1954,13 +2153,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 531 "SchemaEntity201909.tt"
+        #line 587 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 531 "SchemaEntity201909.tt"
+        #line 587 "SchemaEntity201909.tt"
 
         if(IsImplicitArray)
         {
@@ -1969,13 +2168,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 535 "SchemaEntity201909.tt"
+        #line 591 "SchemaEntity201909.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 536 "SchemaEntity201909.tt"
+        #line 592 "SchemaEntity201909.tt"
 
         }
         
@@ -1983,13 +2182,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 539 "SchemaEntity201909.tt"
+        #line 595 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 539 "SchemaEntity201909.tt"
+        #line 595 "SchemaEntity201909.tt"
 
         if(IsImplicitString)
         {
@@ -1998,13 +2197,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 543 "SchemaEntity201909.tt"
+        #line 599 "SchemaEntity201909.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 544 "SchemaEntity201909.tt"
+        #line 600 "SchemaEntity201909.tt"
 
         }
         
@@ -2012,13 +2211,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 547 "SchemaEntity201909.tt"
+        #line 603 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 547 "SchemaEntity201909.tt"
+        #line 603 "SchemaEntity201909.tt"
 
         if(IsImplicitBoolean)
         {
@@ -2027,13 +2226,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 551 "SchemaEntity201909.tt"
+        #line 607 "SchemaEntity201909.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 552 "SchemaEntity201909.tt"
+        #line 608 "SchemaEntity201909.tt"
 
         }
         
@@ -2041,40 +2240,40 @@ namespace ");
         #line default
         #line hidden
         
-        #line 555 "SchemaEntity201909.tt"
+        #line 611 "SchemaEntity201909.tt"
         this.Write("        }\r\n\r\n        /// <summary>\r\n        /// Initializes a new instance of the" +
                 " <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 558 "SchemaEntity201909.tt"
+        #line 614 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 558 "SchemaEntity201909.tt"
+        #line 614 "SchemaEntity201909.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
                 "ue.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 561 "SchemaEntity201909.tt"
+        #line 617 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 561 "SchemaEntity201909.tt"
+        #line 617 "SchemaEntity201909.tt"
         this.Write("(double value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n      " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 564 "SchemaEntity201909.tt"
+        #line 620 "SchemaEntity201909.tt"
 
         if(IsImplicitObject)
         {
@@ -2083,13 +2282,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 568 "SchemaEntity201909.tt"
+        #line 624 "SchemaEntity201909.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 569 "SchemaEntity201909.tt"
+        #line 625 "SchemaEntity201909.tt"
 
         }
         
@@ -2097,13 +2296,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 572 "SchemaEntity201909.tt"
+        #line 628 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 572 "SchemaEntity201909.tt"
+        #line 628 "SchemaEntity201909.tt"
 
         if(IsImplicitArray)
         {
@@ -2112,13 +2311,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 576 "SchemaEntity201909.tt"
+        #line 632 "SchemaEntity201909.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 577 "SchemaEntity201909.tt"
+        #line 633 "SchemaEntity201909.tt"
 
         }
         
@@ -2126,13 +2325,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 580 "SchemaEntity201909.tt"
+        #line 636 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 580 "SchemaEntity201909.tt"
+        #line 636 "SchemaEntity201909.tt"
 
         if(IsImplicitString)
         {
@@ -2141,13 +2340,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 584 "SchemaEntity201909.tt"
+        #line 640 "SchemaEntity201909.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 585 "SchemaEntity201909.tt"
+        #line 641 "SchemaEntity201909.tt"
 
         }
         
@@ -2155,354 +2354,68 @@ namespace ");
         #line default
         #line hidden
         
-        #line 588 "SchemaEntity201909.tt"
+        #line 644 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 588 "SchemaEntity201909.tt"
+        #line 644 "SchemaEntity201909.tt"
 
         if(IsImplicitBoolean)
         {
         
-        
-        #line default
-        #line hidden
-        
-        #line 592 "SchemaEntity201909.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 593 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 596 "SchemaEntity201909.tt"
-        this.Write("            this.numberBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
-                "    /// Initializes a new instance of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 600 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 600 "SchemaEntity201909.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
-                "ue.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 603 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 603 "SchemaEntity201909.tt"
-        this.Write("(int value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 606 "SchemaEntity201909.tt"
-
-        if(IsImplicitObject)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 610 "SchemaEntity201909.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 611 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 614 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 614 "SchemaEntity201909.tt"
-
-        if(IsImplicitArray)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 618 "SchemaEntity201909.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 619 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 622 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 622 "SchemaEntity201909.tt"
-
-        if(IsImplicitString)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 626 "SchemaEntity201909.tt"
-        this.Write("            this.stringBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 627 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 630 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 630 "SchemaEntity201909.tt"
-
-        if(IsImplicitBoolean)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 634 "SchemaEntity201909.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 635 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 638 "SchemaEntity201909.tt"
-        this.Write("            this.numberBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
-                "    /// Initializes a new instance of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 642 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 642 "SchemaEntity201909.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
-                "ue.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 645 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 645 "SchemaEntity201909.tt"
-        this.Write("(float value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n       " +
-                " ");
         
         #line default
         #line hidden
         
         #line 648 "SchemaEntity201909.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 649 "SchemaEntity201909.tt"
 
-        if(IsImplicitObject)
-        {
+        }
         
         
         #line default
         #line hidden
         
         #line 652 "SchemaEntity201909.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 653 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 656 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 656 "SchemaEntity201909.tt"
-
-        if(IsImplicitArray)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 660 "SchemaEntity201909.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 661 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 664 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 664 "SchemaEntity201909.tt"
-
-        if(IsImplicitString)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 668 "SchemaEntity201909.tt"
-        this.Write("            this.stringBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 669 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 672 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 672 "SchemaEntity201909.tt"
-
-        if(IsImplicitBoolean)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 676 "SchemaEntity201909.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 677 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 680 "SchemaEntity201909.tt"
         this.Write("            this.numberBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
                 "    /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 684 "SchemaEntity201909.tt"
+        #line 656 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 684 "SchemaEntity201909.tt"
+        #line 656 "SchemaEntity201909.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
                 "ue.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 687 "SchemaEntity201909.tt"
+        #line 659 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 687 "SchemaEntity201909.tt"
-        this.Write("(long value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n        " +
-                "");
+        #line 659 "SchemaEntity201909.tt"
+        this.Write("(int value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 690 "SchemaEntity201909.tt"
+        #line 662 "SchemaEntity201909.tt"
 
         if(IsImplicitObject)
         {
@@ -2511,13 +2424,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 694 "SchemaEntity201909.tt"
+        #line 666 "SchemaEntity201909.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 695 "SchemaEntity201909.tt"
+        #line 667 "SchemaEntity201909.tt"
 
         }
         
@@ -2525,13 +2438,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 698 "SchemaEntity201909.tt"
+        #line 670 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 698 "SchemaEntity201909.tt"
+        #line 670 "SchemaEntity201909.tt"
 
         if(IsImplicitArray)
         {
@@ -2540,13 +2453,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 702 "SchemaEntity201909.tt"
+        #line 674 "SchemaEntity201909.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 703 "SchemaEntity201909.tt"
+        #line 675 "SchemaEntity201909.tt"
 
         }
         
@@ -2554,13 +2467,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 706 "SchemaEntity201909.tt"
+        #line 678 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 706 "SchemaEntity201909.tt"
+        #line 678 "SchemaEntity201909.tt"
 
         if(IsImplicitString)
         {
@@ -2569,13 +2482,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 710 "SchemaEntity201909.tt"
+        #line 682 "SchemaEntity201909.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 711 "SchemaEntity201909.tt"
+        #line 683 "SchemaEntity201909.tt"
 
         }
         
@@ -2583,13 +2496,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 714 "SchemaEntity201909.tt"
+        #line 686 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 714 "SchemaEntity201909.tt"
+        #line 686 "SchemaEntity201909.tt"
 
         if(IsImplicitBoolean)
         {
@@ -2598,13 +2511,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 718 "SchemaEntity201909.tt"
+        #line 690 "SchemaEntity201909.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 719 "SchemaEntity201909.tt"
+        #line 691 "SchemaEntity201909.tt"
 
         }
         
@@ -2612,13 +2525,299 @@ namespace ");
         #line default
         #line hidden
         
-        #line 722 "SchemaEntity201909.tt"
-        this.Write("            this.numberBacking = value;\r\n        }\r\n    ");
+        #line 694 "SchemaEntity201909.tt"
+        this.Write("            this.numberBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
+                "    /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 698 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 698 "SchemaEntity201909.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
+                "ue.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 701 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 701 "SchemaEntity201909.tt"
+        this.Write("(float value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n       " +
+                " ");
+        
+        #line default
+        #line hidden
+        
+        #line 704 "SchemaEntity201909.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 708 "SchemaEntity201909.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 709 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 712 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 712 "SchemaEntity201909.tt"
+
+        if(IsImplicitArray)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 716 "SchemaEntity201909.tt"
+        this.Write("            this.arrayBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 717 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 720 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 720 "SchemaEntity201909.tt"
+
+        if(IsImplicitString)
+        {
+        
         
         #line default
         #line hidden
         
         #line 724 "SchemaEntity201909.tt"
+        this.Write("            this.stringBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 725 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 728 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 728 "SchemaEntity201909.tt"
+
+        if(IsImplicitBoolean)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 732 "SchemaEntity201909.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 733 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 736 "SchemaEntity201909.tt"
+        this.Write("            this.numberBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
+                "    /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 740 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 740 "SchemaEntity201909.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
+                "ue.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 743 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 743 "SchemaEntity201909.tt"
+        this.Write("(long value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n        " +
+                "");
+        
+        #line default
+        #line hidden
+        
+        #line 746 "SchemaEntity201909.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 750 "SchemaEntity201909.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 751 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 754 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 754 "SchemaEntity201909.tt"
+
+        if(IsImplicitArray)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 758 "SchemaEntity201909.tt"
+        this.Write("            this.arrayBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 759 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 762 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 762 "SchemaEntity201909.tt"
+
+        if(IsImplicitString)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 766 "SchemaEntity201909.tt"
+        this.Write("            this.stringBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 767 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 770 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 770 "SchemaEntity201909.tt"
+
+        if(IsImplicitBoolean)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 774 "SchemaEntity201909.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 775 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 778 "SchemaEntity201909.tt"
+        this.Write("            this.numberBacking = value;\r\n        }\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 780 "SchemaEntity201909.tt"
 
     }
     
@@ -2626,13 +2825,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 727 "SchemaEntity201909.tt"
+        #line 783 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 728 "SchemaEntity201909.tt"
+        #line 784 "SchemaEntity201909.tt"
 
     if(IsImplicitString)
     {
@@ -2641,39 +2840,39 @@ namespace ");
         #line default
         #line hidden
         
-        #line 732 "SchemaEntity201909.tt"
+        #line 788 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 733 "SchemaEntity201909.tt"
+        #line 789 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 733 "SchemaEntity201909.tt"
+        #line 789 "SchemaEntity201909.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A string val" +
                 "ue.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 736 "SchemaEntity201909.tt"
+        #line 792 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 736 "SchemaEntity201909.tt"
+        #line 792 "SchemaEntity201909.tt"
         this.Write("(string value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n      " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 739 "SchemaEntity201909.tt"
+        #line 795 "SchemaEntity201909.tt"
 
         if(IsImplicitObject)
         {
@@ -2682,13 +2881,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 743 "SchemaEntity201909.tt"
+        #line 799 "SchemaEntity201909.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 744 "SchemaEntity201909.tt"
+        #line 800 "SchemaEntity201909.tt"
 
         }
         
@@ -2696,13 +2895,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 747 "SchemaEntity201909.tt"
+        #line 803 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 747 "SchemaEntity201909.tt"
+        #line 803 "SchemaEntity201909.tt"
 
         if(IsImplicitArray)
         {
@@ -2711,13 +2910,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 751 "SchemaEntity201909.tt"
+        #line 807 "SchemaEntity201909.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 752 "SchemaEntity201909.tt"
+        #line 808 "SchemaEntity201909.tt"
 
         }
         
@@ -2725,13 +2924,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 755 "SchemaEntity201909.tt"
+        #line 811 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 755 "SchemaEntity201909.tt"
+        #line 811 "SchemaEntity201909.tt"
 
         if(IsImplicitNumber)
         {
@@ -2740,13 +2939,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 759 "SchemaEntity201909.tt"
+        #line 815 "SchemaEntity201909.tt"
         this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 760 "SchemaEntity201909.tt"
+        #line 816 "SchemaEntity201909.tt"
 
         }
         
@@ -2754,227 +2953,84 @@ namespace ");
         #line default
         #line hidden
         
-        #line 763 "SchemaEntity201909.tt"
+        #line 819 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 763 "SchemaEntity201909.tt"
+        #line 819 "SchemaEntity201909.tt"
 
         if(IsImplicitBoolean)
         {
         
-        
-        #line default
-        #line hidden
-        
-        #line 767 "SchemaEntity201909.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 768 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 771 "SchemaEntity201909.tt"
-        this.Write("            this.stringBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
-                "    /// Initializes a new instance of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 775 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 775 "SchemaEntity201909.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A string val" +
-                "ue.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 778 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 778 "SchemaEntity201909.tt"
-        this.Write("(ReadOnlySpan<char> value)\r\n        {\r\n            this.jsonElementBacking = defa" +
-                "ult;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 781 "SchemaEntity201909.tt"
-
-        if(IsImplicitObject)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 785 "SchemaEntity201909.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 786 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 789 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 789 "SchemaEntity201909.tt"
-
-        if(IsImplicitArray)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 793 "SchemaEntity201909.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 794 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 797 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 797 "SchemaEntity201909.tt"
-
-        if(IsImplicitNumber)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 801 "SchemaEntity201909.tt"
-        this.Write("            this.numberBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 802 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 805 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 805 "SchemaEntity201909.tt"
-
-        if(IsImplicitBoolean)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 809 "SchemaEntity201909.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 810 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 813 "SchemaEntity201909.tt"
-        this.Write("            this.stringBacking = value.ToString();\r\n        }\r\n\r\n        /// <sum" +
-                "mary>\r\n        /// Initializes a new instance of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 817 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 817 "SchemaEntity201909.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A string val" +
-                "ue.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 820 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 820 "SchemaEntity201909.tt"
-        this.Write("(ReadOnlySpan<byte> value)\r\n        {\r\n            this.jsonElementBacking = defa" +
-                "ult;\r\n        ");
         
         #line default
         #line hidden
         
         #line 823 "SchemaEntity201909.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 824 "SchemaEntity201909.tt"
 
-        if(IsImplicitObject)
-        {
+        }
         
         
         #line default
         #line hidden
         
         #line 827 "SchemaEntity201909.tt"
+        this.Write("            this.stringBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
+                "    /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 831 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 831 "SchemaEntity201909.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A string val" +
+                "ue.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 834 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 834 "SchemaEntity201909.tt"
+        this.Write("(ReadOnlySpan<char> value)\r\n        {\r\n            this.jsonElementBacking = defa" +
+                "ult;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 837 "SchemaEntity201909.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 841 "SchemaEntity201909.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 828 "SchemaEntity201909.tt"
+        #line 842 "SchemaEntity201909.tt"
 
         }
         
@@ -2982,13 +3038,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 831 "SchemaEntity201909.tt"
+        #line 845 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 831 "SchemaEntity201909.tt"
+        #line 845 "SchemaEntity201909.tt"
 
         if(IsImplicitArray)
         {
@@ -2997,13 +3053,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 835 "SchemaEntity201909.tt"
+        #line 849 "SchemaEntity201909.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 836 "SchemaEntity201909.tt"
+        #line 850 "SchemaEntity201909.tt"
 
         }
         
@@ -3011,13 +3067,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 839 "SchemaEntity201909.tt"
+        #line 853 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 839 "SchemaEntity201909.tt"
+        #line 853 "SchemaEntity201909.tt"
 
         if(IsImplicitNumber)
         {
@@ -3026,13 +3082,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 843 "SchemaEntity201909.tt"
+        #line 857 "SchemaEntity201909.tt"
         this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 844 "SchemaEntity201909.tt"
+        #line 858 "SchemaEntity201909.tt"
 
         }
         
@@ -3040,13 +3096,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 847 "SchemaEntity201909.tt"
+        #line 861 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 847 "SchemaEntity201909.tt"
+        #line 861 "SchemaEntity201909.tt"
 
         if(IsImplicitBoolean)
         {
@@ -3055,13 +3111,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 851 "SchemaEntity201909.tt"
+        #line 865 "SchemaEntity201909.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 852 "SchemaEntity201909.tt"
+        #line 866 "SchemaEntity201909.tt"
 
         }
         
@@ -3069,7 +3125,150 @@ namespace ");
         #line default
         #line hidden
         
-        #line 855 "SchemaEntity201909.tt"
+        #line 869 "SchemaEntity201909.tt"
+        this.Write("            this.stringBacking = value.ToString();\r\n        }\r\n\r\n        /// <sum" +
+                "mary>\r\n        /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 873 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 873 "SchemaEntity201909.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A string val" +
+                "ue.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 876 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 876 "SchemaEntity201909.tt"
+        this.Write("(ReadOnlySpan<byte> value)\r\n        {\r\n            this.jsonElementBacking = defa" +
+                "ult;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 879 "SchemaEntity201909.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 883 "SchemaEntity201909.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 884 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 887 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 887 "SchemaEntity201909.tt"
+
+        if(IsImplicitArray)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 891 "SchemaEntity201909.tt"
+        this.Write("            this.arrayBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 892 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 895 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 895 "SchemaEntity201909.tt"
+
+        if(IsImplicitNumber)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 899 "SchemaEntity201909.tt"
+        this.Write("            this.numberBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 900 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 903 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 903 "SchemaEntity201909.tt"
+
+        if(IsImplicitBoolean)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 907 "SchemaEntity201909.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 908 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 911 "SchemaEntity201909.tt"
         this.Write("            this.stringBacking = System.Text.Encoding.UTF8.GetString(value);\r\n   " +
                 "     }\r\n\r\n        /// <summary>\r\n        /// Initializes a new instance of the <" +
                 "see cref=\"");
@@ -3077,13 +3276,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 859 "SchemaEntity201909.tt"
+        #line 915 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 859 "SchemaEntity201909.tt"
+        #line 915 "SchemaEntity201909.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"jsonString\">The <se" +
                 "e cref=\"JsonString\"/> from which to construct the value.</param>\r\n        public" +
                 " ");
@@ -3091,13 +3290,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 862 "SchemaEntity201909.tt"
+        #line 918 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 862 "SchemaEntity201909.tt"
+        #line 918 "SchemaEntity201909.tt"
         this.Write(@"(JsonString jsonString)
         {
             if (jsonString.HasJsonElement)
@@ -3116,7 +3315,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 875 "SchemaEntity201909.tt"
+        #line 931 "SchemaEntity201909.tt"
 
         if(IsImplicitObject)
         {
@@ -3125,13 +3324,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 879 "SchemaEntity201909.tt"
+        #line 935 "SchemaEntity201909.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 880 "SchemaEntity201909.tt"
+        #line 936 "SchemaEntity201909.tt"
 
         }
         
@@ -3139,13 +3338,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 883 "SchemaEntity201909.tt"
+        #line 939 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 883 "SchemaEntity201909.tt"
+        #line 939 "SchemaEntity201909.tt"
 
         if(IsImplicitArray)
         {
@@ -3154,13 +3353,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 887 "SchemaEntity201909.tt"
+        #line 943 "SchemaEntity201909.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 888 "SchemaEntity201909.tt"
+        #line 944 "SchemaEntity201909.tt"
 
         }
         
@@ -3168,13 +3367,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 891 "SchemaEntity201909.tt"
+        #line 947 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 891 "SchemaEntity201909.tt"
+        #line 947 "SchemaEntity201909.tt"
 
         if(IsImplicitNumber)
         {
@@ -3183,13 +3382,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 895 "SchemaEntity201909.tt"
+        #line 951 "SchemaEntity201909.tt"
         this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 896 "SchemaEntity201909.tt"
+        #line 952 "SchemaEntity201909.tt"
 
         }
         
@@ -3197,13 +3396,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 899 "SchemaEntity201909.tt"
+        #line 955 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 899 "SchemaEntity201909.tt"
+        #line 955 "SchemaEntity201909.tt"
 
         if(IsImplicitBoolean)
         {
@@ -3212,13 +3411,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 903 "SchemaEntity201909.tt"
+        #line 959 "SchemaEntity201909.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 904 "SchemaEntity201909.tt"
+        #line 960 "SchemaEntity201909.tt"
 
         }
         
@@ -3226,13 +3425,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 907 "SchemaEntity201909.tt"
+        #line 963 "SchemaEntity201909.tt"
         this.Write("        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 908 "SchemaEntity201909.tt"
+        #line 964 "SchemaEntity201909.tt"
 
     }
     
@@ -3240,13 +3439,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 911 "SchemaEntity201909.tt"
+        #line 967 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 912 "SchemaEntity201909.tt"
+        #line 968 "SchemaEntity201909.tt"
 
     if(IsImplicitBoolean)
     {
@@ -3255,19 +3454,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 916 "SchemaEntity201909.tt"
+        #line 972 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 917 "SchemaEntity201909.tt"
+        #line 973 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 917 "SchemaEntity201909.tt"
+        #line 973 "SchemaEntity201909.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"jsonBoolean\">The <s" +
                 "ee cref=\"JsonBoolean\"/> from which to construct the value.</param>\r\n        publ" +
                 "ic ");
@@ -3275,13 +3474,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 920 "SchemaEntity201909.tt"
+        #line 976 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 920 "SchemaEntity201909.tt"
+        #line 976 "SchemaEntity201909.tt"
         this.Write(@"(JsonBoolean jsonBoolean)
         {
             if (jsonBoolean.HasJsonElement)
@@ -3300,237 +3499,94 @@ namespace ");
         #line default
         #line hidden
         
-        #line 933 "SchemaEntity201909.tt"
-
-        if(IsImplicitObject)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 937 "SchemaEntity201909.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 938 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 941 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 941 "SchemaEntity201909.tt"
-
-        if(IsImplicitArray)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 945 "SchemaEntity201909.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 946 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 949 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 949 "SchemaEntity201909.tt"
-
-        if(IsImplicitNumber)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 953 "SchemaEntity201909.tt"
-        this.Write("            this.numberBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 954 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 957 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 957 "SchemaEntity201909.tt"
-
-        if(IsImplicitString)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 961 "SchemaEntity201909.tt"
-        this.Write("            this.stringBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 962 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 965 "SchemaEntity201909.tt"
-        this.Write("        }\r\n\r\n                /// <summary>\r\n        /// Initializes a new instanc" +
-                "e of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 968 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 968 "SchemaEntity201909.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"boolean\">The <see c" +
-                "ref=\"bool\"/> from which to construct the value.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 971 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 971 "SchemaEntity201909.tt"
-        this.Write("(bool boolean)\r\n        {\r\n            this.jsonElementBacking = default;\r\n      " +
-                "      this.booleanBacking = boolean;\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 976 "SchemaEntity201909.tt"
-
-        if(IsImplicitObject)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 980 "SchemaEntity201909.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 981 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 984 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 984 "SchemaEntity201909.tt"
-
-        if(IsImplicitArray)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 988 "SchemaEntity201909.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
         #line 989 "SchemaEntity201909.tt"
 
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 992 "SchemaEntity201909.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 992 "SchemaEntity201909.tt"
-
-        if(IsImplicitNumber)
+        if(IsImplicitObject)
         {
         
         
         #line default
         #line hidden
         
-        #line 996 "SchemaEntity201909.tt"
-        this.Write("            this.numberBacking = default;\r\n        ");
+        #line 993 "SchemaEntity201909.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 994 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 997 "SchemaEntity201909.tt"
+        this.Write("        ");
         
         #line default
         #line hidden
         
         #line 997 "SchemaEntity201909.tt"
 
+        if(IsImplicitArray)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1001 "SchemaEntity201909.tt"
+        this.Write("            this.arrayBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1002 "SchemaEntity201909.tt"
+
         }
         
         
         #line default
         #line hidden
         
-        #line 1000 "SchemaEntity201909.tt"
+        #line 1005 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1000 "SchemaEntity201909.tt"
+        #line 1005 "SchemaEntity201909.tt"
+
+        if(IsImplicitNumber)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1009 "SchemaEntity201909.tt"
+        this.Write("            this.numberBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1010 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1013 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1013 "SchemaEntity201909.tt"
 
         if(IsImplicitString)
         {
@@ -3539,13 +3595,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1004 "SchemaEntity201909.tt"
+        #line 1017 "SchemaEntity201909.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1005 "SchemaEntity201909.tt"
+        #line 1018 "SchemaEntity201909.tt"
 
         }
         
@@ -3553,13 +3609,156 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1008 "SchemaEntity201909.tt"
+        #line 1021 "SchemaEntity201909.tt"
+        this.Write("        }\r\n\r\n                /// <summary>\r\n        /// Initializes a new instanc" +
+                "e of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 1024 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 1024 "SchemaEntity201909.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"boolean\">The <see c" +
+                "ref=\"bool\"/> from which to construct the value.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 1027 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 1027 "SchemaEntity201909.tt"
+        this.Write("(bool boolean)\r\n        {\r\n            this.jsonElementBacking = default;\r\n      " +
+                "      this.booleanBacking = boolean;\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1032 "SchemaEntity201909.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1036 "SchemaEntity201909.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1037 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1040 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1040 "SchemaEntity201909.tt"
+
+        if(IsImplicitArray)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1044 "SchemaEntity201909.tt"
+        this.Write("            this.arrayBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1045 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1048 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1048 "SchemaEntity201909.tt"
+
+        if(IsImplicitNumber)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1052 "SchemaEntity201909.tt"
+        this.Write("            this.numberBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1053 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1056 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1056 "SchemaEntity201909.tt"
+
+        if(IsImplicitString)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1060 "SchemaEntity201909.tt"
+        this.Write("            this.stringBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1061 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1064 "SchemaEntity201909.tt"
         this.Write("        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1010 "SchemaEntity201909.tt"
+        #line 1066 "SchemaEntity201909.tt"
 
     }
     
@@ -3567,25 +3766,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1013 "SchemaEntity201909.tt"
+        #line 1069 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1014 "SchemaEntity201909.tt"
+        #line 1070 "SchemaEntity201909.tt"
  /* Implicit Constructors */ 
         
         #line default
         #line hidden
         
-        #line 1015 "SchemaEntity201909.tt"
+        #line 1071 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1016 "SchemaEntity201909.tt"
+        #line 1072 "SchemaEntity201909.tt"
 
     foreach (Conversion conversion in ConversionsViaConstructor)
     {
@@ -3598,56 +3797,56 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1024 "SchemaEntity201909.tt"
+        #line 1080 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 1025 "SchemaEntity201909.tt"
+        #line 1081 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1025 "SchemaEntity201909.tt"
+        #line 1081 "SchemaEntity201909.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"conversion\">The <se" +
                 "e cref=\"");
         
         #line default
         #line hidden
         
-        #line 1027 "SchemaEntity201909.tt"
+        #line 1083 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1027 "SchemaEntity201909.tt"
+        #line 1083 "SchemaEntity201909.tt"
         this.Write("\"/> from which to construct the value.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 1028 "SchemaEntity201909.tt"
+        #line 1084 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1028 "SchemaEntity201909.tt"
+        #line 1084 "SchemaEntity201909.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 1028 "SchemaEntity201909.tt"
+        #line 1084 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1028 "SchemaEntity201909.tt"
+        #line 1084 "SchemaEntity201909.tt"
         this.Write(" conversion)\r\n        {\r\n            if (conversion.HasJsonElement)\r\n            " +
                 "{\r\n                this.jsonElementBacking = conversion.AsJsonElement;\r\n        " +
                 "");
@@ -3655,7 +3854,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1033 "SchemaEntity201909.tt"
+        #line 1089 "SchemaEntity201909.tt"
 
         if(IsImplicitObject)
         {
@@ -3664,13 +3863,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1037 "SchemaEntity201909.tt"
+        #line 1093 "SchemaEntity201909.tt"
         this.Write("                this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1038 "SchemaEntity201909.tt"
+        #line 1094 "SchemaEntity201909.tt"
 
         }
         
@@ -3678,13 +3877,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1041 "SchemaEntity201909.tt"
+        #line 1097 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1041 "SchemaEntity201909.tt"
+        #line 1097 "SchemaEntity201909.tt"
 
         if(IsImplicitBoolean)
         {
@@ -3693,13 +3892,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1045 "SchemaEntity201909.tt"
+        #line 1101 "SchemaEntity201909.tt"
         this.Write("                this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1046 "SchemaEntity201909.tt"
+        #line 1102 "SchemaEntity201909.tt"
 
         }
         
@@ -3707,13 +3906,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1049 "SchemaEntity201909.tt"
+        #line 1105 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1050 "SchemaEntity201909.tt"
+        #line 1106 "SchemaEntity201909.tt"
 
         if(IsImplicitArray)
         {
@@ -3722,13 +3921,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1054 "SchemaEntity201909.tt"
+        #line 1110 "SchemaEntity201909.tt"
         this.Write("                this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1055 "SchemaEntity201909.tt"
+        #line 1111 "SchemaEntity201909.tt"
 
         }
         
@@ -3736,13 +3935,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1058 "SchemaEntity201909.tt"
+        #line 1114 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1058 "SchemaEntity201909.tt"
+        #line 1114 "SchemaEntity201909.tt"
 
         if(IsImplicitNumber)
         {
@@ -3751,13 +3950,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1062 "SchemaEntity201909.tt"
+        #line 1118 "SchemaEntity201909.tt"
         this.Write("                this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1063 "SchemaEntity201909.tt"
+        #line 1119 "SchemaEntity201909.tt"
 
         }
         
@@ -3765,13 +3964,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1066 "SchemaEntity201909.tt"
+        #line 1122 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1066 "SchemaEntity201909.tt"
+        #line 1122 "SchemaEntity201909.tt"
 
         if(IsImplicitString)
         {
@@ -3780,13 +3979,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1070 "SchemaEntity201909.tt"
+        #line 1126 "SchemaEntity201909.tt"
         this.Write("                this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1071 "SchemaEntity201909.tt"
+        #line 1127 "SchemaEntity201909.tt"
 
         }
         
@@ -3794,14 +3993,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1074 "SchemaEntity201909.tt"
+        #line 1130 "SchemaEntity201909.tt"
         this.Write("            }\r\n            else\r\n            {\r\n                this.jsonElementB" +
                 "acking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1078 "SchemaEntity201909.tt"
+        #line 1134 "SchemaEntity201909.tt"
 
         if(conversion.IsObject)
         {
@@ -3810,7 +4009,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1082 "SchemaEntity201909.tt"
+        #line 1138 "SchemaEntity201909.tt"
         this.Write(@"                if (conversion.ValueKind == JsonValueKind.Object)
                 {
                     this.objectBacking = conversion;
@@ -3824,7 +4023,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1090 "SchemaEntity201909.tt"
+        #line 1146 "SchemaEntity201909.tt"
 
         }
         else if (IsImplicitObject)
@@ -3834,13 +4033,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1095 "SchemaEntity201909.tt"
+        #line 1151 "SchemaEntity201909.tt"
         this.Write("                this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1096 "SchemaEntity201909.tt"
+        #line 1152 "SchemaEntity201909.tt"
 
         }
         
@@ -3848,13 +4047,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1099 "SchemaEntity201909.tt"
+        #line 1155 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1099 "SchemaEntity201909.tt"
+        #line 1155 "SchemaEntity201909.tt"
 
         if(conversion.IsBoolean)
         {
@@ -3863,7 +4062,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1103 "SchemaEntity201909.tt"
+        #line 1159 "SchemaEntity201909.tt"
         this.Write(@"                if (conversion.ValueKind == JsonValueKind.True || conversion.ValueKind == JsonValueKind.False)
                 {
                     this.booleanBacking = conversion;
@@ -3877,7 +4076,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1111 "SchemaEntity201909.tt"
+        #line 1167 "SchemaEntity201909.tt"
 
         }
         else if (IsImplicitBoolean)
@@ -3887,13 +4086,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1116 "SchemaEntity201909.tt"
+        #line 1172 "SchemaEntity201909.tt"
         this.Write("                this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1117 "SchemaEntity201909.tt"
+        #line 1173 "SchemaEntity201909.tt"
 
         }
         
@@ -3901,13 +4100,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1120 "SchemaEntity201909.tt"
+        #line 1176 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1121 "SchemaEntity201909.tt"
+        #line 1177 "SchemaEntity201909.tt"
 
         if(conversion.IsArray)
         {
@@ -3916,7 +4115,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1125 "SchemaEntity201909.tt"
+        #line 1181 "SchemaEntity201909.tt"
         this.Write(@"                if (conversion.ValueKind == JsonValueKind.Array)
                 {
                     this.arrayBacking = conversion;
@@ -3930,7 +4129,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1133 "SchemaEntity201909.tt"
+        #line 1189 "SchemaEntity201909.tt"
 
         }
         else if (IsImplicitArray)
@@ -3940,13 +4139,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1138 "SchemaEntity201909.tt"
+        #line 1194 "SchemaEntity201909.tt"
         this.Write("                this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1139 "SchemaEntity201909.tt"
+        #line 1195 "SchemaEntity201909.tt"
 
         }
         
@@ -3954,13 +4153,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1142 "SchemaEntity201909.tt"
+        #line 1198 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1142 "SchemaEntity201909.tt"
+        #line 1198 "SchemaEntity201909.tt"
 
         if(conversion.IsNumber)
         {
@@ -3969,7 +4168,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1146 "SchemaEntity201909.tt"
+        #line 1202 "SchemaEntity201909.tt"
         this.Write(@"                if (conversion.ValueKind == JsonValueKind.Number)
                 {
                     this.numberBacking = conversion;
@@ -3983,7 +4182,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1154 "SchemaEntity201909.tt"
+        #line 1210 "SchemaEntity201909.tt"
 
         }
         else if (IsImplicitNumber)
@@ -3993,13 +4192,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1159 "SchemaEntity201909.tt"
+        #line 1215 "SchemaEntity201909.tt"
         this.Write("                this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1160 "SchemaEntity201909.tt"
+        #line 1216 "SchemaEntity201909.tt"
 
         }
         
@@ -4007,13 +4206,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1163 "SchemaEntity201909.tt"
+        #line 1219 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1163 "SchemaEntity201909.tt"
+        #line 1219 "SchemaEntity201909.tt"
 
         if(conversion.IsString)
         {
@@ -4022,7 +4221,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1167 "SchemaEntity201909.tt"
+        #line 1223 "SchemaEntity201909.tt"
         this.Write(@"                if (conversion.ValueKind == JsonValueKind.String)
                 {
                     this.stringBacking = conversion;
@@ -4036,7 +4235,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1175 "SchemaEntity201909.tt"
+        #line 1231 "SchemaEntity201909.tt"
 
         }
         else if (IsImplicitString)
@@ -4046,13 +4245,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1180 "SchemaEntity201909.tt"
+        #line 1236 "SchemaEntity201909.tt"
         this.Write("                this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1181 "SchemaEntity201909.tt"
+        #line 1237 "SchemaEntity201909.tt"
 
         }
         
@@ -4060,13 +4259,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1184 "SchemaEntity201909.tt"
+        #line 1240 "SchemaEntity201909.tt"
         this.Write("            }\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1186 "SchemaEntity201909.tt"
+        #line 1242 "SchemaEntity201909.tt"
 
     }
     
@@ -4074,13 +4273,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1189 "SchemaEntity201909.tt"
+        #line 1245 "SchemaEntity201909.tt"
         this.Write("\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1191 "SchemaEntity201909.tt"
+        #line 1247 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -4089,7 +4288,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1195 "SchemaEntity201909.tt"
+        #line 1251 "SchemaEntity201909.tt"
         this.Write(@"        /// <inheritdoc/>
         public int Length
         {
@@ -4108,7 +4307,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1208 "SchemaEntity201909.tt"
+        #line 1264 "SchemaEntity201909.tt"
 
     }
     
@@ -4116,13 +4315,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1211 "SchemaEntity201909.tt"
+        #line 1267 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1212 "SchemaEntity201909.tt"
+        #line 1268 "SchemaEntity201909.tt"
 
     foreach (Conversion conversion in ConversionsViaConstructor)
     {
@@ -4135,43 +4334,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1220 "SchemaEntity201909.tt"
+        #line 1276 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Gets the value as a <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 1221 "SchemaEntity201909.tt"
+        #line 1277 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1221 "SchemaEntity201909.tt"
+        #line 1277 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 1223 "SchemaEntity201909.tt"
+        #line 1279 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1223 "SchemaEntity201909.tt"
+        #line 1279 "SchemaEntity201909.tt"
         this.Write(" As");
         
         #line default
         #line hidden
         
-        #line 1223 "SchemaEntity201909.tt"
+        #line 1279 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1223 "SchemaEntity201909.tt"
+        #line 1279 "SchemaEntity201909.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return this;\r\n      " +
                 "      }\r\n        }\r\n\r\n        /// <summary>\r\n        /// Gets a value indicating" +
                 " whether this is a valid <see cref=\"");
@@ -4179,43 +4378,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1232 "SchemaEntity201909.tt"
+        #line 1288 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1232 "SchemaEntity201909.tt"
+        #line 1288 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public bool Is");
         
         #line default
         #line hidden
         
-        #line 1234 "SchemaEntity201909.tt"
+        #line 1290 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1234 "SchemaEntity201909.tt"
+        #line 1290 "SchemaEntity201909.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return ((");
         
         #line default
         #line hidden
         
-        #line 1238 "SchemaEntity201909.tt"
+        #line 1294 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1238 "SchemaEntity201909.tt"
+        #line 1294 "SchemaEntity201909.tt"
         this.Write(")this).Validate().IsValid;\r\n            }\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1242 "SchemaEntity201909.tt"
+        #line 1298 "SchemaEntity201909.tt"
 
     }
     
@@ -4223,13 +4422,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1245 "SchemaEntity201909.tt"
+        #line 1301 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1246 "SchemaEntity201909.tt"
+        #line 1302 "SchemaEntity201909.tt"
 
     if (HasIfThenElse)
     {
@@ -4238,13 +4437,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1250 "SchemaEntity201909.tt"
+        #line 1306 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1250 "SchemaEntity201909.tt"
+        #line 1306 "SchemaEntity201909.tt"
 
         if (HasThen)
         {
@@ -4253,32 +4452,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1254 "SchemaEntity201909.tt"
+        #line 1310 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Gets a value indicating whether this matches t" +
                 "he If/Then type.\r\n        /// </summary>\r\n        public bool IsIfMatch");
         
         #line default
         #line hidden
         
-        #line 1257 "SchemaEntity201909.tt"
+        #line 1313 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                ThenDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1257 "SchemaEntity201909.tt"
+        #line 1313 "SchemaEntity201909.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return this.As<");
         
         #line default
         #line hidden
         
-        #line 1261 "SchemaEntity201909.tt"
+        #line 1317 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                IfFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1261 "SchemaEntity201909.tt"
+        #line 1317 "SchemaEntity201909.tt"
         this.Write(">().IsValid(); \r\n            }\r\n        }\r\n\r\n        /// <summary>\r\n        /// G" +
                 "ets this as the matching type for the If/Then clause.\r\n        /// </summary>\r\n " +
                 "       public ");
@@ -4286,43 +4485,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1268 "SchemaEntity201909.tt"
+        #line 1324 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ThenFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1268 "SchemaEntity201909.tt"
+        #line 1324 "SchemaEntity201909.tt"
         this.Write(" AsIfMatch");
         
         #line default
         #line hidden
         
-        #line 1268 "SchemaEntity201909.tt"
+        #line 1324 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ThenDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1268 "SchemaEntity201909.tt"
+        #line 1324 "SchemaEntity201909.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return this.As<");
         
         #line default
         #line hidden
         
-        #line 1272 "SchemaEntity201909.tt"
+        #line 1328 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ThenFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1272 "SchemaEntity201909.tt"
+        #line 1328 "SchemaEntity201909.tt"
         this.Write(">(); \r\n            }\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1276 "SchemaEntity201909.tt"
+        #line 1332 "SchemaEntity201909.tt"
 
         }
         
@@ -4330,13 +4529,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1279 "SchemaEntity201909.tt"
+        #line 1335 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1280 "SchemaEntity201909.tt"
+        #line 1336 "SchemaEntity201909.tt"
 
         if (HasElse)
         {
@@ -4345,32 +4544,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1284 "SchemaEntity201909.tt"
+        #line 1340 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Gets a value indicating whether this matches t" +
                 "he If/Else type.\r\n        /// </summary>\r\n        public bool IsElseMatch");
         
         #line default
         #line hidden
         
-        #line 1287 "SchemaEntity201909.tt"
+        #line 1343 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ElseDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1287 "SchemaEntity201909.tt"
+        #line 1343 "SchemaEntity201909.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return !this.As<");
         
         #line default
         #line hidden
         
-        #line 1291 "SchemaEntity201909.tt"
+        #line 1347 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(IfFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1291 "SchemaEntity201909.tt"
+        #line 1347 "SchemaEntity201909.tt"
         this.Write(">().IsValid(); \r\n            }\r\n        }\r\n\r\n        /// <summary>\r\n        /// G" +
                 "ets this as the matching type for the If/Else clause.\r\n        /// </summary>\r\n " +
                 "       public ");
@@ -4378,43 +4577,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1298 "SchemaEntity201909.tt"
+        #line 1354 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ElseFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1298 "SchemaEntity201909.tt"
+        #line 1354 "SchemaEntity201909.tt"
         this.Write(" AsElseMatch");
         
         #line default
         #line hidden
         
-        #line 1298 "SchemaEntity201909.tt"
+        #line 1354 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ElseDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1298 "SchemaEntity201909.tt"
+        #line 1354 "SchemaEntity201909.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return this.As<");
         
         #line default
         #line hidden
         
-        #line 1302 "SchemaEntity201909.tt"
+        #line 1358 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ElseFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1302 "SchemaEntity201909.tt"
+        #line 1358 "SchemaEntity201909.tt"
         this.Write(">(); \r\n            }\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1305 "SchemaEntity201909.tt"
+        #line 1361 "SchemaEntity201909.tt"
 
         }
         
@@ -4422,13 +4621,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1308 "SchemaEntity201909.tt"
+        #line 1364 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 1308 "SchemaEntity201909.tt"
+        #line 1364 "SchemaEntity201909.tt"
 
     }
     
@@ -4436,13 +4635,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1311 "SchemaEntity201909.tt"
+        #line 1367 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1312 "SchemaEntity201909.tt"
+        #line 1368 "SchemaEntity201909.tt"
 
     if(HasProperties)
     {
@@ -4451,13 +4650,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1316 "SchemaEntity201909.tt"
+        #line 1372 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1316 "SchemaEntity201909.tt"
+        #line 1372 "SchemaEntity201909.tt"
 
         foreach(var property in Properties)
         {
@@ -4466,19 +4665,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1320 "SchemaEntity201909.tt"
+        #line 1376 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Gets ");
         
         #line default
         #line hidden
         
-        #line 1322 "SchemaEntity201909.tt"
+        #line 1378 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 1322 "SchemaEntity201909.tt"
+        #line 1378 "SchemaEntity201909.tt"
         this.Write(".\r\n        /// </summary>\r\n        /// <remarks>\r\n        /// {Property title}.\r\n" +
                 "        /// {Property description}.\r\n        /// </remarks>\r\n        /// <exampl" +
                 "e>\r\n        /// {Property examples}.\r\n        /// </example>\r\n        public ");
@@ -4486,25 +4685,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1331 "SchemaEntity201909.tt"
+        #line 1387 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1331 "SchemaEntity201909.tt"
+        #line 1387 "SchemaEntity201909.tt"
         this.Write(" ");
         
         #line default
         #line hidden
         
-        #line 1331 "SchemaEntity201909.tt"
+        #line 1387 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 1331 "SchemaEntity201909.tt"
+        #line 1387 "SchemaEntity201909.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                if (this.objectBacki" +
                 "ng is ImmutableDictionary<string, JsonAny> properties)\r\n                {\r\n     " +
                 "               if(properties.TryGetValue(");
@@ -4512,13 +4711,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1337 "SchemaEntity201909.tt"
+        #line 1393 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 1337 "SchemaEntity201909.tt"
+        #line 1393 "SchemaEntity201909.tt"
         this.Write(@"JsonPropertyName, out JsonAny result))
                     {
                         return result;
@@ -4532,33 +4731,33 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1345 "SchemaEntity201909.tt"
+        #line 1401 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 1345 "SchemaEntity201909.tt"
+        #line 1401 "SchemaEntity201909.tt"
         this.Write("Utf8JsonPropertyName.Span, out JsonElement result))\r\n                    {\r\n     " +
                 "                   return new  ");
         
         #line default
         #line hidden
         
-        #line 1347 "SchemaEntity201909.tt"
+        #line 1403 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1347 "SchemaEntity201909.tt"
+        #line 1403 "SchemaEntity201909.tt"
         this.Write("(result);\r\n                    }\r\n                }\r\n\r\n                return def" +
                 "ault;\r\n            }\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1355 "SchemaEntity201909.tt"
+        #line 1411 "SchemaEntity201909.tt"
 
         }
         
@@ -4566,13 +4765,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1358 "SchemaEntity201909.tt"
+        #line 1414 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 1358 "SchemaEntity201909.tt"
+        #line 1414 "SchemaEntity201909.tt"
 
     }
     
@@ -4580,7 +4779,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1361 "SchemaEntity201909.tt"
+        #line 1417 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Gets a value indicating whether this is backed" +
                 " by a JSON element.\r\n        /// </summary>\r\n        public bool HasJsonElement " +
                 "=>\r\n    ");
@@ -4588,7 +4787,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1365 "SchemaEntity201909.tt"
+        #line 1421 "SchemaEntity201909.tt"
 
     bool isFirstProperty = true;
     
@@ -4596,13 +4795,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1368 "SchemaEntity201909.tt"
+        #line 1424 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1369 "SchemaEntity201909.tt"
+        #line 1425 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -4611,13 +4810,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1373 "SchemaEntity201909.tt"
+        #line 1429 "SchemaEntity201909.tt"
         this.Write("            this.objectBacking is null\r\n            \r\n    ");
         
         #line default
         #line hidden
         
-        #line 1375 "SchemaEntity201909.tt"
+        #line 1431 "SchemaEntity201909.tt"
 
         isFirstProperty = false;
     }
@@ -4626,13 +4825,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1379 "SchemaEntity201909.tt"
+        #line 1435 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1380 "SchemaEntity201909.tt"
+        #line 1436 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -4641,13 +4840,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1384 "SchemaEntity201909.tt"
+        #line 1440 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1384 "SchemaEntity201909.tt"
+        #line 1440 "SchemaEntity201909.tt"
 
         if (isFirstProperty)
         {
@@ -4660,13 +4859,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1392 "SchemaEntity201909.tt"
+        #line 1448 "SchemaEntity201909.tt"
         this.Write("            &&\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1393 "SchemaEntity201909.tt"
+        #line 1449 "SchemaEntity201909.tt"
 
         }
         
@@ -4674,13 +4873,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1396 "SchemaEntity201909.tt"
+        #line 1452 "SchemaEntity201909.tt"
         this.Write("            this.arrayBacking is null\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1397 "SchemaEntity201909.tt"
+        #line 1453 "SchemaEntity201909.tt"
 
     }
     
@@ -4688,13 +4887,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1400 "SchemaEntity201909.tt"
+        #line 1456 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 1400 "SchemaEntity201909.tt"
+        #line 1456 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -4703,13 +4902,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1404 "SchemaEntity201909.tt"
+        #line 1460 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1404 "SchemaEntity201909.tt"
+        #line 1460 "SchemaEntity201909.tt"
 
         if (isFirstProperty)
         {
@@ -4722,13 +4921,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1412 "SchemaEntity201909.tt"
+        #line 1468 "SchemaEntity201909.tt"
         this.Write("            &&\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1413 "SchemaEntity201909.tt"
+        #line 1469 "SchemaEntity201909.tt"
 
         }
         
@@ -4736,13 +4935,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1416 "SchemaEntity201909.tt"
+        #line 1472 "SchemaEntity201909.tt"
         this.Write("            this.numberBacking is null\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1417 "SchemaEntity201909.tt"
+        #line 1473 "SchemaEntity201909.tt"
 
     }
     
@@ -4750,13 +4949,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1420 "SchemaEntity201909.tt"
+        #line 1476 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 1420 "SchemaEntity201909.tt"
+        #line 1476 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -4765,13 +4964,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1424 "SchemaEntity201909.tt"
+        #line 1480 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1424 "SchemaEntity201909.tt"
+        #line 1480 "SchemaEntity201909.tt"
 
         if (isFirstProperty)
         {
@@ -4784,13 +4983,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1432 "SchemaEntity201909.tt"
+        #line 1488 "SchemaEntity201909.tt"
         this.Write("            &&\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1433 "SchemaEntity201909.tt"
+        #line 1489 "SchemaEntity201909.tt"
 
         }
         
@@ -4798,13 +4997,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1436 "SchemaEntity201909.tt"
+        #line 1492 "SchemaEntity201909.tt"
         this.Write("            this.stringBacking is null\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1437 "SchemaEntity201909.tt"
+        #line 1493 "SchemaEntity201909.tt"
 
     }
     
@@ -4812,13 +5011,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1440 "SchemaEntity201909.tt"
+        #line 1496 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 1440 "SchemaEntity201909.tt"
+        #line 1496 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -4827,13 +5026,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1444 "SchemaEntity201909.tt"
+        #line 1500 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1444 "SchemaEntity201909.tt"
+        #line 1500 "SchemaEntity201909.tt"
 
         if (isFirstProperty)
         {
@@ -4846,13 +5045,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1452 "SchemaEntity201909.tt"
+        #line 1508 "SchemaEntity201909.tt"
         this.Write("            &&\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1453 "SchemaEntity201909.tt"
+        #line 1509 "SchemaEntity201909.tt"
 
         }
         
@@ -4860,132 +5059,8 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1456 "SchemaEntity201909.tt"
+        #line 1512 "SchemaEntity201909.tt"
         this.Write("            this.booleanBacking is null\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1457 "SchemaEntity201909.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1460 "SchemaEntity201909.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1461 "SchemaEntity201909.tt"
-
-    if (!IsImplicitObject && !IsImplicitArray && !IsImplicitNumber && !IsImplicitBoolean && !IsImplicitString)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1465 "SchemaEntity201909.tt"
-        this.Write("    true\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1466 "SchemaEntity201909.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1469 "SchemaEntity201909.tt"
-        this.Write("            ;\r\n\r\n        /// <summary>\r\n        /// Gets the value as a JsonEleme" +
-                "nt.\r\n        /// </summary>\r\n        public JsonElement AsJsonElement\r\n        {" +
-                "\r\n            get\r\n            {\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1478 "SchemaEntity201909.tt"
-
-    if (IsImplicitObject)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1482 "SchemaEntity201909.tt"
-        this.Write("          \r\n                if (this.objectBacking is ImmutableDictionary<string," +
-                " JsonAny> objectBacking)\r\n                {\r\n                    return JsonObje" +
-                "ct.PropertiesToJsonElement(objectBacking);\r\n                }\r\n\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1488 "SchemaEntity201909.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1491 "SchemaEntity201909.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1492 "SchemaEntity201909.tt"
-
-    if (IsImplicitArray)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1496 "SchemaEntity201909.tt"
-        this.Write("                if (this.arrayBacking is ImmutableList<JsonAny> arrayBacking)\r\n  " +
-                "              {\r\n                    return JsonArray.ItemsToJsonElement(arrayBa" +
-                "cking);\r\n                }\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1500 "SchemaEntity201909.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1503 "SchemaEntity201909.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1504 "SchemaEntity201909.tt"
-
-    if (IsImplicitNumber)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1508 "SchemaEntity201909.tt"
-        this.Write("                if (this.numberBacking is double numberBacking)\r\n                " +
-                "{\r\n                    return JsonNumber.NumberToJsonElement(numberBacking);\r\n  " +
-                "              }\r\n\r\n    ");
         
         #line default
         #line hidden
@@ -5006,7 +5081,7 @@ namespace ");
         
         #line 1517 "SchemaEntity201909.tt"
 
-    if (IsImplicitString)
+    if (!IsImplicitObject && !IsImplicitArray && !IsImplicitNumber && !IsImplicitBoolean && !IsImplicitString)
     {
     
         
@@ -5014,6 +5089,130 @@ namespace ");
         #line hidden
         
         #line 1521 "SchemaEntity201909.tt"
+        this.Write("    true\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1522 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1525 "SchemaEntity201909.tt"
+        this.Write("            ;\r\n\r\n        /// <summary>\r\n        /// Gets the value as a JsonEleme" +
+                "nt.\r\n        /// </summary>\r\n        public JsonElement AsJsonElement\r\n        {" +
+                "\r\n            get\r\n            {\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1534 "SchemaEntity201909.tt"
+
+    if (IsImplicitObject)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1538 "SchemaEntity201909.tt"
+        this.Write("          \r\n                if (this.objectBacking is ImmutableDictionary<string," +
+                " JsonAny> objectBacking)\r\n                {\r\n                    return JsonObje" +
+                "ct.PropertiesToJsonElement(objectBacking);\r\n                }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1544 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1547 "SchemaEntity201909.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1548 "SchemaEntity201909.tt"
+
+    if (IsImplicitArray)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1552 "SchemaEntity201909.tt"
+        this.Write("                if (this.arrayBacking is ImmutableList<JsonAny> arrayBacking)\r\n  " +
+                "              {\r\n                    return JsonArray.ItemsToJsonElement(arrayBa" +
+                "cking);\r\n                }\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1556 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1559 "SchemaEntity201909.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1560 "SchemaEntity201909.tt"
+
+    if (IsImplicitNumber)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1564 "SchemaEntity201909.tt"
+        this.Write("                if (this.numberBacking is double numberBacking)\r\n                " +
+                "{\r\n                    return JsonNumber.NumberToJsonElement(numberBacking);\r\n  " +
+                "              }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1569 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1572 "SchemaEntity201909.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1573 "SchemaEntity201909.tt"
+
+    if (IsImplicitString)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1577 "SchemaEntity201909.tt"
         this.Write("                if (this.stringBacking is string stringBacking)\r\n                " +
                 "{\r\n                    return JsonString.StringToJsonElement(stringBacking);\r\n  " +
                 "              }\r\n\r\n    ");
@@ -5021,7 +5220,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1526 "SchemaEntity201909.tt"
+        #line 1582 "SchemaEntity201909.tt"
 
     }
     
@@ -5029,13 +5228,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1529 "SchemaEntity201909.tt"
+        #line 1585 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1530 "SchemaEntity201909.tt"
+        #line 1586 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -5044,7 +5243,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1534 "SchemaEntity201909.tt"
+        #line 1590 "SchemaEntity201909.tt"
         this.Write("                if (this.booleanBacking is bool booleanBacking)\r\n                " +
                 "{\r\n                    return JsonBoolean.BoolToJsonElement(booleanBacking);\r\n  " +
                 "              }\r\n\r\n    ");
@@ -5052,7 +5251,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1539 "SchemaEntity201909.tt"
+        #line 1595 "SchemaEntity201909.tt"
 
     }
     
@@ -5060,7 +5259,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1542 "SchemaEntity201909.tt"
+        #line 1598 "SchemaEntity201909.tt"
         this.Write("\r\n                return this.jsonElementBacking;\r\n            }\r\n        }\r\n\r\n  " +
                 "      /// <inheritdoc/>\r\n        public JsonValueKind ValueKind\r\n        {\r\n    " +
                 "        get\r\n            {\r\n    ");
@@ -5068,7 +5267,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1552 "SchemaEntity201909.tt"
+        #line 1608 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -5077,7 +5276,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1556 "SchemaEntity201909.tt"
+        #line 1612 "SchemaEntity201909.tt"
         this.Write("                if (this.objectBacking is ImmutableDictionary<string, JsonAny>)\r\n" +
                 "                {\r\n                    return JsonValueKind.Object;\r\n           " +
                 "     }\r\n\r\n    ");
@@ -5085,7 +5284,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1561 "SchemaEntity201909.tt"
+        #line 1617 "SchemaEntity201909.tt"
 
     }
     
@@ -5093,13 +5292,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1564 "SchemaEntity201909.tt"
+        #line 1620 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1565 "SchemaEntity201909.tt"
+        #line 1621 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -5108,14 +5307,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1569 "SchemaEntity201909.tt"
+        #line 1625 "SchemaEntity201909.tt"
         this.Write("                if (this.arrayBacking is ImmutableList<JsonAny>)\r\n               " +
                 " {\r\n                    return JsonValueKind.Array;\r\n                }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1574 "SchemaEntity201909.tt"
+        #line 1630 "SchemaEntity201909.tt"
 
     }
     
@@ -5123,13 +5322,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1577 "SchemaEntity201909.tt"
+        #line 1633 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1578 "SchemaEntity201909.tt"
+        #line 1634 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -5138,14 +5337,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1582 "SchemaEntity201909.tt"
+        #line 1638 "SchemaEntity201909.tt"
         this.Write("                if (this.numberBacking is double)\r\n                {\r\n           " +
                 "         return JsonValueKind.Number;\r\n                }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1587 "SchemaEntity201909.tt"
+        #line 1643 "SchemaEntity201909.tt"
 
     }
     
@@ -5153,13 +5352,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1590 "SchemaEntity201909.tt"
+        #line 1646 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1591 "SchemaEntity201909.tt"
+        #line 1647 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -5168,14 +5367,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1595 "SchemaEntity201909.tt"
+        #line 1651 "SchemaEntity201909.tt"
         this.Write("                if (this.stringBacking is string)\r\n                {\r\n           " +
                 "         return JsonValueKind.String;\r\n                }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1600 "SchemaEntity201909.tt"
+        #line 1656 "SchemaEntity201909.tt"
 
     }
     
@@ -5183,13 +5382,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1603 "SchemaEntity201909.tt"
+        #line 1659 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1604 "SchemaEntity201909.tt"
+        #line 1660 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -5198,7 +5397,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1608 "SchemaEntity201909.tt"
+        #line 1664 "SchemaEntity201909.tt"
         this.Write("                if (this.booleanBacking is bool booleanBacking)\r\n                " +
                 "{\r\n                    return booleanBacking ? JsonValueKind.True : JsonValueKin" +
                 "d.False;\r\n                }\r\n\r\n    ");
@@ -5206,7 +5405,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1613 "SchemaEntity201909.tt"
+        #line 1669 "SchemaEntity201909.tt"
 
     }
     
@@ -5214,7 +5413,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1616 "SchemaEntity201909.tt"
+        #line 1672 "SchemaEntity201909.tt"
         this.Write("\r\n                return this.jsonElementBacking.ValueKind;\r\n            }\r\n     " +
                 "   }\r\n\r\n        /// <inheritdoc/>\r\n        public JsonAny AsAny\r\n        {\r\n    " +
                 "        get\r\n            {\r\n    ");
@@ -5222,7 +5421,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1626 "SchemaEntity201909.tt"
+        #line 1682 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -5231,7 +5430,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1630 "SchemaEntity201909.tt"
+        #line 1686 "SchemaEntity201909.tt"
         this.Write("                if (this.objectBacking is ImmutableDictionary<string, JsonAny> ob" +
                 "jectBacking)\r\n                {\r\n                    return new JsonAny(objectBa" +
                 "cking);\r\n                }\r\n\r\n    ");
@@ -5239,7 +5438,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1635 "SchemaEntity201909.tt"
+        #line 1691 "SchemaEntity201909.tt"
 
     }
     
@@ -5247,13 +5446,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1638 "SchemaEntity201909.tt"
+        #line 1694 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1639 "SchemaEntity201909.tt"
+        #line 1695 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -5262,7 +5461,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1643 "SchemaEntity201909.tt"
+        #line 1699 "SchemaEntity201909.tt"
         this.Write("                if (this.arrayBacking is ImmutableList<JsonAny> arrayBacking)\r\n  " +
                 "              {\r\n                    return new JsonAny(arrayBacking);\r\n        " +
                 "        }\r\n\r\n    ");
@@ -5270,7 +5469,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1648 "SchemaEntity201909.tt"
+        #line 1704 "SchemaEntity201909.tt"
 
     }
     
@@ -5278,13 +5477,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1651 "SchemaEntity201909.tt"
+        #line 1707 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1652 "SchemaEntity201909.tt"
+        #line 1708 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -5293,7 +5492,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1656 "SchemaEntity201909.tt"
+        #line 1712 "SchemaEntity201909.tt"
         this.Write("                if (this.numberBacking is double numberBacking)\r\n                " +
                 "{\r\n                    return new JsonAny(numberBacking);\r\n                }\r\n\r\n" +
                 "    ");
@@ -5301,7 +5500,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1661 "SchemaEntity201909.tt"
+        #line 1717 "SchemaEntity201909.tt"
 
     }
     
@@ -5309,13 +5508,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1664 "SchemaEntity201909.tt"
+        #line 1720 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1665 "SchemaEntity201909.tt"
+        #line 1721 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -5324,7 +5523,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1669 "SchemaEntity201909.tt"
+        #line 1725 "SchemaEntity201909.tt"
         this.Write("                if (this.stringBacking is string stringBacking)\r\n                " +
                 "{\r\n                    return new JsonAny(stringBacking);\r\n                }\r\n\r\n" +
                 "    ");
@@ -5332,7 +5531,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1674 "SchemaEntity201909.tt"
+        #line 1730 "SchemaEntity201909.tt"
 
     }
     
@@ -5340,13 +5539,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1677 "SchemaEntity201909.tt"
+        #line 1733 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1678 "SchemaEntity201909.tt"
+        #line 1734 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -5355,7 +5554,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1682 "SchemaEntity201909.tt"
+        #line 1738 "SchemaEntity201909.tt"
         this.Write("                if (this.booleanBacking is bool booleanBacking)\r\n                " +
                 "{\r\n                    return new JsonAny(booleanBacking);\r\n                }\r\n\r" +
                 "\n    ");
@@ -5363,7 +5562,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1687 "SchemaEntity201909.tt"
+        #line 1743 "SchemaEntity201909.tt"
 
     }
     
@@ -5371,14 +5570,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1690 "SchemaEntity201909.tt"
+        #line 1746 "SchemaEntity201909.tt"
         this.Write("\r\n                return new JsonAny(this.jsonElementBacking);\r\n            }\r\n  " +
                 "      }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1695 "SchemaEntity201909.tt"
+        #line 1751 "SchemaEntity201909.tt"
 
     foreach(Conversion conversion in ConversionsViaConstructor)
     {
@@ -5391,100 +5590,100 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1703 "SchemaEntity201909.tt"
+        #line 1759 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Conversion from <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 1704 "SchemaEntity201909.tt"
+        #line 1760 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1704 "SchemaEntity201909.tt"
+        #line 1760 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        /// <param name=\"value\">The value from whi" +
                 "ch to convert.</param>\r\n        public static implicit operator ");
         
         #line default
         #line hidden
         
-        #line 1707 "SchemaEntity201909.tt"
+        #line 1763 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1707 "SchemaEntity201909.tt"
+        #line 1763 "SchemaEntity201909.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 1707 "SchemaEntity201909.tt"
+        #line 1763 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1707 "SchemaEntity201909.tt"
+        #line 1763 "SchemaEntity201909.tt"
         this.Write(" value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1709 "SchemaEntity201909.tt"
+        #line 1765 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1709 "SchemaEntity201909.tt"
+        #line 1765 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to <see cref" +
                 "=\"");
         
         #line default
         #line hidden
         
-        #line 1713 "SchemaEntity201909.tt"
+        #line 1769 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1713 "SchemaEntity201909.tt"
+        #line 1769 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        /// <param name=\"value\">The value from whi" +
                 "ch to convert.</param>\r\n        public static implicit operator ");
         
         #line default
         #line hidden
         
-        #line 1716 "SchemaEntity201909.tt"
+        #line 1772 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1716 "SchemaEntity201909.tt"
+        #line 1772 "SchemaEntity201909.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 1716 "SchemaEntity201909.tt"
+        #line 1772 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1716 "SchemaEntity201909.tt"
+        #line 1772 "SchemaEntity201909.tt"
         this.Write(" value)\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1718 "SchemaEntity201909.tt"
+        #line 1774 "SchemaEntity201909.tt"
 
         if(conversion.IsObject)
         {
@@ -5493,26 +5692,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1722 "SchemaEntity201909.tt"
+        #line 1778 "SchemaEntity201909.tt"
         this.Write("            if (value.ValueKind == JsonValueKind.Object)\r\n            {\r\n        " +
                 "        return new ");
         
         #line default
         #line hidden
         
-        #line 1724 "SchemaEntity201909.tt"
+        #line 1780 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1724 "SchemaEntity201909.tt"
+        #line 1780 "SchemaEntity201909.tt"
         this.Write("(value.AsObject);\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1726 "SchemaEntity201909.tt"
+        #line 1782 "SchemaEntity201909.tt"
 
         }
         
@@ -5520,13 +5719,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1729 "SchemaEntity201909.tt"
+        #line 1785 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1729 "SchemaEntity201909.tt"
+        #line 1785 "SchemaEntity201909.tt"
 
         if(conversion.IsArray)
         {
@@ -5535,26 +5734,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1733 "SchemaEntity201909.tt"
+        #line 1789 "SchemaEntity201909.tt"
         this.Write("            if (value.ValueKind == JsonValueKind.Array)\r\n            {\r\n         " +
                 "       return new ");
         
         #line default
         #line hidden
         
-        #line 1735 "SchemaEntity201909.tt"
+        #line 1791 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1735 "SchemaEntity201909.tt"
+        #line 1791 "SchemaEntity201909.tt"
         this.Write("(value.AsArray);\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1737 "SchemaEntity201909.tt"
+        #line 1793 "SchemaEntity201909.tt"
 
         }
         
@@ -5562,13 +5761,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1740 "SchemaEntity201909.tt"
+        #line 1796 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1740 "SchemaEntity201909.tt"
+        #line 1796 "SchemaEntity201909.tt"
 
         if(conversion.IsString)
         {
@@ -5577,26 +5776,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1744 "SchemaEntity201909.tt"
+        #line 1800 "SchemaEntity201909.tt"
         this.Write("            if (value.ValueKind == JsonValueKind.String)\r\n            {\r\n        " +
                 "        return new ");
         
         #line default
         #line hidden
         
-        #line 1746 "SchemaEntity201909.tt"
+        #line 1802 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1746 "SchemaEntity201909.tt"
+        #line 1802 "SchemaEntity201909.tt"
         this.Write("(value.AsString);\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1748 "SchemaEntity201909.tt"
+        #line 1804 "SchemaEntity201909.tt"
 
         }
         
@@ -5604,13 +5803,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1751 "SchemaEntity201909.tt"
+        #line 1807 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1751 "SchemaEntity201909.tt"
+        #line 1807 "SchemaEntity201909.tt"
 
         if(conversion.IsBoolean)
         {
@@ -5619,26 +5818,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1755 "SchemaEntity201909.tt"
+        #line 1811 "SchemaEntity201909.tt"
         this.Write("            if (value.ValueKind == JsonValueKind.True || value.ValueKind == JsonV" +
                 "alueKind.False)\r\n            {\r\n                return new ");
         
         #line default
         #line hidden
         
-        #line 1757 "SchemaEntity201909.tt"
+        #line 1813 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1757 "SchemaEntity201909.tt"
+        #line 1813 "SchemaEntity201909.tt"
         this.Write("(value.AsBoolean);\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1759 "SchemaEntity201909.tt"
+        #line 1815 "SchemaEntity201909.tt"
 
         }
         
@@ -5646,13 +5845,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1762 "SchemaEntity201909.tt"
+        #line 1818 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1762 "SchemaEntity201909.tt"
+        #line 1818 "SchemaEntity201909.tt"
 
         if(conversion.IsNumber)
         {
@@ -5661,26 +5860,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1766 "SchemaEntity201909.tt"
+        #line 1822 "SchemaEntity201909.tt"
         this.Write("            if (value.ValueKind == JsonValueKind.Number)\r\n            {\r\n        " +
                 "        return new ");
         
         #line default
         #line hidden
         
-        #line 1768 "SchemaEntity201909.tt"
+        #line 1824 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1768 "SchemaEntity201909.tt"
+        #line 1824 "SchemaEntity201909.tt"
         this.Write("(value.AsNumber);\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1770 "SchemaEntity201909.tt"
+        #line 1826 "SchemaEntity201909.tt"
 
         }
         
@@ -5688,13 +5887,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1773 "SchemaEntity201909.tt"
+        #line 1829 "SchemaEntity201909.tt"
         this.Write("            return default;\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1775 "SchemaEntity201909.tt"
+        #line 1831 "SchemaEntity201909.tt"
 
     }
     
@@ -5702,13 +5901,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1778 "SchemaEntity201909.tt"
+        #line 1834 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1779 "SchemaEntity201909.tt"
+        #line 1835 "SchemaEntity201909.tt"
 
     foreach(Conversion conversion in ConversionsViaCast)
     {
@@ -5717,112 +5916,112 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1783 "SchemaEntity201909.tt"
+        #line 1839 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Conversion from <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 1784 "SchemaEntity201909.tt"
+        #line 1840 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1784 "SchemaEntity201909.tt"
+        #line 1840 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        /// <param name=\"value\">The value from whi" +
                 "ch to convert.</param>\r\n        public static implicit operator ");
         
         #line default
         #line hidden
         
-        #line 1787 "SchemaEntity201909.tt"
+        #line 1843 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1787 "SchemaEntity201909.tt"
+        #line 1843 "SchemaEntity201909.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 1787 "SchemaEntity201909.tt"
+        #line 1843 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1787 "SchemaEntity201909.tt"
+        #line 1843 "SchemaEntity201909.tt"
         this.Write(" value)\r\n        {\r\n            return (");
         
         #line default
         #line hidden
         
-        #line 1789 "SchemaEntity201909.tt"
+        #line 1845 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.ConvertViaDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1789 "SchemaEntity201909.tt"
+        #line 1845 "SchemaEntity201909.tt"
         this.Write(")value;\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to <see cref=" +
                 "\"");
         
         #line default
         #line hidden
         
-        #line 1793 "SchemaEntity201909.tt"
+        #line 1849 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1793 "SchemaEntity201909.tt"
+        #line 1849 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        /// <param name=\"value\">The value from whi" +
                 "ch to convert.</param>\r\n        public static implicit operator ");
         
         #line default
         #line hidden
         
-        #line 1796 "SchemaEntity201909.tt"
+        #line 1852 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1796 "SchemaEntity201909.tt"
+        #line 1852 "SchemaEntity201909.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 1796 "SchemaEntity201909.tt"
+        #line 1852 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1796 "SchemaEntity201909.tt"
+        #line 1852 "SchemaEntity201909.tt"
         this.Write(" value)\r\n        {\r\n            return (");
         
         #line default
         #line hidden
         
-        #line 1798 "SchemaEntity201909.tt"
+        #line 1854 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.ConvertViaDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1798 "SchemaEntity201909.tt"
+        #line 1854 "SchemaEntity201909.tt"
         this.Write(")value;\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1800 "SchemaEntity201909.tt"
+        #line 1856 "SchemaEntity201909.tt"
 
     }
     
@@ -5830,7 +6029,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1803 "SchemaEntity201909.tt"
+        #line 1859 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from any.\r\n        /// </summary>" +
                 "\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n    " +
                 "    public static implicit operator ");
@@ -5838,38 +6037,38 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1808 "SchemaEntity201909.tt"
+        #line 1864 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1808 "SchemaEntity201909.tt"
+        #line 1864 "SchemaEntity201909.tt"
         this.Write("(JsonAny value)\r\n        {\r\n            if (value.HasJsonElement)\r\n            {\r" +
                 "\n                return new ");
         
         #line default
         #line hidden
         
-        #line 1812 "SchemaEntity201909.tt"
+        #line 1868 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1812 "SchemaEntity201909.tt"
+        #line 1868 "SchemaEntity201909.tt"
         this.Write("(value.AsJsonElement);\r\n            }\r\n\r\n            return value.As<");
         
         #line default
         #line hidden
         
-        #line 1815 "SchemaEntity201909.tt"
+        #line 1871 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1815 "SchemaEntity201909.tt"
+        #line 1871 "SchemaEntity201909.tt"
         this.Write(">();\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to any.\r\n       " +
                 " /// </summary>\r\n        /// <param name=\"value\">The value from which to convert" +
                 ".</param>\r\n        public static implicit operator JsonAny(");
@@ -5877,19 +6076,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1822 "SchemaEntity201909.tt"
+        #line 1878 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1822 "SchemaEntity201909.tt"
+        #line 1878 "SchemaEntity201909.tt"
         this.Write(" value)\r\n        {\r\n            return value.AsAny;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1827 "SchemaEntity201909.tt"
+        #line 1883 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -5898,7 +6097,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1831 "SchemaEntity201909.tt"
+        #line 1887 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from array.\r\n        /// </summar" +
                 "y>\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n  " +
                 "      public static implicit operator ");
@@ -5906,25 +6105,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1836 "SchemaEntity201909.tt"
+        #line 1892 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1836 "SchemaEntity201909.tt"
+        #line 1892 "SchemaEntity201909.tt"
         this.Write("(JsonArray value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1838 "SchemaEntity201909.tt"
+        #line 1894 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1838 "SchemaEntity201909.tt"
+        #line 1894 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to array.\r\n " +
                 "       /// </summary>\r\n        /// <param name=\"value\">The value from which to c" +
                 "onvert.</param>\r\n        public static implicit operator JsonArray(");
@@ -5932,13 +6131,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1845 "SchemaEntity201909.tt"
+        #line 1901 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1845 "SchemaEntity201909.tt"
+        #line 1901 "SchemaEntity201909.tt"
         this.Write(@" value)
         {
             return value.AsArray;
@@ -5953,13 +6152,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1854 "SchemaEntity201909.tt"
+        #line 1910 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1854 "SchemaEntity201909.tt"
+        #line 1910 "SchemaEntity201909.tt"
         this.Write(@" value)
         {
             return value.AsArray.AsItemsList;
@@ -5974,31 +6173,31 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1863 "SchemaEntity201909.tt"
+        #line 1919 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1863 "SchemaEntity201909.tt"
+        #line 1919 "SchemaEntity201909.tt"
         this.Write("(ImmutableList<JsonAny> value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1865 "SchemaEntity201909.tt"
+        #line 1921 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1865 "SchemaEntity201909.tt"
+        #line 1921 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1867 "SchemaEntity201909.tt"
+        #line 1923 "SchemaEntity201909.tt"
 
     }
     
@@ -6006,13 +6205,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1870 "SchemaEntity201909.tt"
+        #line 1926 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1871 "SchemaEntity201909.tt"
+        #line 1927 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -6021,7 +6220,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1875 "SchemaEntity201909.tt"
+        #line 1931 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from object.\r\n        /// </summa" +
                 "ry>\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n " +
                 "       public static implicit operator ");
@@ -6029,25 +6228,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1880 "SchemaEntity201909.tt"
+        #line 1936 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1880 "SchemaEntity201909.tt"
+        #line 1936 "SchemaEntity201909.tt"
         this.Write("(JsonObject value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1882 "SchemaEntity201909.tt"
+        #line 1938 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1882 "SchemaEntity201909.tt"
+        #line 1938 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to object.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"value\">The value from which to " +
                 "convert.</param>\r\n        public static implicit operator JsonObject(");
@@ -6055,13 +6254,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1889 "SchemaEntity201909.tt"
+        #line 1945 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1889 "SchemaEntity201909.tt"
+        #line 1945 "SchemaEntity201909.tt"
         this.Write(@" value)
         {
             return value.AsObject;
@@ -6076,13 +6275,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1898 "SchemaEntity201909.tt"
+        #line 1954 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1898 "SchemaEntity201909.tt"
+        #line 1954 "SchemaEntity201909.tt"
         this.Write(@"  value)
         {
             return value.AsObject.AsPropertyDictionary;
@@ -6097,32 +6296,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1907 "SchemaEntity201909.tt"
+        #line 1963 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1907 "SchemaEntity201909.tt"
+        #line 1963 "SchemaEntity201909.tt"
         this.Write(" (ImmutableDictionary<string, JsonAny> value)\r\n        {\r\n            return new " +
                 "");
         
         #line default
         #line hidden
         
-        #line 1909 "SchemaEntity201909.tt"
+        #line 1965 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1909 "SchemaEntity201909.tt"
+        #line 1965 "SchemaEntity201909.tt"
         this.Write(" (value);\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1912 "SchemaEntity201909.tt"
+        #line 1968 "SchemaEntity201909.tt"
 
     }
     
@@ -6130,13 +6329,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1915 "SchemaEntity201909.tt"
+        #line 1971 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1916 "SchemaEntity201909.tt"
+        #line 1972 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -6145,7 +6344,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1920 "SchemaEntity201909.tt"
+        #line 1976 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from string.\r\n        /// </summa" +
                 "ry>\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n " +
                 "       public static implicit operator ");
@@ -6153,25 +6352,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1925 "SchemaEntity201909.tt"
+        #line 1981 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1925 "SchemaEntity201909.tt"
+        #line 1981 "SchemaEntity201909.tt"
         this.Write("(string value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1927 "SchemaEntity201909.tt"
+        #line 1983 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1927 "SchemaEntity201909.tt"
+        #line 1983 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to string.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"value\">The number from which to" +
                 " convert.</param>\r\n        public static implicit operator string(");
@@ -6179,13 +6378,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1934 "SchemaEntity201909.tt"
+        #line 1990 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1934 "SchemaEntity201909.tt"
+        #line 1990 "SchemaEntity201909.tt"
         this.Write(@" value)
         {
             return value.AsString;
@@ -6200,25 +6399,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1943 "SchemaEntity201909.tt"
+        #line 1999 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1943 "SchemaEntity201909.tt"
+        #line 1999 "SchemaEntity201909.tt"
         this.Write("(ReadOnlySpan<char> value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1945 "SchemaEntity201909.tt"
+        #line 2001 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1945 "SchemaEntity201909.tt"
+        #line 2001 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to string.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"value\">The number from which to" +
                 " convert.</param>\r\n        public static implicit operator ReadOnlySpan<char>(");
@@ -6226,13 +6425,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1952 "SchemaEntity201909.tt"
+        #line 2008 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1952 "SchemaEntity201909.tt"
+        #line 2008 "SchemaEntity201909.tt"
         this.Write(@" value)
         {
             return value.AsString;
@@ -6247,25 +6446,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1961 "SchemaEntity201909.tt"
+        #line 2017 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1961 "SchemaEntity201909.tt"
+        #line 2017 "SchemaEntity201909.tt"
         this.Write("(ReadOnlySpan<byte> value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1963 "SchemaEntity201909.tt"
+        #line 2019 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1963 "SchemaEntity201909.tt"
+        #line 2019 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to utf8 byte" +
                 "s.\r\n        /// </summary>\r\n        /// <param name=\"value\">The number from whic" +
                 "h to convert.</param>\r\n        public static implicit operator ReadOnlySpan<byte" +
@@ -6274,13 +6473,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1970 "SchemaEntity201909.tt"
+        #line 2026 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1970 "SchemaEntity201909.tt"
+        #line 2026 "SchemaEntity201909.tt"
         this.Write(@" value)
         {
             return value.AsString;
@@ -6295,25 +6494,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1979 "SchemaEntity201909.tt"
+        #line 2035 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1979 "SchemaEntity201909.tt"
+        #line 2035 "SchemaEntity201909.tt"
         this.Write("(JsonString value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1981 "SchemaEntity201909.tt"
+        #line 2037 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1981 "SchemaEntity201909.tt"
+        #line 2037 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to string.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"value\">The value from which to " +
                 "convert.</param>\r\n        public static implicit operator JsonString(");
@@ -6321,19 +6520,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1988 "SchemaEntity201909.tt"
+        #line 2044 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1988 "SchemaEntity201909.tt"
+        #line 2044 "SchemaEntity201909.tt"
         this.Write(" value)\r\n        {\r\n            return value.AsString;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1993 "SchemaEntity201909.tt"
+        #line 2049 "SchemaEntity201909.tt"
 
     }
     
@@ -6341,13 +6540,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1996 "SchemaEntity201909.tt"
+        #line 2052 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1997 "SchemaEntity201909.tt"
+        #line 2053 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -6356,7 +6555,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2001 "SchemaEntity201909.tt"
+        #line 2057 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from double.\r\n        /// </summa" +
                 "ry>\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n " +
                 "       public static implicit operator ");
@@ -6364,25 +6563,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2006 "SchemaEntity201909.tt"
+        #line 2062 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2006 "SchemaEntity201909.tt"
+        #line 2062 "SchemaEntity201909.tt"
         this.Write("(double value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2008 "SchemaEntity201909.tt"
+        #line 2064 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2008 "SchemaEntity201909.tt"
+        #line 2064 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to double.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"number\">The number from which t" +
                 "o convert.</param>\r\n        public static implicit operator double(");
@@ -6390,13 +6589,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2015 "SchemaEntity201909.tt"
+        #line 2071 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2015 "SchemaEntity201909.tt"
+        #line 2071 "SchemaEntity201909.tt"
         this.Write(@" number)
         {
             return number.AsNumber.GetDouble();
@@ -6411,25 +6610,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2024 "SchemaEntity201909.tt"
+        #line 2080 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2024 "SchemaEntity201909.tt"
+        #line 2080 "SchemaEntity201909.tt"
         this.Write("(float value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2026 "SchemaEntity201909.tt"
+        #line 2082 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2026 "SchemaEntity201909.tt"
+        #line 2082 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to float.\r\n " +
                 "       /// </summary>\r\n        /// <param name=\"number\">The number from which to" +
                 " convert.</param>\r\n        public static implicit operator float(");
@@ -6437,13 +6636,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2033 "SchemaEntity201909.tt"
+        #line 2089 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2033 "SchemaEntity201909.tt"
+        #line 2089 "SchemaEntity201909.tt"
         this.Write(@" number)
         {
             return number.AsNumber.GetSingle();
@@ -6458,25 +6657,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2042 "SchemaEntity201909.tt"
+        #line 2098 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2042 "SchemaEntity201909.tt"
+        #line 2098 "SchemaEntity201909.tt"
         this.Write("(long value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2044 "SchemaEntity201909.tt"
+        #line 2100 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2044 "SchemaEntity201909.tt"
+        #line 2100 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to long.\r\n  " +
                 "      /// </summary>\r\n        /// <param name=\"number\">The number from which to " +
                 "convert.</param>\r\n        public static implicit operator long(");
@@ -6484,13 +6683,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2051 "SchemaEntity201909.tt"
+        #line 2107 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2051 "SchemaEntity201909.tt"
+        #line 2107 "SchemaEntity201909.tt"
         this.Write(@" number)
         {
             return number.AsNumber.GetInt64();
@@ -6505,25 +6704,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2060 "SchemaEntity201909.tt"
+        #line 2116 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2060 "SchemaEntity201909.tt"
+        #line 2116 "SchemaEntity201909.tt"
         this.Write("(int value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2062 "SchemaEntity201909.tt"
+        #line 2118 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2062 "SchemaEntity201909.tt"
+        #line 2118 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to int.\r\n   " +
                 "     /// </summary>\r\n        /// <param name=\"number\">The number from which to c" +
                 "onvert.</param>\r\n        public static implicit operator int(");
@@ -6531,13 +6730,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2069 "SchemaEntity201909.tt"
+        #line 2125 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2069 "SchemaEntity201909.tt"
+        #line 2125 "SchemaEntity201909.tt"
         this.Write(@" number)
         {
             return number.AsNumber.GetInt32();
@@ -6552,25 +6751,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2078 "SchemaEntity201909.tt"
+        #line 2134 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2078 "SchemaEntity201909.tt"
+        #line 2134 "SchemaEntity201909.tt"
         this.Write("(JsonNumber value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2080 "SchemaEntity201909.tt"
+        #line 2136 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2080 "SchemaEntity201909.tt"
+        #line 2136 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to number.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"number\">The value from which to" +
                 " convert.</param>\r\n        public static implicit operator JsonNumber(");
@@ -6578,19 +6777,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2087 "SchemaEntity201909.tt"
+        #line 2143 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2087 "SchemaEntity201909.tt"
+        #line 2143 "SchemaEntity201909.tt"
         this.Write(" number)\r\n        {\r\n            return number.AsNumber;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2092 "SchemaEntity201909.tt"
+        #line 2148 "SchemaEntity201909.tt"
 
     }
     
@@ -6598,13 +6797,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2095 "SchemaEntity201909.tt"
+        #line 2151 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2096 "SchemaEntity201909.tt"
+        #line 2152 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -6613,7 +6812,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2100 "SchemaEntity201909.tt"
+        #line 2156 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from bool.\r\n        /// </summary" +
                 ">\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n   " +
                 "     public static implicit operator ");
@@ -6621,25 +6820,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2105 "SchemaEntity201909.tt"
+        #line 2161 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2105 "SchemaEntity201909.tt"
+        #line 2161 "SchemaEntity201909.tt"
         this.Write("(bool value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2107 "SchemaEntity201909.tt"
+        #line 2163 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2107 "SchemaEntity201909.tt"
+        #line 2163 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to bool.\r\n  " +
                 "      /// </summary>\r\n        /// <param name=\"boolean\">The value from which to " +
                 "convert.</param>\r\n        public static implicit operator bool(");
@@ -6647,13 +6846,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2114 "SchemaEntity201909.tt"
+        #line 2170 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2114 "SchemaEntity201909.tt"
+        #line 2170 "SchemaEntity201909.tt"
         this.Write(@" boolean)
         {
             return boolean.AsBoolean.GetBoolean();
@@ -6668,25 +6867,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2123 "SchemaEntity201909.tt"
+        #line 2179 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2123 "SchemaEntity201909.tt"
+        #line 2179 "SchemaEntity201909.tt"
         this.Write("(JsonBoolean value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2125 "SchemaEntity201909.tt"
+        #line 2181 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2125 "SchemaEntity201909.tt"
+        #line 2181 "SchemaEntity201909.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to bool.\r\n  " +
                 "      /// </summary>\r\n        /// <param name=\"boolean\">The value from which to " +
                 "convert.</param>\r\n        public static implicit operator JsonBoolean(");
@@ -6694,19 +6893,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2132 "SchemaEntity201909.tt"
+        #line 2188 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2132 "SchemaEntity201909.tt"
+        #line 2188 "SchemaEntity201909.tt"
         this.Write(" boolean)\r\n        {\r\n            return boolean.AsBoolean;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2137 "SchemaEntity201909.tt"
+        #line 2193 "SchemaEntity201909.tt"
 
     }
     
@@ -6714,7 +6913,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2140 "SchemaEntity201909.tt"
+        #line 2196 "SchemaEntity201909.tt"
         this.Write(@"
         /// <summary>
         /// Standard equality operator.
@@ -6727,25 +6926,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2147 "SchemaEntity201909.tt"
+        #line 2203 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2147 "SchemaEntity201909.tt"
+        #line 2203 "SchemaEntity201909.tt"
         this.Write(" lhs, ");
         
         #line default
         #line hidden
         
-        #line 2147 "SchemaEntity201909.tt"
+        #line 2203 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2147 "SchemaEntity201909.tt"
+        #line 2203 "SchemaEntity201909.tt"
         this.Write(@" rhs)
         {
             return lhs.Equals(rhs);
@@ -6762,31 +6961,31 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2158 "SchemaEntity201909.tt"
+        #line 2214 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2158 "SchemaEntity201909.tt"
+        #line 2214 "SchemaEntity201909.tt"
         this.Write(" lhs, ");
         
         #line default
         #line hidden
         
-        #line 2158 "SchemaEntity201909.tt"
+        #line 2214 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2158 "SchemaEntity201909.tt"
+        #line 2214 "SchemaEntity201909.tt"
         this.Write(" rhs)\r\n        {\r\n            return !lhs.Equals(rhs);\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2163 "SchemaEntity201909.tt"
+        #line 2219 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -6795,13 +6994,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2167 "SchemaEntity201909.tt"
+        #line 2223 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 2167 "SchemaEntity201909.tt"
+        #line 2223 "SchemaEntity201909.tt"
 
         if (CanEnumerateAsSpecificType)
         {
@@ -6810,7 +7009,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2171 "SchemaEntity201909.tt"
+        #line 2227 "SchemaEntity201909.tt"
         this.Write(@"        /// <summary>
         /// Create an array from the given items.
         /// </summary>
@@ -6821,25 +7020,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2176 "SchemaEntity201909.tt"
+        #line 2232 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2176 "SchemaEntity201909.tt"
+        #line 2232 "SchemaEntity201909.tt"
         this.Write(" From(params ");
         
         #line default
         #line hidden
         
-        #line 2176 "SchemaEntity201909.tt"
+        #line 2232 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2176 "SchemaEntity201909.tt"
+        #line 2232 "SchemaEntity201909.tt"
         this.Write("[] items)\r\n        {\r\n            var builder = ImmutableList.CreateBuilder<JsonA" +
                 "ny>();\r\n            foreach (var item in items)\r\n            {\r\n                " +
                 "builder.Add(item);\r\n            }\r\n\r\n            return new ");
@@ -6847,13 +7046,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2184 "SchemaEntity201909.tt"
+        #line 2240 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2184 "SchemaEntity201909.tt"
+        #line 2240 "SchemaEntity201909.tt"
         this.Write(@"(builder.ToImmutable());
         }
 
@@ -6867,37 +7066,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2192 "SchemaEntity201909.tt"
+        #line 2248 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2192 "SchemaEntity201909.tt"
+        #line 2248 "SchemaEntity201909.tt"
         this.Write(" From(");
         
         #line default
         #line hidden
         
-        #line 2192 "SchemaEntity201909.tt"
+        #line 2248 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2192 "SchemaEntity201909.tt"
+        #line 2248 "SchemaEntity201909.tt"
         this.Write(" item1)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2194 "SchemaEntity201909.tt"
+        #line 2250 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2194 "SchemaEntity201909.tt"
+        #line 2250 "SchemaEntity201909.tt"
         this.Write(@"(ImmutableList.Create((JsonAny)item1));
         }
 
@@ -6912,49 +7111,49 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2203 "SchemaEntity201909.tt"
+        #line 2259 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2203 "SchemaEntity201909.tt"
+        #line 2259 "SchemaEntity201909.tt"
         this.Write(" From(");
         
         #line default
         #line hidden
         
-        #line 2203 "SchemaEntity201909.tt"
+        #line 2259 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2203 "SchemaEntity201909.tt"
+        #line 2259 "SchemaEntity201909.tt"
         this.Write(" item1, ");
         
         #line default
         #line hidden
         
-        #line 2203 "SchemaEntity201909.tt"
+        #line 2259 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2203 "SchemaEntity201909.tt"
+        #line 2259 "SchemaEntity201909.tt"
         this.Write(" item2)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2205 "SchemaEntity201909.tt"
+        #line 2261 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2205 "SchemaEntity201909.tt"
+        #line 2261 "SchemaEntity201909.tt"
         this.Write(@"(ImmutableList.Create((JsonAny)item1, (JsonAny)item2));
         }
 
@@ -6970,61 +7169,61 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2215 "SchemaEntity201909.tt"
+        #line 2271 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2215 "SchemaEntity201909.tt"
+        #line 2271 "SchemaEntity201909.tt"
         this.Write(" From(");
         
         #line default
         #line hidden
         
-        #line 2215 "SchemaEntity201909.tt"
+        #line 2271 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2215 "SchemaEntity201909.tt"
+        #line 2271 "SchemaEntity201909.tt"
         this.Write(" item1, ");
         
         #line default
         #line hidden
         
-        #line 2215 "SchemaEntity201909.tt"
+        #line 2271 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2215 "SchemaEntity201909.tt"
+        #line 2271 "SchemaEntity201909.tt"
         this.Write(" item2, ");
         
         #line default
         #line hidden
         
-        #line 2215 "SchemaEntity201909.tt"
+        #line 2271 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2215 "SchemaEntity201909.tt"
+        #line 2271 "SchemaEntity201909.tt"
         this.Write(" item3)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2217 "SchemaEntity201909.tt"
+        #line 2273 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2217 "SchemaEntity201909.tt"
+        #line 2273 "SchemaEntity201909.tt"
         this.Write(@"(ImmutableList.Create((JsonAny)item1, (JsonAny)item2, (JsonAny)item3));
         }
 
@@ -7041,80 +7240,80 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2228 "SchemaEntity201909.tt"
+        #line 2284 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2228 "SchemaEntity201909.tt"
+        #line 2284 "SchemaEntity201909.tt"
         this.Write(" From(");
         
         #line default
         #line hidden
         
-        #line 2228 "SchemaEntity201909.tt"
+        #line 2284 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2228 "SchemaEntity201909.tt"
+        #line 2284 "SchemaEntity201909.tt"
         this.Write(" item1, ");
         
         #line default
         #line hidden
         
-        #line 2228 "SchemaEntity201909.tt"
+        #line 2284 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2228 "SchemaEntity201909.tt"
+        #line 2284 "SchemaEntity201909.tt"
         this.Write(" item2, ");
         
         #line default
         #line hidden
         
-        #line 2228 "SchemaEntity201909.tt"
+        #line 2284 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2228 "SchemaEntity201909.tt"
+        #line 2284 "SchemaEntity201909.tt"
         this.Write(" item3, ");
         
         #line default
         #line hidden
         
-        #line 2228 "SchemaEntity201909.tt"
+        #line 2284 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2228 "SchemaEntity201909.tt"
+        #line 2284 "SchemaEntity201909.tt"
         this.Write(" item4)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2230 "SchemaEntity201909.tt"
+        #line 2286 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2230 "SchemaEntity201909.tt"
+        #line 2286 "SchemaEntity201909.tt"
         this.Write("(ImmutableList.Create((JsonAny)item1, (JsonAny)item2, (JsonAny)item3, (JsonAny)it" +
                 "em4));\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2232 "SchemaEntity201909.tt"
+        #line 2288 "SchemaEntity201909.tt"
 
         }
         else
@@ -7124,7 +7323,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2237 "SchemaEntity201909.tt"
+        #line 2293 "SchemaEntity201909.tt"
         this.Write(@"                /// <summary>
         /// Create an array from the given items.
         /// </summary>
@@ -7135,25 +7334,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2242 "SchemaEntity201909.tt"
+        #line 2298 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2242 "SchemaEntity201909.tt"
+        #line 2298 "SchemaEntity201909.tt"
         this.Write(" From(params JsonAny[] items)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2244 "SchemaEntity201909.tt"
+        #line 2300 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2244 "SchemaEntity201909.tt"
+        #line 2300 "SchemaEntity201909.tt"
         this.Write(@"(items.ToImmutableList());
         }
 
@@ -7167,25 +7366,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2252 "SchemaEntity201909.tt"
+        #line 2308 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2252 "SchemaEntity201909.tt"
+        #line 2308 "SchemaEntity201909.tt"
         this.Write(" From(JsonAny item1)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2254 "SchemaEntity201909.tt"
+        #line 2310 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2254 "SchemaEntity201909.tt"
+        #line 2310 "SchemaEntity201909.tt"
         this.Write(@"(ImmutableList.Create(item1));
         }
 
@@ -7200,25 +7399,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2263 "SchemaEntity201909.tt"
+        #line 2319 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2263 "SchemaEntity201909.tt"
+        #line 2319 "SchemaEntity201909.tt"
         this.Write(" From(JsonAny item1, JsonAny item2)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2265 "SchemaEntity201909.tt"
+        #line 2321 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2265 "SchemaEntity201909.tt"
+        #line 2321 "SchemaEntity201909.tt"
         this.Write(@"(ImmutableList.Create(item1, item2));
         }
 
@@ -7234,26 +7433,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2275 "SchemaEntity201909.tt"
+        #line 2331 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2275 "SchemaEntity201909.tt"
+        #line 2331 "SchemaEntity201909.tt"
         this.Write(" From(JsonAny item1, JsonAny item2, JsonAny item3)\r\n        {\r\n            return" +
                 " new ");
         
         #line default
         #line hidden
         
-        #line 2277 "SchemaEntity201909.tt"
+        #line 2333 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2277 "SchemaEntity201909.tt"
+        #line 2333 "SchemaEntity201909.tt"
         this.Write(@"(ImmutableList.Create(item1, item2, item3));
         }
 
@@ -7270,32 +7469,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2288 "SchemaEntity201909.tt"
+        #line 2344 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2288 "SchemaEntity201909.tt"
+        #line 2344 "SchemaEntity201909.tt"
         this.Write(" From(JsonAny item1, JsonAny item2, JsonAny item3, JsonAny item4)\r\n        {\r\n   " +
                 "         return new ");
         
         #line default
         #line hidden
         
-        #line 2290 "SchemaEntity201909.tt"
+        #line 2346 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2290 "SchemaEntity201909.tt"
+        #line 2346 "SchemaEntity201909.tt"
         this.Write("(ImmutableList.Create(item1, item2, item3, item4));\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2292 "SchemaEntity201909.tt"
+        #line 2348 "SchemaEntity201909.tt"
 
         }
         
@@ -7303,13 +7502,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2295 "SchemaEntity201909.tt"
+        #line 2351 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2296 "SchemaEntity201909.tt"
+        #line 2352 "SchemaEntity201909.tt"
 
     }
     
@@ -7317,13 +7516,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2299 "SchemaEntity201909.tt"
+        #line 2355 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2300 "SchemaEntity201909.tt"
+        #line 2356 "SchemaEntity201909.tt"
 
     if (HasProperties)
     {
@@ -7332,111 +7531,114 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2304 "SchemaEntity201909.tt"
+        #line 2360 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Creates an instance of a <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 2305 "SchemaEntity201909.tt"
+        #line 2361 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2305 "SchemaEntity201909.tt"
+        #line 2361 "SchemaEntity201909.tt"
         this.Write("\"/>.\r\n        /// </summary>\r\n        public static ");
         
         #line default
         #line hidden
         
-        #line 2307 "SchemaEntity201909.tt"
+        #line 2363 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2307 "SchemaEntity201909.tt"
+        #line 2363 "SchemaEntity201909.tt"
         this.Write(" Create(\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2308 "SchemaEntity201909.tt"
+        #line 2364 "SchemaEntity201909.tt"
 
         bool isFirstCreateParameter = true;
         foreach(var property in RequiredAllOfAndRefProperties)
         {
-            if (isFirstCreateParameter)
-            {
-                isFirstCreateParameter = false;
-            }
-            else
-            {
+            if (!IsConst(property.Type))
+            {           
+                if (isFirstCreateParameter)
+                {
+                    isFirstCreateParameter = false;
+                }
+                else
+                {
         
         
         #line default
         #line hidden
         
-        #line 2319 "SchemaEntity201909.tt"
+        #line 2377 "SchemaEntity201909.tt"
         this.Write(", ");
         
         #line default
         #line hidden
         
-        #line 2319 "SchemaEntity201909.tt"
+        #line 2377 "SchemaEntity201909.tt"
 
-            }
+                }
         
         
         #line default
         #line hidden
         
-        #line 2322 "SchemaEntity201909.tt"
+        #line 2380 "SchemaEntity201909.tt"
         this.Write("           ");
         
         #line default
         #line hidden
         
-        #line 2322 "SchemaEntity201909.tt"
+        #line 2380 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2322 "SchemaEntity201909.tt"
+        #line 2380 "SchemaEntity201909.tt"
         this.Write(" ");
         
         #line default
         #line hidden
         
-        #line 2322 "SchemaEntity201909.tt"
+        #line 2380 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2322 "SchemaEntity201909.tt"
+        #line 2380 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2323 "SchemaEntity201909.tt"
+        #line 2381 "SchemaEntity201909.tt"
 
+            }
         }
         
         
         #line default
         #line hidden
         
-        #line 2326 "SchemaEntity201909.tt"
+        #line 2385 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 2326 "SchemaEntity201909.tt"
+        #line 2385 "SchemaEntity201909.tt"
 
         foreach(var property in OptionalAllOfAndRefProperties)
         {
@@ -7451,13 +7653,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2336 "SchemaEntity201909.tt"
+        #line 2395 "SchemaEntity201909.tt"
         this.Write(", ");
         
         #line default
         #line hidden
         
-        #line 2336 "SchemaEntity201909.tt"
+        #line 2395 "SchemaEntity201909.tt"
 
             }
         
@@ -7465,37 +7667,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2339 "SchemaEntity201909.tt"
+        #line 2398 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 2339 "SchemaEntity201909.tt"
+        #line 2398 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2339 "SchemaEntity201909.tt"
+        #line 2398 "SchemaEntity201909.tt"
         this.Write("? ");
         
         #line default
         #line hidden
         
-        #line 2339 "SchemaEntity201909.tt"
+        #line 2398 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2339 "SchemaEntity201909.tt"
+        #line 2398 "SchemaEntity201909.tt"
         this.Write(" = null\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2340 "SchemaEntity201909.tt"
+        #line 2399 "SchemaEntity201909.tt"
 
         }
         
@@ -7503,67 +7705,110 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2343 "SchemaEntity201909.tt"
+        #line 2402 "SchemaEntity201909.tt"
         this.Write("\r\n        )\r\n        {\r\n            var builder = ImmutableDictionary.CreateBuild" +
                 "er<string, JsonAny>();\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2347 "SchemaEntity201909.tt"
+        #line 2406 "SchemaEntity201909.tt"
 
         foreach(var property in RequiredAllOfAndRefProperties)
         {
+            if (IsConst(property.Type))
+            {
         
         
         #line default
         #line hidden
         
-        #line 2351 "SchemaEntity201909.tt"
+        #line 2412 "SchemaEntity201909.tt"
         this.Write("            builder.Add(");
         
         #line default
         #line hidden
         
-        #line 2351 "SchemaEntity201909.tt"
+        #line 2412 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName));
         
         #line default
         #line hidden
         
-        #line 2351 "SchemaEntity201909.tt"
+        #line 2412 "SchemaEntity201909.tt"
+        this.Write("JsonPropertyName, new ");
+        
+        #line default
+        #line hidden
+        
+        #line 2412 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 2412 "SchemaEntity201909.tt"
+        this.Write("());\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 2413 "SchemaEntity201909.tt"
+
+            }
+            else
+            {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 2418 "SchemaEntity201909.tt"
+        this.Write("            builder.Add(");
+        
+        #line default
+        #line hidden
+        
+        #line 2418 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName));
+        
+        #line default
+        #line hidden
+        
+        #line 2418 "SchemaEntity201909.tt"
         this.Write("JsonPropertyName, ");
         
         #line default
         #line hidden
         
-        #line 2351 "SchemaEntity201909.tt"
+        #line 2418 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2351 "SchemaEntity201909.tt"
+        #line 2418 "SchemaEntity201909.tt"
         this.Write(");\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2352 "SchemaEntity201909.tt"
+        #line 2419 "SchemaEntity201909.tt"
 
+            }
         }
         
         
         #line default
         #line hidden
         
-        #line 2355 "SchemaEntity201909.tt"
+        #line 2423 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 2355 "SchemaEntity201909.tt"
+        #line 2423 "SchemaEntity201909.tt"
 
         foreach(var property in OptionalAllOfAndRefProperties)
         {
@@ -7572,108 +7817,152 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2359 "SchemaEntity201909.tt"
+        #line 2427 "SchemaEntity201909.tt"
         this.Write("            if (");
         
         #line default
         #line hidden
         
-        #line 2359 "SchemaEntity201909.tt"
+        #line 2427 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2359 "SchemaEntity201909.tt"
+        #line 2427 "SchemaEntity201909.tt"
         this.Write(" is ");
         
         #line default
         #line hidden
         
-        #line 2359 "SchemaEntity201909.tt"
+        #line 2427 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2359 "SchemaEntity201909.tt"
+        #line 2427 "SchemaEntity201909.tt"
         this.Write(" ");
         
         #line default
         #line hidden
         
-        #line 2359 "SchemaEntity201909.tt"
+        #line 2427 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2359 "SchemaEntity201909.tt"
+        #line 2427 "SchemaEntity201909.tt"
         this.Write("__)\r\n            {\r\n                builder.Add(");
         
         #line default
         #line hidden
         
-        #line 2361 "SchemaEntity201909.tt"
+        #line 2429 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName));
         
         #line default
         #line hidden
         
-        #line 2361 "SchemaEntity201909.tt"
+        #line 2429 "SchemaEntity201909.tt"
         this.Write("JsonPropertyName, ");
         
         #line default
         #line hidden
         
-        #line 2361 "SchemaEntity201909.tt"
+        #line 2429 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2361 "SchemaEntity201909.tt"
-        this.Write("__);\r\n            }\r\n        ");
+        #line 2429 "SchemaEntity201909.tt"
+        this.Write("__);\r\n            }            \r\n        ");
         
         #line default
         #line hidden
         
-        #line 2363 "SchemaEntity201909.tt"
+        #line 2431 "SchemaEntity201909.tt"
 
+            if (IsConst(property.Type))
+            {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 2435 "SchemaEntity201909.tt"
+        this.Write("            else\r\n            {\r\n                builder.Add(");
+        
+        #line default
+        #line hidden
+        
+        #line 2437 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName));
+        
+        #line default
+        #line hidden
+        
+        #line 2437 "SchemaEntity201909.tt"
+        this.Write("JsonPropertyName, new ");
+        
+        #line default
+        #line hidden
+        
+        #line 2437 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 2437 "SchemaEntity201909.tt"
+        this.Write("());\r\n            }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 2439 "SchemaEntity201909.tt"
+
+            }
         }
         
         
         #line default
         #line hidden
         
-        #line 2366 "SchemaEntity201909.tt"
+        #line 2443 "SchemaEntity201909.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2369 "SchemaEntity201909.tt"
+        #line 2446 "SchemaEntity201909.tt"
 
         foreach(var property in Properties)
         {
+            if (IsConst(property.Type))
+            {
+                continue;
+            }
         
         
         #line default
         #line hidden
         
-        #line 2373 "SchemaEntity201909.tt"
+        #line 2454 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Sets ");
         
         #line default
         #line hidden
         
-        #line 2375 "SchemaEntity201909.tt"
+        #line 2456 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(property.JsonPropertyName, true).Trim('"') ));
         
         #line default
         #line hidden
         
-        #line 2375 "SchemaEntity201909.tt"
+        #line 2456 "SchemaEntity201909.tt"
         this.Write(".\r\n        /// </summary>\r\n        /// <param name=\"value\">The value to set.</par" +
                 "am>\r\n        /// <returns>The entity with the updated property.</returns>\r\n     " +
                 "   public ");
@@ -7681,55 +7970,55 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2379 "SchemaEntity201909.tt"
+        #line 2460 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2379 "SchemaEntity201909.tt"
+        #line 2460 "SchemaEntity201909.tt"
         this.Write(" With");
         
         #line default
         #line hidden
         
-        #line 2379 "SchemaEntity201909.tt"
+        #line 2460 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 2379 "SchemaEntity201909.tt"
+        #line 2460 "SchemaEntity201909.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 2379 "SchemaEntity201909.tt"
+        #line 2460 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2379 "SchemaEntity201909.tt"
+        #line 2460 "SchemaEntity201909.tt"
         this.Write(" value)\r\n        {\r\n            return this.SetProperty(");
         
         #line default
         #line hidden
         
-        #line 2381 "SchemaEntity201909.tt"
+        #line 2462 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 2381 "SchemaEntity201909.tt"
+        #line 2462 "SchemaEntity201909.tt"
         this.Write("JsonPropertyName, value);\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2384 "SchemaEntity201909.tt"
+        #line 2465 "SchemaEntity201909.tt"
 
         }
         
@@ -7737,13 +8026,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2387 "SchemaEntity201909.tt"
+        #line 2468 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2388 "SchemaEntity201909.tt"
+        #line 2469 "SchemaEntity201909.tt"
 
     }
     
@@ -7751,7 +8040,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2391 "SchemaEntity201909.tt"
+        #line 2472 "SchemaEntity201909.tt"
         this.Write(@"
         /// <inheritdoc/>
         public override string ToString()
@@ -7782,7 +8071,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2416 "SchemaEntity201909.tt"
+        #line 2497 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -7791,13 +8080,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2420 "SchemaEntity201909.tt"
+        #line 2501 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2421 "SchemaEntity201909.tt"
+        #line 2502 "SchemaEntity201909.tt"
 
     }
     else
@@ -7807,13 +8096,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2426 "SchemaEntity201909.tt"
+        #line 2507 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2427 "SchemaEntity201909.tt"
+        #line 2508 "SchemaEntity201909.tt"
 
     }
     
@@ -7821,13 +8110,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2430 "SchemaEntity201909.tt"
+        #line 2511 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2430 "SchemaEntity201909.tt"
+        #line 2511 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -7836,13 +8125,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2434 "SchemaEntity201909.tt"
+        #line 2515 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2435 "SchemaEntity201909.tt"
+        #line 2516 "SchemaEntity201909.tt"
 
     }
     else
@@ -7852,13 +8141,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2440 "SchemaEntity201909.tt"
+        #line 2521 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2441 "SchemaEntity201909.tt"
+        #line 2522 "SchemaEntity201909.tt"
 
     }
     
@@ -7866,13 +8155,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2444 "SchemaEntity201909.tt"
+        #line 2525 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2444 "SchemaEntity201909.tt"
+        #line 2525 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -7881,13 +8170,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2448 "SchemaEntity201909.tt"
+        #line 2529 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2449 "SchemaEntity201909.tt"
+        #line 2530 "SchemaEntity201909.tt"
 
     }
     else
@@ -7897,13 +8186,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2454 "SchemaEntity201909.tt"
+        #line 2535 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2455 "SchemaEntity201909.tt"
+        #line 2536 "SchemaEntity201909.tt"
 
     }
     
@@ -7911,13 +8200,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2458 "SchemaEntity201909.tt"
+        #line 2539 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2458 "SchemaEntity201909.tt"
+        #line 2539 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -7926,13 +8215,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2462 "SchemaEntity201909.tt"
+        #line 2543 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2463 "SchemaEntity201909.tt"
+        #line 2544 "SchemaEntity201909.tt"
 
     }
     else
@@ -7942,13 +8231,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2468 "SchemaEntity201909.tt"
+        #line 2549 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2469 "SchemaEntity201909.tt"
+        #line 2550 "SchemaEntity201909.tt"
 
     }
     
@@ -7956,13 +8245,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2472 "SchemaEntity201909.tt"
+        #line 2553 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2472 "SchemaEntity201909.tt"
+        #line 2553 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -7971,14 +8260,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2476 "SchemaEntity201909.tt"
+        #line 2557 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.GetHa" +
                 "shCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2477 "SchemaEntity201909.tt"
+        #line 2558 "SchemaEntity201909.tt"
 
     }
     else
@@ -7988,14 +8277,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2482 "SchemaEntity201909.tt"
+        #line 2563 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Get" +
                 "HashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2483 "SchemaEntity201909.tt"
+        #line 2564 "SchemaEntity201909.tt"
 
     }
     
@@ -8003,7 +8292,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2486 "SchemaEntity201909.tt"
+        #line 2567 "SchemaEntity201909.tt"
         this.Write(@"                JsonValueKind.Null => JsonNull.NullHashCode,
                 _ => JsonAny.UndefinedHashCode,
             };
@@ -8020,7 +8309,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2497 "SchemaEntity201909.tt"
+        #line 2578 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -8029,7 +8318,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2501 "SchemaEntity201909.tt"
+        #line 2582 "SchemaEntity201909.tt"
         this.Write("            if (this.objectBacking is ImmutableDictionary<string, JsonAny> object" +
                 "Backing)\r\n            {\r\n                JsonObject.WriteProperties(objectBackin" +
                 "g, writer);\r\n                return;\r\n            }\r\n\r\n    ");
@@ -8037,7 +8326,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2507 "SchemaEntity201909.tt"
+        #line 2588 "SchemaEntity201909.tt"
 
     }
     
@@ -8045,13 +8334,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2510 "SchemaEntity201909.tt"
+        #line 2591 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2511 "SchemaEntity201909.tt"
+        #line 2592 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -8060,7 +8349,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2515 "SchemaEntity201909.tt"
+        #line 2596 "SchemaEntity201909.tt"
         this.Write("            if (this.arrayBacking is ImmutableList<JsonAny> arrayBacking)\r\n      " +
                 "      {\r\n                JsonArray.WriteItems(arrayBacking, writer);\r\n          " +
                 "      return;\r\n            }\r\n\r\n    ");
@@ -8068,7 +8357,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2521 "SchemaEntity201909.tt"
+        #line 2602 "SchemaEntity201909.tt"
 
     }
     
@@ -8076,13 +8365,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2524 "SchemaEntity201909.tt"
+        #line 2605 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2525 "SchemaEntity201909.tt"
+        #line 2606 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -8091,7 +8380,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2529 "SchemaEntity201909.tt"
+        #line 2610 "SchemaEntity201909.tt"
         this.Write("            if (this.numberBacking is double numberBacking)\r\n            {\r\n     " +
                 "           writer.WriteNumberValue(numberBacking);\r\n                return;\r\n   " +
                 "         }\r\n\r\n    ");
@@ -8099,7 +8388,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2535 "SchemaEntity201909.tt"
+        #line 2616 "SchemaEntity201909.tt"
 
     }
     
@@ -8107,13 +8396,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2538 "SchemaEntity201909.tt"
+        #line 2619 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2539 "SchemaEntity201909.tt"
+        #line 2620 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -8122,7 +8411,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2543 "SchemaEntity201909.tt"
+        #line 2624 "SchemaEntity201909.tt"
         this.Write("            if (this.stringBacking is string stringBacking)\r\n            {\r\n     " +
                 "           writer.WriteStringValue(stringBacking);\r\n                return;\r\n   " +
                 "         }\r\n\r\n    ");
@@ -8130,7 +8419,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2549 "SchemaEntity201909.tt"
+        #line 2630 "SchemaEntity201909.tt"
 
     }
     
@@ -8138,13 +8427,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2552 "SchemaEntity201909.tt"
+        #line 2633 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2553 "SchemaEntity201909.tt"
+        #line 2634 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -8153,7 +8442,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2557 "SchemaEntity201909.tt"
+        #line 2638 "SchemaEntity201909.tt"
         this.Write("            if (this.booleanBacking is bool booleanBacking)\r\n            {\r\n     " +
                 "           writer.WriteBooleanValue(booleanBacking);\r\n                return;\r\n " +
                 "           }\r\n    ");
@@ -8161,7 +8450,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2562 "SchemaEntity201909.tt"
+        #line 2643 "SchemaEntity201909.tt"
 
     }
     
@@ -8169,7 +8458,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2565 "SchemaEntity201909.tt"
+        #line 2646 "SchemaEntity201909.tt"
         this.Write("\r\n            if (this.jsonElementBacking.ValueKind != JsonValueKind.Undefined)\r\n" +
                 "            {\r\n                this.jsonElementBacking.WriteTo(writer);\r\n       " +
                 "         return;\r\n            }\r\n\r\n            writer.WriteNullValue();\r\n       " +
@@ -8178,7 +8467,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2575 "SchemaEntity201909.tt"
+        #line 2656 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -8187,13 +8476,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2579 "SchemaEntity201909.tt"
+        #line 2660 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2580 "SchemaEntity201909.tt"
+        #line 2661 "SchemaEntity201909.tt"
 
         if (HasAdditionalPropertiesObject && !HasUnevaluatedPropertiesObject)
         {
@@ -8202,20 +8491,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2584 "SchemaEntity201909.tt"
+        #line 2665 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the object as the given item type\r\n " +
                 "       /// </summary>\r\n        public JsonObjectEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2587 "SchemaEntity201909.tt"
+        #line 2668 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2587 "SchemaEntity201909.tt"
+        #line 2668 "SchemaEntity201909.tt"
         this.Write("> EnumerateProperties()\r\n        {\r\n            if (this.objectBacking is Immutab" +
                 "leDictionary<string, JsonAny> properties)\r\n            {\r\n                return" +
                 " new JsonObjectEnumerator<");
@@ -8223,13 +8512,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2591 "SchemaEntity201909.tt"
+        #line 2672 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2591 "SchemaEntity201909.tt"
+        #line 2672 "SchemaEntity201909.tt"
         this.Write(">(properties);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKin" +
                 "d == JsonValueKind.Object)\r\n            {\r\n                return new JsonObject" +
                 "Enumerator<");
@@ -8237,20 +8526,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2596 "SchemaEntity201909.tt"
+        #line 2677 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2596 "SchemaEntity201909.tt"
+        #line 2677 "SchemaEntity201909.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n\r\n    " +
                 "    }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2602 "SchemaEntity201909.tt"
+        #line 2683 "SchemaEntity201909.tt"
 
         }
         
@@ -8258,13 +8547,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2605 "SchemaEntity201909.tt"
+        #line 2686 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2606 "SchemaEntity201909.tt"
+        #line 2687 "SchemaEntity201909.tt"
 
         if (!HasAdditionalPropertiesObject && HasUnevaluatedPropertiesObject)
         {
@@ -8273,20 +8562,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2610 "SchemaEntity201909.tt"
+        #line 2691 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the object as the given item type\r\n " +
                 "       /// </summary>\r\n        public JsonObjectEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2613 "SchemaEntity201909.tt"
+        #line 2694 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2613 "SchemaEntity201909.tt"
+        #line 2694 "SchemaEntity201909.tt"
         this.Write("> EnumerateProperties()\r\n        {\r\n            if (this.objectBacking is Immutab" +
                 "leDictionary<string, JsonAny> properties)\r\n            {\r\n                return" +
                 " new JsonObjectEnumerator<");
@@ -8294,13 +8583,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2617 "SchemaEntity201909.tt"
+        #line 2698 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2617 "SchemaEntity201909.tt"
+        #line 2698 "SchemaEntity201909.tt"
         this.Write(">(properties);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKin" +
                 "d == JsonValueKind.Object)\r\n            {\r\n                return new JsonObject" +
                 "Enumerator<");
@@ -8308,20 +8597,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2622 "SchemaEntity201909.tt"
+        #line 2703 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2622 "SchemaEntity201909.tt"
+        #line 2703 "SchemaEntity201909.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n\r\n    " +
                 "    }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2628 "SchemaEntity201909.tt"
+        #line 2709 "SchemaEntity201909.tt"
 
         }
         
@@ -8329,7 +8618,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2631 "SchemaEntity201909.tt"
+        #line 2712 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public JsonObjectEnumerator EnumerateObject(" +
                 ")\r\n        {\r\n            return this.AsObject.EnumerateObject();\r\n        }\r\n\r\n" +
                 "    ");
@@ -8337,7 +8626,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2638 "SchemaEntity201909.tt"
+        #line 2719 "SchemaEntity201909.tt"
 
     }
     
@@ -8345,13 +8634,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2641 "SchemaEntity201909.tt"
+        #line 2722 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2642 "SchemaEntity201909.tt"
+        #line 2723 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -8360,13 +8649,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2646 "SchemaEntity201909.tt"
+        #line 2727 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2647 "SchemaEntity201909.tt"
+        #line 2728 "SchemaEntity201909.tt"
 
         if (CanEnumerateAsSpecificType)
         {
@@ -8375,32 +8664,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2651 "SchemaEntity201909.tt"
+        #line 2732 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the items in the array as a <see cre" +
                 "f=\"");
         
         #line default
         #line hidden
         
-        #line 2652 "SchemaEntity201909.tt"
+        #line 2733 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2652 "SchemaEntity201909.tt"
+        #line 2733 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public JsonArrayEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2654 "SchemaEntity201909.tt"
+        #line 2735 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2654 "SchemaEntity201909.tt"
+        #line 2735 "SchemaEntity201909.tt"
         this.Write("> EnumerateItems()\r\n        {\r\n            if (this.arrayBacking is ImmutableList" +
                 "<JsonAny> items)\r\n            {\r\n                return new JsonArrayEnumerator<" +
                 "");
@@ -8408,13 +8697,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2658 "SchemaEntity201909.tt"
+        #line 2739 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2658 "SchemaEntity201909.tt"
+        #line 2739 "SchemaEntity201909.tt"
         this.Write(">(items);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKind == " +
                 "JsonValueKind.Array)\r\n            {\r\n                return new JsonArrayEnumera" +
                 "tor<");
@@ -8422,20 +8711,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2663 "SchemaEntity201909.tt"
+        #line 2744 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2663 "SchemaEntity201909.tt"
+        #line 2744 "SchemaEntity201909.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n      " +
                 "  }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2668 "SchemaEntity201909.tt"
+        #line 2749 "SchemaEntity201909.tt"
 
         }
         
@@ -8443,14 +8732,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2671 "SchemaEntity201909.tt"
+        #line 2752 "SchemaEntity201909.tt"
         this.Write("        /// <inheritdoc/>\r\n        public JsonArrayEnumerator EnumerateArray()\r\n " +
                 "       {\r\n            return this.AsArray.EnumerateArray();\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2676 "SchemaEntity201909.tt"
+        #line 2757 "SchemaEntity201909.tt"
 
     }
     
@@ -8458,13 +8747,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2679 "SchemaEntity201909.tt"
+        #line 2760 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2680 "SchemaEntity201909.tt"
+        #line 2761 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -8473,7 +8762,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2684 "SchemaEntity201909.tt"
+        #line 2765 "SchemaEntity201909.tt"
         this.Write(@"
         /// <inheritdoc/>
         public bool TryGetProperty(string name, out JsonAny value)
@@ -8498,7 +8787,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2703 "SchemaEntity201909.tt"
+        #line 2784 "SchemaEntity201909.tt"
 
         if (HasDefaults)
         {
@@ -8507,7 +8796,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2707 "SchemaEntity201909.tt"
+        #line 2788 "SchemaEntity201909.tt"
         this.Write(@"        /// <inheritdoc/>
         public bool TryGetDefault(string name, out JsonAny value)
         {
@@ -8549,7 +8838,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2743 "SchemaEntity201909.tt"
+        #line 2824 "SchemaEntity201909.tt"
 
         }
         
@@ -8557,13 +8846,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2746 "SchemaEntity201909.tt"
+        #line 2827 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2747 "SchemaEntity201909.tt"
+        #line 2828 "SchemaEntity201909.tt"
 
     }
     
@@ -8571,7 +8860,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2750 "SchemaEntity201909.tt"
+        #line 2831 "SchemaEntity201909.tt"
         this.Write(@"
         /// <inheritdoc/>
         public bool Equals<T>(T other)
@@ -8591,7 +8880,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2764 "SchemaEntity201909.tt"
+        #line 2845 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -8600,14 +8889,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2768 "SchemaEntity201909.tt"
+        #line 2849 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.Equals(other.AsObject()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2769 "SchemaEntity201909.tt"
+        #line 2850 "SchemaEntity201909.tt"
 
     }
     else
@@ -8617,14 +8906,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2774 "SchemaEntity201909.tt"
+        #line 2855 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().Equals(other.AsObject())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2775 "SchemaEntity201909.tt"
+        #line 2856 "SchemaEntity201909.tt"
 
     }
     
@@ -8632,13 +8921,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2778 "SchemaEntity201909.tt"
+        #line 2859 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2778 "SchemaEntity201909.tt"
+        #line 2859 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -8647,14 +8936,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2782 "SchemaEntity201909.tt"
+        #line 2863 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.Equals(other.AsArray()),\r\n   " +
                 " ");
         
         #line default
         #line hidden
         
-        #line 2783 "SchemaEntity201909.tt"
+        #line 2864 "SchemaEntity201909.tt"
 
     }
     else
@@ -8664,14 +8953,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2788 "SchemaEntity201909.tt"
+        #line 2869 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().Equals(other.AsArray()),\r\n " +
                 "   ");
         
         #line default
         #line hidden
         
-        #line 2789 "SchemaEntity201909.tt"
+        #line 2870 "SchemaEntity201909.tt"
 
     }
     
@@ -8679,13 +8968,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2792 "SchemaEntity201909.tt"
+        #line 2873 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2792 "SchemaEntity201909.tt"
+        #line 2873 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -8694,14 +8983,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2796 "SchemaEntity201909.tt"
+        #line 2877 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.Equals(other.AsNumber()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2797 "SchemaEntity201909.tt"
+        #line 2878 "SchemaEntity201909.tt"
 
     }
     else
@@ -8711,14 +9000,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2802 "SchemaEntity201909.tt"
+        #line 2883 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().Equals(other.AsNumber())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2803 "SchemaEntity201909.tt"
+        #line 2884 "SchemaEntity201909.tt"
 
     }
     
@@ -8726,13 +9015,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2806 "SchemaEntity201909.tt"
+        #line 2887 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2806 "SchemaEntity201909.tt"
+        #line 2887 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -8741,14 +9030,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2810 "SchemaEntity201909.tt"
+        #line 2891 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString.Equals(other.AsString()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2811 "SchemaEntity201909.tt"
+        #line 2892 "SchemaEntity201909.tt"
 
     }
     else
@@ -8758,14 +9047,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2816 "SchemaEntity201909.tt"
+        #line 2897 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString().Equals(other.AsString())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2817 "SchemaEntity201909.tt"
+        #line 2898 "SchemaEntity201909.tt"
 
     }
     
@@ -8773,13 +9062,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2820 "SchemaEntity201909.tt"
+        #line 2901 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2820 "SchemaEntity201909.tt"
+        #line 2901 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -8788,14 +9077,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2824 "SchemaEntity201909.tt"
+        #line 2905 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.Equal" +
                 "s(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2825 "SchemaEntity201909.tt"
+        #line 2906 "SchemaEntity201909.tt"
 
     }
     else
@@ -8805,14 +9094,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2830 "SchemaEntity201909.tt"
+        #line 2911 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Equ" +
                 "als(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2831 "SchemaEntity201909.tt"
+        #line 2912 "SchemaEntity201909.tt"
 
     }
     
@@ -8820,20 +9109,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2834 "SchemaEntity201909.tt"
+        #line 2915 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Null => true,\r\n                _ => false,\r\n       " +
                 "     };\r\n        }\r\n\r\n        /// <inheritdoc/>\r\n        public bool Equals(");
         
         #line default
         #line hidden
         
-        #line 2840 "SchemaEntity201909.tt"
+        #line 2921 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2840 "SchemaEntity201909.tt"
+        #line 2921 "SchemaEntity201909.tt"
         this.Write(" other)\r\n        {\r\n            JsonValueKind valueKind = this.ValueKind;\r\n\r\n    " +
                 "        if (other.ValueKind != valueKind)\r\n            {\r\n                return" +
                 " false;\r\n            }\r\n\r\n            return valueKind switch\r\n            {\r\n  " +
@@ -8842,7 +9131,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2851 "SchemaEntity201909.tt"
+        #line 2932 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -8851,14 +9140,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2855 "SchemaEntity201909.tt"
+        #line 2936 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.Equals(other.AsObject),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2856 "SchemaEntity201909.tt"
+        #line 2937 "SchemaEntity201909.tt"
 
     }
     else
@@ -8868,14 +9157,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2861 "SchemaEntity201909.tt"
+        #line 2942 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().Equals(other.AsObject())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2862 "SchemaEntity201909.tt"
+        #line 2943 "SchemaEntity201909.tt"
 
     }
     
@@ -8883,13 +9172,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2865 "SchemaEntity201909.tt"
+        #line 2946 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2865 "SchemaEntity201909.tt"
+        #line 2946 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -8898,13 +9187,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2869 "SchemaEntity201909.tt"
+        #line 2950 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.Equals(other.AsArray),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2870 "SchemaEntity201909.tt"
+        #line 2951 "SchemaEntity201909.tt"
 
     }
     else
@@ -8914,14 +9203,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2875 "SchemaEntity201909.tt"
+        #line 2956 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().Equals(other.AsArray()),\r\n " +
                 "   ");
         
         #line default
         #line hidden
         
-        #line 2876 "SchemaEntity201909.tt"
+        #line 2957 "SchemaEntity201909.tt"
 
     }
     
@@ -8929,13 +9218,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2879 "SchemaEntity201909.tt"
+        #line 2960 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2879 "SchemaEntity201909.tt"
+        #line 2960 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -8944,14 +9233,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2883 "SchemaEntity201909.tt"
+        #line 2964 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.Equals(other.AsNumber),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2884 "SchemaEntity201909.tt"
+        #line 2965 "SchemaEntity201909.tt"
 
     }
     else
@@ -8961,14 +9250,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2889 "SchemaEntity201909.tt"
+        #line 2970 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().Equals(other.AsNumber())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2890 "SchemaEntity201909.tt"
+        #line 2971 "SchemaEntity201909.tt"
 
     }
     
@@ -8976,13 +9265,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2893 "SchemaEntity201909.tt"
+        #line 2974 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2893 "SchemaEntity201909.tt"
+        #line 2974 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -8991,14 +9280,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2897 "SchemaEntity201909.tt"
+        #line 2978 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString.Equals(other.AsString),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2898 "SchemaEntity201909.tt"
+        #line 2979 "SchemaEntity201909.tt"
 
     }
     else
@@ -9008,14 +9297,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2903 "SchemaEntity201909.tt"
+        #line 2984 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.String => this.AsString().Equals(other.AsString())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2904 "SchemaEntity201909.tt"
+        #line 2985 "SchemaEntity201909.tt"
 
     }
     
@@ -9023,13 +9312,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2907 "SchemaEntity201909.tt"
+        #line 2988 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2907 "SchemaEntity201909.tt"
+        #line 2988 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -9038,14 +9327,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2911 "SchemaEntity201909.tt"
+        #line 2992 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.Equal" +
                 "s(other.AsBoolean),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2912 "SchemaEntity201909.tt"
+        #line 2993 "SchemaEntity201909.tt"
 
     }
     else
@@ -9055,14 +9344,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2917 "SchemaEntity201909.tt"
+        #line 2998 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Equ" +
                 "als(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2918 "SchemaEntity201909.tt"
+        #line 2999 "SchemaEntity201909.tt"
 
     }
     
@@ -9070,14 +9359,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2921 "SchemaEntity201909.tt"
+        #line 3002 "SchemaEntity201909.tt"
         this.Write("                JsonValueKind.Null => true,\r\n                _ => false,\r\n       " +
                 "     };\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2926 "SchemaEntity201909.tt"
+        #line 3007 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -9086,7 +9375,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2930 "SchemaEntity201909.tt"
+        #line 3011 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public bool HasProperty(string name)\r\n      " +
                 "  {\r\n            if (this.objectBacking is ImmutableDictionary<string, JsonAny> " +
                 "properties)\r\n            {\r\n                return properties.TryGetValue(name, " +
@@ -9112,13 +9401,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2978 "SchemaEntity201909.tt"
+        #line 3059 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2978 "SchemaEntity201909.tt"
+        #line 3059 "SchemaEntity201909.tt"
         this.Write(@" SetProperty<TValue>(string name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9136,13 +9425,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2990 "SchemaEntity201909.tt"
+        #line 3071 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2990 "SchemaEntity201909.tt"
+        #line 3071 "SchemaEntity201909.tt"
         this.Write(@" SetProperty<TValue>(ReadOnlySpan<char> name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9160,13 +9449,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3002 "SchemaEntity201909.tt"
+        #line 3083 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3002 "SchemaEntity201909.tt"
+        #line 3083 "SchemaEntity201909.tt"
         this.Write(@" SetProperty<TValue>(ReadOnlySpan<byte> utf8name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9184,13 +9473,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3014 "SchemaEntity201909.tt"
+        #line 3095 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3014 "SchemaEntity201909.tt"
+        #line 3095 "SchemaEntity201909.tt"
         this.Write(@" RemoveProperty(string name)
         {
             if (this.ValueKind == JsonValueKind.Object)
@@ -9207,13 +9496,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3025 "SchemaEntity201909.tt"
+        #line 3106 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3025 "SchemaEntity201909.tt"
+        #line 3106 "SchemaEntity201909.tt"
         this.Write(@" RemoveProperty(ReadOnlySpan<char> name)
         {
             if (this.ValueKind == JsonValueKind.Object)
@@ -9230,13 +9519,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3036 "SchemaEntity201909.tt"
+        #line 3117 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3036 "SchemaEntity201909.tt"
+        #line 3117 "SchemaEntity201909.tt"
         this.Write(" RemoveProperty(ReadOnlySpan<byte> utf8Name)\r\n        {\r\n            if (this.Val" +
                 "ueKind == JsonValueKind.Object)\r\n            {\r\n                return this.AsOb" +
                 "ject.RemoveProperty(utf8Name);\r\n            }\r\n\r\n            return this;\r\n     " +
@@ -9245,7 +9534,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3046 "SchemaEntity201909.tt"
+        #line 3127 "SchemaEntity201909.tt"
 
     }
     
@@ -9253,13 +9542,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3049 "SchemaEntity201909.tt"
+        #line 3130 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3050 "SchemaEntity201909.tt"
+        #line 3131 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -9268,19 +9557,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3054 "SchemaEntity201909.tt"
+        #line 3135 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 3056 "SchemaEntity201909.tt"
+        #line 3137 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3056 "SchemaEntity201909.tt"
+        #line 3137 "SchemaEntity201909.tt"
         this.Write(@" Add<TItem>(TItem item)
             where TItem : struct, IJsonValue
         {
@@ -9298,13 +9587,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3068 "SchemaEntity201909.tt"
+        #line 3149 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3068 "SchemaEntity201909.tt"
+        #line 3149 "SchemaEntity201909.tt"
         this.Write(@" Add<TItem1, TItem2>(TItem1 item1, TItem2 item2)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9323,13 +9612,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3081 "SchemaEntity201909.tt"
+        #line 3162 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3081 "SchemaEntity201909.tt"
+        #line 3162 "SchemaEntity201909.tt"
         this.Write(@" Add<TItem1, TItem2, TItem3>(TItem1 item1, TItem2 item2, TItem3 item3)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9349,13 +9638,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3095 "SchemaEntity201909.tt"
+        #line 3176 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3095 "SchemaEntity201909.tt"
+        #line 3176 "SchemaEntity201909.tt"
         this.Write(@" Add<TItem1, TItem2, TItem3, TItem4>(TItem1 item1, TItem2 item2, TItem3 item3, TItem4 item4)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9376,13 +9665,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3110 "SchemaEntity201909.tt"
+        #line 3191 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3110 "SchemaEntity201909.tt"
+        #line 3191 "SchemaEntity201909.tt"
         this.Write(@" Add<TItem>(params TItem[] items)
             where TItem : struct, IJsonValue
         {
@@ -9400,13 +9689,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3122 "SchemaEntity201909.tt"
+        #line 3203 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3122 "SchemaEntity201909.tt"
+        #line 3203 "SchemaEntity201909.tt"
         this.Write(@" AddRange<TItem>(IEnumerable<TItem> items)
             where TItem : struct, IJsonValue
         {
@@ -9424,13 +9713,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3134 "SchemaEntity201909.tt"
+        #line 3215 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3134 "SchemaEntity201909.tt"
+        #line 3215 "SchemaEntity201909.tt"
         this.Write(@" Insert<TItem>(int index, TItem item)
             where TItem : struct, IJsonValue
         {
@@ -9448,13 +9737,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3146 "SchemaEntity201909.tt"
+        #line 3227 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3146 "SchemaEntity201909.tt"
+        #line 3227 "SchemaEntity201909.tt"
         this.Write(@" Replace<TItem>(TItem oldValue, TItem newValue)
             where TItem : struct, IJsonValue
         {
@@ -9472,13 +9761,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3158 "SchemaEntity201909.tt"
+        #line 3239 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3158 "SchemaEntity201909.tt"
+        #line 3239 "SchemaEntity201909.tt"
         this.Write(@" RemoveAt(int index)
         {
             if (this.ValueKind == JsonValueKind.Array)
@@ -9495,13 +9784,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3169 "SchemaEntity201909.tt"
+        #line 3250 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3169 "SchemaEntity201909.tt"
+        #line 3250 "SchemaEntity201909.tt"
         this.Write(@" RemoveRange(int index, int count)
         {
             if (this.ValueKind == JsonValueKind.Array)
@@ -9518,13 +9807,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3180 "SchemaEntity201909.tt"
+        #line 3261 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3180 "SchemaEntity201909.tt"
+        #line 3261 "SchemaEntity201909.tt"
         this.Write(@" SetItem<TItem>(int index, TItem value)
             where TItem : struct, IJsonValue
         {
@@ -9541,7 +9830,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3191 "SchemaEntity201909.tt"
+        #line 3272 "SchemaEntity201909.tt"
 
     }
     
@@ -9549,26 +9838,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3194 "SchemaEntity201909.tt"
+        #line 3275 "SchemaEntity201909.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public T As<T>()\r\n            where T : stru" +
                 "ct, IJsonValue\r\n        {\r\n            return this.As<");
         
         #line default
         #line hidden
         
-        #line 3199 "SchemaEntity201909.tt"
+        #line 3280 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3199 "SchemaEntity201909.tt"
+        #line 3280 "SchemaEntity201909.tt"
         this.Write(", T>();\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3202 "SchemaEntity201909.tt"
+        #line 3283 "SchemaEntity201909.tt"
 
     if(HasPatternProperties)
     {
@@ -9577,13 +9866,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3206 "SchemaEntity201909.tt"
+        #line 3287 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3207 "SchemaEntity201909.tt"
+        #line 3288 "SchemaEntity201909.tt"
 
         foreach(var patternProperty in PatternProperties)
         {
@@ -9592,122 +9881,122 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3211 "SchemaEntity201909.tt"
+        #line 3292 "SchemaEntity201909.tt"
         this.Write("        /// <summary>\r\n        /// Determines if a property matches ");
         
         #line default
         #line hidden
         
-        #line 3212 "SchemaEntity201909.tt"
+        #line 3293 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                Formatting.FormatLiteralOrNull(patternProperty.Pattern, true).Trim('"')));
         
         #line default
         #line hidden
         
-        #line 3212 "SchemaEntity201909.tt"
+        #line 3293 "SchemaEntity201909.tt"
         this.Write(" producing a <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 3212 "SchemaEntity201909.tt"
+        #line 3293 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3212 "SchemaEntity201909.tt"
+        #line 3293 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public bool MatchesPattern");
         
         #line default
         #line hidden
         
-        #line 3214 "SchemaEntity201909.tt"
+        #line 3295 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3214 "SchemaEntity201909.tt"
+        #line 3295 "SchemaEntity201909.tt"
         this.Write("(in Property property)\r\n        {\r\n            return PatternProperty");
         
         #line default
         #line hidden
         
-        #line 3216 "SchemaEntity201909.tt"
+        #line 3297 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3216 "SchemaEntity201909.tt"
+        #line 3297 "SchemaEntity201909.tt"
         this.Write(".IsMatch(property.Name);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Get a p" +
                 "roperty as the matching property type ");
         
         #line default
         #line hidden
         
-        #line 3220 "SchemaEntity201909.tt"
+        #line 3301 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                Formatting.FormatLiteralOrNull(patternProperty.Pattern, true).Trim('"')));
         
         #line default
         #line hidden
         
-        #line 3220 "SchemaEntity201909.tt"
+        #line 3301 "SchemaEntity201909.tt"
         this.Write(" as a <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 3220 "SchemaEntity201909.tt"
+        #line 3301 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3220 "SchemaEntity201909.tt"
+        #line 3301 "SchemaEntity201909.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 3222 "SchemaEntity201909.tt"
+        #line 3303 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3222 "SchemaEntity201909.tt"
+        #line 3303 "SchemaEntity201909.tt"
         this.Write(" AsPattern");
         
         #line default
         #line hidden
         
-        #line 3222 "SchemaEntity201909.tt"
+        #line 3303 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3222 "SchemaEntity201909.tt"
+        #line 3303 "SchemaEntity201909.tt"
         this.Write("(in Property property)\r\n        {\r\n            return property.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 3224 "SchemaEntity201909.tt"
+        #line 3305 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3224 "SchemaEntity201909.tt"
+        #line 3305 "SchemaEntity201909.tt"
         this.Write(">();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3227 "SchemaEntity201909.tt"
+        #line 3308 "SchemaEntity201909.tt"
 
         }
         
@@ -9715,13 +10004,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3230 "SchemaEntity201909.tt"
+        #line 3311 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 3230 "SchemaEntity201909.tt"
+        #line 3311 "SchemaEntity201909.tt"
 
     }
     
@@ -9729,7 +10018,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3233 "SchemaEntity201909.tt"
+        #line 3314 "SchemaEntity201909.tt"
         this.Write(@"
         /// <inheritdoc/>
         public ValidationContext Validate(in ValidationContext? validationContext = null, ValidationLevel level = ValidationLevel.Flag)
@@ -9746,7 +10035,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3244 "SchemaEntity201909.tt"
+        #line 3325 "SchemaEntity201909.tt"
 
         if (HasAdditionalProperties || HasUnevaluatedProperties)
         {
@@ -9755,13 +10044,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3248 "SchemaEntity201909.tt"
+        #line 3329 "SchemaEntity201909.tt"
         this.Write("            result = result.UsingEvaluatedProperties();\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3249 "SchemaEntity201909.tt"
+        #line 3330 "SchemaEntity201909.tt"
 
         }
         
@@ -9769,13 +10058,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3252 "SchemaEntity201909.tt"
+        #line 3333 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3253 "SchemaEntity201909.tt"
+        #line 3334 "SchemaEntity201909.tt"
 
         if (HasAdditionalItems || HasUnevaluatedItems)
         {
@@ -9784,13 +10073,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3257 "SchemaEntity201909.tt"
+        #line 3338 "SchemaEntity201909.tt"
         this.Write("            result = result.UsingEvaluatedItems();\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3258 "SchemaEntity201909.tt"
+        #line 3339 "SchemaEntity201909.tt"
 
         }
         
@@ -9798,13 +10087,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3261 "SchemaEntity201909.tt"
+        #line 3342 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3262 "SchemaEntity201909.tt"
+        #line 3343 "SchemaEntity201909.tt"
 
     if (HasRef)
     {    
@@ -9813,7 +10102,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3266 "SchemaEntity201909.tt"
+        #line 3347 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateRef(result, level);\r\n            if (level == V" +
                 "alidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return r" +
                 "esult;\r\n            }\r\n    ");
@@ -9821,7 +10110,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3271 "SchemaEntity201909.tt"
+        #line 3352 "SchemaEntity201909.tt"
 
     }
     
@@ -9829,13 +10118,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3274 "SchemaEntity201909.tt"
+        #line 3355 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3275 "SchemaEntity201909.tt"
+        #line 3356 "SchemaEntity201909.tt"
 
     if ((HasExplicitType || HasFormat || HasMediaTypeOrEncoding) || (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasAdditionalItems) || (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties || HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)))))
     {
@@ -9844,13 +10133,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3279 "SchemaEntity201909.tt"
+        #line 3360 "SchemaEntity201909.tt"
         this.Write("            JsonValueKind valueKind = this.ValueKind;\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3280 "SchemaEntity201909.tt"
+        #line 3361 "SchemaEntity201909.tt"
 
     }
     
@@ -9858,13 +10147,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3283 "SchemaEntity201909.tt"
+        #line 3364 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3284 "SchemaEntity201909.tt"
+        #line 3365 "SchemaEntity201909.tt"
 
     if (HasExplicitType || HasFormat || HasMediaTypeOrEncoding)
     {
@@ -9873,13 +10162,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3288 "SchemaEntity201909.tt"
+        #line 3369 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3289 "SchemaEntity201909.tt"
+        #line 3370 "SchemaEntity201909.tt"
 
         if (HasExplicitType)
         {
@@ -9888,7 +10177,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3293 "SchemaEntity201909.tt"
+        #line 3374 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateType(valueKind, result, level);\r\n            if" +
                 " (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n            " +
                 "    return result;\r\n            }\r\n        ");
@@ -9896,7 +10185,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3298 "SchemaEntity201909.tt"
+        #line 3379 "SchemaEntity201909.tt"
 
         }
         
@@ -9904,13 +10193,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3301 "SchemaEntity201909.tt"
+        #line 3382 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3302 "SchemaEntity201909.tt"
+        #line 3383 "SchemaEntity201909.tt"
 
         if (HasFormat)
         {
@@ -9919,231 +10208,10 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3306 "SchemaEntity201909.tt"
+        #line 3387 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateFormat(valueKind, result, level);\r\n            " +
                 "if (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n          " +
                 "      return result;\r\n            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3311 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3314 "SchemaEntity201909.tt"
-        this.Write("\r\n        \r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3316 "SchemaEntity201909.tt"
-
-        if (HasMediaTypeOrEncoding)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3320 "SchemaEntity201909.tt"
-        this.Write("            result = this.ValidateMediaTypeAndEncoding(valueKind, result, level);" +
-                "\r\n            if (level == ValidationLevel.Flag && !result.IsValid)\r\n           " +
-                " {\r\n                return result;\r\n            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3325 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3328 "SchemaEntity201909.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3329 "SchemaEntity201909.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3332 "SchemaEntity201909.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3333 "SchemaEntity201909.tt"
-
-    if (HasConst)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3337 "SchemaEntity201909.tt"
-        this.Write("            result = Corvus.Json.Validate.ValidateConst(this, result, level, __Co" +
-                "rvusConstValue);\r\n            if (level == ValidationLevel.Flag && !result.IsVal" +
-                "id)\r\n            {\r\n                return result;\r\n            }\r\n\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3343 "SchemaEntity201909.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3346 "SchemaEntity201909.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3347 "SchemaEntity201909.tt"
-
-    if (HasEnum)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3351 "SchemaEntity201909.tt"
-        this.Write("            result = Corvus.Json.Validate.ValidateEnum(\r\n                this,\r\n " +
-                "               result,\r\n                level\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3355 "SchemaEntity201909.tt"
-
-        for(int enumIndex = 0; enumIndex < EnumValues.Length; ++enumIndex)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3359 "SchemaEntity201909.tt"
-        this.Write("                , EnumValues.Item");
-        
-        #line default
-        #line hidden
-        
-        #line 3359 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( enumIndex ));
-        
-        #line default
-        #line hidden
-        
-        #line 3359 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3360 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3363 "SchemaEntity201909.tt"
-        this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
-                "Valid)\r\n            {\r\n                return result;\r\n            }\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3369 "SchemaEntity201909.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3372 "SchemaEntity201909.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3373 "SchemaEntity201909.tt"
-
-    if (HasMultipleOf || HasMaximum || HasExclusiveMaximum|| HasMinimum || HasExclusiveMinimum)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3377 "SchemaEntity201909.tt"
-        this.Write("            result = Corvus.Json.Validate.ValidateNumber(\r\n                this,\r" +
-                "\n                result,\r\n                level,\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3381 "SchemaEntity201909.tt"
-
-        if (HasMultipleOf)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3385 "SchemaEntity201909.tt"
-        this.Write("                ");
-        
-        #line default
-        #line hidden
-        
-        #line 3385 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( MultipleOf ));
-        
-        #line default
-        #line hidden
-        
-        #line 3385 "SchemaEntity201909.tt"
-        this.Write(",\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3386 "SchemaEntity201909.tt"
-
-        }
-        else
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3391 "SchemaEntity201909.tt"
-        this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
@@ -10157,50 +10225,24 @@ namespace ");
         #line hidden
         
         #line 3395 "SchemaEntity201909.tt"
-        this.Write("        ");
+        this.Write("\r\n        \r\n        ");
         
         #line default
         #line hidden
         
-        #line 3395 "SchemaEntity201909.tt"
+        #line 3397 "SchemaEntity201909.tt"
 
-        if (HasMaximum)
+        if (HasMediaTypeOrEncoding)
         {
         
         
         #line default
         #line hidden
         
-        #line 3399 "SchemaEntity201909.tt"
-        this.Write("                 ");
-        
-        #line default
-        #line hidden
-        
-        #line 3399 "SchemaEntity201909.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( Maximum ));
-        
-        #line default
-        #line hidden
-        
-        #line 3399 "SchemaEntity201909.tt"
-        this.Write(",\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3400 "SchemaEntity201909.tt"
-
-        }
-        else
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3405 "SchemaEntity201909.tt"
-        this.Write("                null,\r\n        ");
+        #line 3401 "SchemaEntity201909.tt"
+        this.Write("            result = this.ValidateMediaTypeAndEncoding(valueKind, result, level);" +
+                "\r\n            if (level == ValidationLevel.Flag && !result.IsValid)\r\n           " +
+                " {\r\n                return result;\r\n            }\r\n        ");
         
         #line default
         #line hidden
@@ -10214,12 +10256,259 @@ namespace ");
         #line hidden
         
         #line 3409 "SchemaEntity201909.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3410 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3413 "SchemaEntity201909.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3414 "SchemaEntity201909.tt"
+
+    if (HasConst)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3418 "SchemaEntity201909.tt"
+        this.Write("            result = Corvus.Json.Validate.ValidateConst(this, result, level, __Co" +
+                "rvusConstValue);\r\n            if (level == ValidationLevel.Flag && !result.IsVal" +
+                "id)\r\n            {\r\n                return result;\r\n            }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3424 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3427 "SchemaEntity201909.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3428 "SchemaEntity201909.tt"
+
+    if (HasEnum)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3432 "SchemaEntity201909.tt"
+        this.Write("            result = Corvus.Json.Validate.ValidateEnum(\r\n                this,\r\n " +
+                "               result,\r\n                level\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3436 "SchemaEntity201909.tt"
+
+        for(int enumIndex = 0; enumIndex < EnumValues.Length; ++enumIndex)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3440 "SchemaEntity201909.tt"
+        this.Write("                , EnumValues.Item");
+        
+        #line default
+        #line hidden
+        
+        #line 3440 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( enumIndex ));
+        
+        #line default
+        #line hidden
+        
+        #line 3440 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3441 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3444 "SchemaEntity201909.tt"
+        this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
+                "Valid)\r\n            {\r\n                return result;\r\n            }\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3450 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3453 "SchemaEntity201909.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3454 "SchemaEntity201909.tt"
+
+    if (HasMultipleOf || HasMaximum || HasExclusiveMaximum|| HasMinimum || HasExclusiveMinimum)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3458 "SchemaEntity201909.tt"
+        this.Write("            result = Corvus.Json.Validate.ValidateNumber(\r\n                this,\r" +
+                "\n                result,\r\n                level,\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3462 "SchemaEntity201909.tt"
+
+        if (HasMultipleOf)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3466 "SchemaEntity201909.tt"
+        this.Write("                ");
+        
+        #line default
+        #line hidden
+        
+        #line 3466 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( MultipleOf ));
+        
+        #line default
+        #line hidden
+        
+        #line 3466 "SchemaEntity201909.tt"
+        this.Write(",\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3467 "SchemaEntity201909.tt"
+
+        }
+        else
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3472 "SchemaEntity201909.tt"
+        this.Write("                null,\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3473 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3476 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3409 "SchemaEntity201909.tt"
+        #line 3476 "SchemaEntity201909.tt"
+
+        if (HasMaximum)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3480 "SchemaEntity201909.tt"
+        this.Write("                 ");
+        
+        #line default
+        #line hidden
+        
+        #line 3480 "SchemaEntity201909.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( Maximum ));
+        
+        #line default
+        #line hidden
+        
+        #line 3480 "SchemaEntity201909.tt"
+        this.Write(",\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3481 "SchemaEntity201909.tt"
+
+        }
+        else
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3486 "SchemaEntity201909.tt"
+        this.Write("                null,\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3487 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3490 "SchemaEntity201909.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3490 "SchemaEntity201909.tt"
 
         if (HasExclusiveMaximum)
         {
@@ -10228,25 +10517,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3413 "SchemaEntity201909.tt"
+        #line 3494 "SchemaEntity201909.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3413 "SchemaEntity201909.tt"
+        #line 3494 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ExclusiveMaximum ));
         
         #line default
         #line hidden
         
-        #line 3413 "SchemaEntity201909.tt"
+        #line 3494 "SchemaEntity201909.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3414 "SchemaEntity201909.tt"
+        #line 3495 "SchemaEntity201909.tt"
 
         }
         else
@@ -10256,13 +10545,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3419 "SchemaEntity201909.tt"
+        #line 3500 "SchemaEntity201909.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3420 "SchemaEntity201909.tt"
+        #line 3501 "SchemaEntity201909.tt"
 
         }
         
@@ -10270,13 +10559,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3423 "SchemaEntity201909.tt"
+        #line 3504 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3423 "SchemaEntity201909.tt"
+        #line 3504 "SchemaEntity201909.tt"
 
         if (HasMinimum)
         {
@@ -10285,25 +10574,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3427 "SchemaEntity201909.tt"
+        #line 3508 "SchemaEntity201909.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3427 "SchemaEntity201909.tt"
+        #line 3508 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Minimum ));
         
         #line default
         #line hidden
         
-        #line 3427 "SchemaEntity201909.tt"
+        #line 3508 "SchemaEntity201909.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3428 "SchemaEntity201909.tt"
+        #line 3509 "SchemaEntity201909.tt"
 
         }
         else
@@ -10313,13 +10602,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3433 "SchemaEntity201909.tt"
+        #line 3514 "SchemaEntity201909.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3434 "SchemaEntity201909.tt"
+        #line 3515 "SchemaEntity201909.tt"
 
         }
         
@@ -10327,13 +10616,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3437 "SchemaEntity201909.tt"
+        #line 3518 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3437 "SchemaEntity201909.tt"
+        #line 3518 "SchemaEntity201909.tt"
 
         if (HasExclusiveMinimum)
         {
@@ -10342,25 +10631,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3441 "SchemaEntity201909.tt"
+        #line 3522 "SchemaEntity201909.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3441 "SchemaEntity201909.tt"
+        #line 3522 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ExclusiveMinimum ));
         
         #line default
         #line hidden
         
-        #line 3441 "SchemaEntity201909.tt"
+        #line 3522 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3442 "SchemaEntity201909.tt"
+        #line 3523 "SchemaEntity201909.tt"
 
         }
         else
@@ -10370,13 +10659,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3447 "SchemaEntity201909.tt"
+        #line 3528 "SchemaEntity201909.tt"
         this.Write("                null\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3448 "SchemaEntity201909.tt"
+        #line 3529 "SchemaEntity201909.tt"
 
         }
         
@@ -10384,14 +10673,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3451 "SchemaEntity201909.tt"
+        #line 3532 "SchemaEntity201909.tt"
         this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
                 "Valid)\r\n            {\r\n                return result;\r\n            }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3458 "SchemaEntity201909.tt"
+        #line 3539 "SchemaEntity201909.tt"
 
     }
     
@@ -10399,13 +10688,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3461 "SchemaEntity201909.tt"
+        #line 3542 "SchemaEntity201909.tt"
         this.Write("    \r\n    ");
         
         #line default
         #line hidden
         
-        #line 3462 "SchemaEntity201909.tt"
+        #line 3543 "SchemaEntity201909.tt"
 
     if (HasMaxLength || HasMinLength || HasPattern)
     {
@@ -10414,14 +10703,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3466 "SchemaEntity201909.tt"
+        #line 3547 "SchemaEntity201909.tt"
         this.Write("            result = Corvus.Json.Validate.ValidateString(\r\n                this,\r" +
                 "\n                result,\r\n                level,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3470 "SchemaEntity201909.tt"
+        #line 3551 "SchemaEntity201909.tt"
 
         if (HasMaxLength)
         {
@@ -10430,25 +10719,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3474 "SchemaEntity201909.tt"
+        #line 3555 "SchemaEntity201909.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3474 "SchemaEntity201909.tt"
+        #line 3555 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxLength ));
         
         #line default
         #line hidden
         
-        #line 3474 "SchemaEntity201909.tt"
+        #line 3555 "SchemaEntity201909.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3475 "SchemaEntity201909.tt"
+        #line 3556 "SchemaEntity201909.tt"
 
         }
         else
@@ -10458,13 +10747,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3480 "SchemaEntity201909.tt"
+        #line 3561 "SchemaEntity201909.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3481 "SchemaEntity201909.tt"
+        #line 3562 "SchemaEntity201909.tt"
 
         }
         
@@ -10472,13 +10761,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3484 "SchemaEntity201909.tt"
+        #line 3565 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3484 "SchemaEntity201909.tt"
+        #line 3565 "SchemaEntity201909.tt"
 
         if (HasMinLength)
         {
@@ -10487,25 +10776,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3488 "SchemaEntity201909.tt"
+        #line 3569 "SchemaEntity201909.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3488 "SchemaEntity201909.tt"
+        #line 3569 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinLength ));
         
         #line default
         #line hidden
         
-        #line 3488 "SchemaEntity201909.tt"
+        #line 3569 "SchemaEntity201909.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3489 "SchemaEntity201909.tt"
+        #line 3570 "SchemaEntity201909.tt"
 
         }
         else
@@ -10515,13 +10804,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3494 "SchemaEntity201909.tt"
+        #line 3575 "SchemaEntity201909.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3495 "SchemaEntity201909.tt"
+        #line 3576 "SchemaEntity201909.tt"
 
         }
         
@@ -10529,13 +10818,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3498 "SchemaEntity201909.tt"
+        #line 3579 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3498 "SchemaEntity201909.tt"
+        #line 3579 "SchemaEntity201909.tt"
 
         if (HasPattern)
         {
@@ -10544,13 +10833,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3502 "SchemaEntity201909.tt"
+        #line 3583 "SchemaEntity201909.tt"
         this.Write("                __CorvusPatternExpression\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3503 "SchemaEntity201909.tt"
+        #line 3584 "SchemaEntity201909.tt"
 
         }
         else
@@ -10560,13 +10849,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3508 "SchemaEntity201909.tt"
+        #line 3589 "SchemaEntity201909.tt"
         this.Write("                null\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3509 "SchemaEntity201909.tt"
+        #line 3590 "SchemaEntity201909.tt"
 
         }
         
@@ -10574,14 +10863,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3512 "SchemaEntity201909.tt"
+        #line 3593 "SchemaEntity201909.tt"
         this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
                 "Valid)\r\n            {\r\n                return result;\r\n            }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3518 "SchemaEntity201909.tt"
+        #line 3599 "SchemaEntity201909.tt"
 
     }
     
@@ -10589,13 +10878,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3521 "SchemaEntity201909.tt"
+        #line 3602 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3522 "SchemaEntity201909.tt"
+        #line 3603 "SchemaEntity201909.tt"
 
     if (HasIfThenElse)
     {
@@ -10604,7 +10893,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3526 "SchemaEntity201909.tt"
+        #line 3607 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateIfThenElse(result, level);\r\n            if (lev" +
                 "el == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                r" +
                 "eturn result;\r\n            }\r\n\r\n    ");
@@ -10612,7 +10901,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3532 "SchemaEntity201909.tt"
+        #line 3613 "SchemaEntity201909.tt"
 
     }
     
@@ -10620,13 +10909,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3535 "SchemaEntity201909.tt"
+        #line 3616 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3536 "SchemaEntity201909.tt"
+        #line 3617 "SchemaEntity201909.tt"
 
     if (HasNot)
     {
@@ -10635,7 +10924,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3540 "SchemaEntity201909.tt"
+        #line 3621 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateNot(result, level);\r\n            if (level == V" +
                 "alidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return r" +
                 "esult;\r\n            }\r\n\r\n    ");
@@ -10643,7 +10932,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3546 "SchemaEntity201909.tt"
+        #line 3627 "SchemaEntity201909.tt"
 
     }
     
@@ -10651,13 +10940,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3549 "SchemaEntity201909.tt"
+        #line 3630 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3550 "SchemaEntity201909.tt"
+        #line 3631 "SchemaEntity201909.tt"
 
     if (HasAllOf)
     {
@@ -10666,7 +10955,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3554 "SchemaEntity201909.tt"
+        #line 3635 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateAllOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n    ");
@@ -10674,7 +10963,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3559 "SchemaEntity201909.tt"
+        #line 3640 "SchemaEntity201909.tt"
 
     }
     
@@ -10682,13 +10971,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3562 "SchemaEntity201909.tt"
+        #line 3643 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3563 "SchemaEntity201909.tt"
+        #line 3644 "SchemaEntity201909.tt"
 
     if (HasAnyOf)
     {
@@ -10697,7 +10986,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3567 "SchemaEntity201909.tt"
+        #line 3648 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateAnyOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n    ");
@@ -10705,7 +10994,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3572 "SchemaEntity201909.tt"
+        #line 3653 "SchemaEntity201909.tt"
 
     }
     
@@ -10713,13 +11002,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3575 "SchemaEntity201909.tt"
+        #line 3656 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3576 "SchemaEntity201909.tt"
+        #line 3657 "SchemaEntity201909.tt"
 
     if (HasOneOf)
     {
@@ -10728,7 +11017,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3580 "SchemaEntity201909.tt"
+        #line 3661 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateOneOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n\r\n    ");
@@ -10736,7 +11025,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3586 "SchemaEntity201909.tt"
+        #line 3667 "SchemaEntity201909.tt"
 
     }
     
@@ -10744,13 +11033,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3589 "SchemaEntity201909.tt"
+        #line 3670 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3590 "SchemaEntity201909.tt"
+        #line 3671 "SchemaEntity201909.tt"
 
     if (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties || HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)) || !AllowsAdditionalProperties))
     {
@@ -10759,7 +11048,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3594 "SchemaEntity201909.tt"
+        #line 3675 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateObject(valueKind, result, level);\r\n            " +
                 "if (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n          " +
                 "      return result;\r\n            }\r\n\r\n    ");
@@ -10767,7 +11056,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3600 "SchemaEntity201909.tt"
+        #line 3681 "SchemaEntity201909.tt"
 
     }
     
@@ -10775,13 +11064,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3603 "SchemaEntity201909.tt"
+        #line 3684 "SchemaEntity201909.tt"
         this.Write("\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3605 "SchemaEntity201909.tt"
+        #line 3686 "SchemaEntity201909.tt"
 
     if (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasAdditionalItems)
     {
@@ -10790,7 +11079,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3609 "SchemaEntity201909.tt"
+        #line 3690 "SchemaEntity201909.tt"
         this.Write("            result = this.ValidateArray(valueKind, result, level);\r\n            i" +
                 "f (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n           " +
                 "     return result;\r\n            }\r\n    ");
@@ -10798,7 +11087,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3614 "SchemaEntity201909.tt"
+        #line 3695 "SchemaEntity201909.tt"
 
     }
     
@@ -10806,13 +11095,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3617 "SchemaEntity201909.tt"
+        #line 3698 "SchemaEntity201909.tt"
         this.Write("            return result;\r\n        }\r\n\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3621 "SchemaEntity201909.tt"
+        #line 3702 "SchemaEntity201909.tt"
 
     if (HasPatternProperties)
     {
@@ -10821,7 +11110,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3625 "SchemaEntity201909.tt"
+        #line 3706 "SchemaEntity201909.tt"
         this.Write(@"        private static ImmutableDictionary<Regex, PatternPropertyValidator> CreatePatternPropertiesValidators()
         {
             ImmutableDictionary<Regex, PatternPropertyValidator>.Builder builder =
@@ -10832,7 +11121,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3630 "SchemaEntity201909.tt"
+        #line 3711 "SchemaEntity201909.tt"
 
         foreach (var patternProperty in PatternProperties)
         {
@@ -10841,37 +11130,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3634 "SchemaEntity201909.tt"
+        #line 3715 "SchemaEntity201909.tt"
         this.Write("            builder.Add(\r\n                PatternProperty");
         
         #line default
         #line hidden
         
-        #line 3635 "SchemaEntity201909.tt"
+        #line 3716 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3635 "SchemaEntity201909.tt"
+        #line 3716 "SchemaEntity201909.tt"
         this.Write(", __CorvusValidatePatternProperty");
         
         #line default
         #line hidden
         
-        #line 3635 "SchemaEntity201909.tt"
+        #line 3716 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3635 "SchemaEntity201909.tt"
+        #line 3716 "SchemaEntity201909.tt"
         this.Write(");\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3636 "SchemaEntity201909.tt"
+        #line 3717 "SchemaEntity201909.tt"
 
         }
         
@@ -10879,13 +11168,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3639 "SchemaEntity201909.tt"
+        #line 3720 "SchemaEntity201909.tt"
         this.Write("\r\n            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3643 "SchemaEntity201909.tt"
+        #line 3724 "SchemaEntity201909.tt"
 
         foreach (var patternProperty in PatternProperties)
         {
@@ -10894,38 +11183,38 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3647 "SchemaEntity201909.tt"
+        #line 3728 "SchemaEntity201909.tt"
         this.Write("        private static ValidationContext __CorvusValidatePatternProperty");
         
         #line default
         #line hidden
         
-        #line 3647 "SchemaEntity201909.tt"
+        #line 3728 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3647 "SchemaEntity201909.tt"
+        #line 3728 "SchemaEntity201909.tt"
         this.Write("(in Property that, in ValidationContext validationContext, ValidationLevel level)" +
                 "\r\n        {\r\n            return that.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 3649 "SchemaEntity201909.tt"
+        #line 3730 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3649 "SchemaEntity201909.tt"
+        #line 3730 "SchemaEntity201909.tt"
         this.Write(">().Validate(validationContext, level);\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3651 "SchemaEntity201909.tt"
+        #line 3732 "SchemaEntity201909.tt"
 
         }
         
@@ -10933,13 +11222,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3654 "SchemaEntity201909.tt"
+        #line 3735 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3655 "SchemaEntity201909.tt"
+        #line 3736 "SchemaEntity201909.tt"
 
     }
     
@@ -10947,13 +11236,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3658 "SchemaEntity201909.tt"
+        #line 3739 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3659 "SchemaEntity201909.tt"
+        #line 3740 "SchemaEntity201909.tt"
 
     if (HasDependentSchemas)
     {
@@ -10962,51 +11251,51 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3663 "SchemaEntity201909.tt"
+        #line 3744 "SchemaEntity201909.tt"
         this.Write("\r\n        private static ImmutableDictionary<string, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3664 "SchemaEntity201909.tt"
+        #line 3745 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3664 "SchemaEntity201909.tt"
+        #line 3745 "SchemaEntity201909.tt"
         this.Write(">> CreateDependentSchemaValidators()\r\n        {\r\n            ImmutableDictionary<" +
                 "string, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3666 "SchemaEntity201909.tt"
+        #line 3747 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3666 "SchemaEntity201909.tt"
+        #line 3747 "SchemaEntity201909.tt"
         this.Write(">>.Builder builder =\r\n                ImmutableDictionary.CreateBuilder<string, P" +
                 "ropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3667 "SchemaEntity201909.tt"
+        #line 3748 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3667 "SchemaEntity201909.tt"
+        #line 3748 "SchemaEntity201909.tt"
         this.Write(">>();\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3669 "SchemaEntity201909.tt"
+        #line 3750 "SchemaEntity201909.tt"
 
         int dsIndex = 0;
         foreach (var dependentSchema in DependentSchemas)
@@ -11017,37 +11306,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3675 "SchemaEntity201909.tt"
+        #line 3756 "SchemaEntity201909.tt"
         this.Write("            builder.Add(\r\n                \"");
         
         #line default
         #line hidden
         
-        #line 3676 "SchemaEntity201909.tt"
+        #line 3757 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dependentSchema.Name ));
         
         #line default
         #line hidden
         
-        #line 3676 "SchemaEntity201909.tt"
+        #line 3757 "SchemaEntity201909.tt"
         this.Write("\", __CorvusValidateDependentSchema");
         
         #line default
         #line hidden
         
-        #line 3676 "SchemaEntity201909.tt"
+        #line 3757 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dsIndex ));
         
         #line default
         #line hidden
         
-        #line 3676 "SchemaEntity201909.tt"
+        #line 3757 "SchemaEntity201909.tt"
         this.Write(");\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3678 "SchemaEntity201909.tt"
+        #line 3759 "SchemaEntity201909.tt"
 
         }
         
@@ -11055,13 +11344,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3681 "SchemaEntity201909.tt"
+        #line 3762 "SchemaEntity201909.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3684 "SchemaEntity201909.tt"
+        #line 3765 "SchemaEntity201909.tt"
 
         int dsIndexV = 0;
         foreach (var dependentSchema in DependentSchemas)
@@ -11072,50 +11361,50 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3690 "SchemaEntity201909.tt"
+        #line 3771 "SchemaEntity201909.tt"
         this.Write("        private static ValidationContext __CorvusValidateDependentSchema");
         
         #line default
         #line hidden
         
-        #line 3690 "SchemaEntity201909.tt"
+        #line 3771 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dsIndexV ));
         
         #line default
         #line hidden
         
-        #line 3690 "SchemaEntity201909.tt"
+        #line 3771 "SchemaEntity201909.tt"
         this.Write("(in ");
         
         #line default
         #line hidden
         
-        #line 3690 "SchemaEntity201909.tt"
+        #line 3771 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3690 "SchemaEntity201909.tt"
+        #line 3771 "SchemaEntity201909.tt"
         this.Write(" that, in ValidationContext validationContext, ValidationLevel level)\r\n        {\r" +
                 "\n            return that.As<");
         
         #line default
         #line hidden
         
-        #line 3692 "SchemaEntity201909.tt"
+        #line 3773 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dependentSchema.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3692 "SchemaEntity201909.tt"
+        #line 3773 "SchemaEntity201909.tt"
         this.Write(">().Validate(validationContext, level);\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3694 "SchemaEntity201909.tt"
+        #line 3775 "SchemaEntity201909.tt"
 
         }
         
@@ -11123,13 +11412,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3697 "SchemaEntity201909.tt"
+        #line 3778 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3698 "SchemaEntity201909.tt"
+        #line 3779 "SchemaEntity201909.tt"
 
     }
     
@@ -11137,13 +11426,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3701 "SchemaEntity201909.tt"
+        #line 3782 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3702 "SchemaEntity201909.tt"
+        #line 3783 "SchemaEntity201909.tt"
 
     if (HasDefaults)
     {
@@ -11152,7 +11441,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3706 "SchemaEntity201909.tt"
+        #line 3787 "SchemaEntity201909.tt"
         this.Write("        private static ImmutableDictionary<string, JsonAny> BuildDefaults()\r\n    " +
                 "    {\r\n            ImmutableDictionary<string, JsonAny>.Builder builder =\r\n     " +
                 "           ImmutableDictionary.CreateBuilder<string, JsonAny>();\r\n\r\n        ");
@@ -11160,7 +11449,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3711 "SchemaEntity201909.tt"
+        #line 3792 "SchemaEntity201909.tt"
 
         foreach (var property in Defaults)
         {
@@ -11169,37 +11458,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3715 "SchemaEntity201909.tt"
+        #line 3796 "SchemaEntity201909.tt"
         this.Write("            builder.Add(");
         
         #line default
         #line hidden
         
-        #line 3715 "SchemaEntity201909.tt"
+        #line 3796 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3715 "SchemaEntity201909.tt"
+        #line 3796 "SchemaEntity201909.tt"
         this.Write("JsonPropertyName, JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 3715 "SchemaEntity201909.tt"
+        #line 3796 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(property.DefaultValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3715 "SchemaEntity201909.tt"
+        #line 3796 "SchemaEntity201909.tt"
         this.Write("));\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3716 "SchemaEntity201909.tt"
+        #line 3797 "SchemaEntity201909.tt"
 
         }
         
@@ -11207,13 +11496,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3719 "SchemaEntity201909.tt"
+        #line 3800 "SchemaEntity201909.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3721 "SchemaEntity201909.tt"
+        #line 3802 "SchemaEntity201909.tt"
 
     }
     
@@ -11221,13 +11510,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3724 "SchemaEntity201909.tt"
+        #line 3805 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3725 "SchemaEntity201909.tt"
+        #line 3806 "SchemaEntity201909.tt"
 
     if (HasDependentRequired)
     {
@@ -11236,7 +11525,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3729 "SchemaEntity201909.tt"
+        #line 3810 "SchemaEntity201909.tt"
         this.Write(@"
         private static ImmutableDictionary<string, ImmutableArray<ReadOnlyMemory<byte>>> BuildDependentRequired()
         {
@@ -11248,7 +11537,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3735 "SchemaEntity201909.tt"
+        #line 3816 "SchemaEntity201909.tt"
 
         foreach (var dependentRequired in DependentRequired)
         {
@@ -11257,26 +11546,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3739 "SchemaEntity201909.tt"
+        #line 3820 "SchemaEntity201909.tt"
         this.Write("            builder.Add(\r\n                    ");
         
         #line default
         #line hidden
         
-        #line 3740 "SchemaEntity201909.tt"
+        #line 3821 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(dependentRequired.Name, true) ));
         
         #line default
         #line hidden
         
-        #line 3740 "SchemaEntity201909.tt"
+        #line 3821 "SchemaEntity201909.tt"
         this.Write(",\r\n                    ImmutableArray.Create<ReadOnlyMemory<byte>>(\r\n            " +
                 "");
         
         #line default
         #line hidden
         
-        #line 3742 "SchemaEntity201909.tt"
+        #line 3823 "SchemaEntity201909.tt"
 
             bool isFirst1 = true;
             foreach (var dependentRequiredValue in dependentRequired.RequiredNames)
@@ -11286,13 +11575,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3747 "SchemaEntity201909.tt"
+        #line 3828 "SchemaEntity201909.tt"
         this.Write("                ");
         
         #line default
         #line hidden
         
-        #line 3747 "SchemaEntity201909.tt"
+        #line 3828 "SchemaEntity201909.tt"
 
                 if (isFirst1)
                 {
@@ -11302,25 +11591,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3752 "SchemaEntity201909.tt"
+        #line 3833 "SchemaEntity201909.tt"
         this.Write("                        System.Text.Encoding.UTF8.GetBytes(");
         
         #line default
         #line hidden
         
-        #line 3752 "SchemaEntity201909.tt"
+        #line 3833 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  Formatting.FormatLiteralOrNull(dependentRequiredValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3752 "SchemaEntity201909.tt"
+        #line 3833 "SchemaEntity201909.tt"
         this.Write(").AsMemory()\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3753 "SchemaEntity201909.tt"
+        #line 3834 "SchemaEntity201909.tt"
 
                 }
                 else
@@ -11330,25 +11619,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3758 "SchemaEntity201909.tt"
+        #line 3839 "SchemaEntity201909.tt"
         this.Write("                        , System.Text.Encoding.UTF8.GetBytes(");
         
         #line default
         #line hidden
         
-        #line 3758 "SchemaEntity201909.tt"
+        #line 3839 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  Formatting.FormatLiteralOrNull(dependentRequiredValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3758 "SchemaEntity201909.tt"
+        #line 3839 "SchemaEntity201909.tt"
         this.Write(").AsMemory()\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3759 "SchemaEntity201909.tt"
+        #line 3840 "SchemaEntity201909.tt"
 
                 }
                 
@@ -11356,13 +11645,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3762 "SchemaEntity201909.tt"
+        #line 3843 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 3762 "SchemaEntity201909.tt"
+        #line 3843 "SchemaEntity201909.tt"
 
             }
             
@@ -11370,13 +11659,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3765 "SchemaEntity201909.tt"
+        #line 3846 "SchemaEntity201909.tt"
         this.Write("                        ));\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3766 "SchemaEntity201909.tt"
+        #line 3847 "SchemaEntity201909.tt"
 
         }
         
@@ -11384,13 +11673,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3769 "SchemaEntity201909.tt"
+        #line 3850 "SchemaEntity201909.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3772 "SchemaEntity201909.tt"
+        #line 3853 "SchemaEntity201909.tt"
 
     }
     
@@ -11398,13 +11687,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3775 "SchemaEntity201909.tt"
+        #line 3856 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3776 "SchemaEntity201909.tt"
+        #line 3857 "SchemaEntity201909.tt"
 
     if (HasLocalProperties)
     {
@@ -11413,51 +11702,51 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3780 "SchemaEntity201909.tt"
+        #line 3861 "SchemaEntity201909.tt"
         this.Write("\r\n        private static ImmutableDictionary<string, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3781 "SchemaEntity201909.tt"
+        #line 3862 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3781 "SchemaEntity201909.tt"
+        #line 3862 "SchemaEntity201909.tt"
         this.Write(">> CreateLocalPropertyValidators()\r\n        {\r\n            ImmutableDictionary<st" +
                 "ring, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3783 "SchemaEntity201909.tt"
+        #line 3864 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3783 "SchemaEntity201909.tt"
+        #line 3864 "SchemaEntity201909.tt"
         this.Write(">>.Builder builder =\r\n                ImmutableDictionary.CreateBuilder<string, P" +
                 "ropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3784 "SchemaEntity201909.tt"
+        #line 3865 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3784 "SchemaEntity201909.tt"
+        #line 3865 "SchemaEntity201909.tt"
         this.Write(">>();\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3786 "SchemaEntity201909.tt"
+        #line 3867 "SchemaEntity201909.tt"
 
         foreach (var property in LocalProperties)
         {
@@ -11466,37 +11755,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3790 "SchemaEntity201909.tt"
+        #line 3871 "SchemaEntity201909.tt"
         this.Write("            builder.Add(\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3791 "SchemaEntity201909.tt"
+        #line 3872 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3791 "SchemaEntity201909.tt"
+        #line 3872 "SchemaEntity201909.tt"
         this.Write("JsonPropertyName, __CorvusValidate");
         
         #line default
         #line hidden
         
-        #line 3791 "SchemaEntity201909.tt"
+        #line 3872 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3791 "SchemaEntity201909.tt"
+        #line 3872 "SchemaEntity201909.tt"
         this.Write(");\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3792 "SchemaEntity201909.tt"
+        #line 3873 "SchemaEntity201909.tt"
 
         }
         
@@ -11504,13 +11793,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3795 "SchemaEntity201909.tt"
+        #line 3876 "SchemaEntity201909.tt"
         this.Write("\r\n            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3799 "SchemaEntity201909.tt"
+        #line 3880 "SchemaEntity201909.tt"
 
         foreach (var property in LocalProperties)
         {
@@ -11519,63 +11808,63 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3803 "SchemaEntity201909.tt"
+        #line 3884 "SchemaEntity201909.tt"
         this.Write("        private static ValidationContext __CorvusValidate");
         
         #line default
         #line hidden
         
-        #line 3803 "SchemaEntity201909.tt"
+        #line 3884 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3803 "SchemaEntity201909.tt"
+        #line 3884 "SchemaEntity201909.tt"
         this.Write("(in ");
         
         #line default
         #line hidden
         
-        #line 3803 "SchemaEntity201909.tt"
+        #line 3884 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3803 "SchemaEntity201909.tt"
+        #line 3884 "SchemaEntity201909.tt"
         this.Write(" that, in ValidationContext validationContext, ValidationLevel level)\r\n        {\r" +
                 "\n            ");
         
         #line default
         #line hidden
         
-        #line 3805 "SchemaEntity201909.tt"
+        #line 3886 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3805 "SchemaEntity201909.tt"
+        #line 3886 "SchemaEntity201909.tt"
         this.Write(" property = that.");
         
         #line default
         #line hidden
         
-        #line 3805 "SchemaEntity201909.tt"
+        #line 3886 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3805 "SchemaEntity201909.tt"
+        #line 3886 "SchemaEntity201909.tt"
         this.Write(";\r\n            return property.Validate(validationContext, level);\r\n        }\r\n  " +
                 "      ");
         
         #line default
         #line hidden
         
-        #line 3808 "SchemaEntity201909.tt"
+        #line 3889 "SchemaEntity201909.tt"
 
         }
         
@@ -11583,13 +11872,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3811 "SchemaEntity201909.tt"
+        #line 3892 "SchemaEntity201909.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 3811 "SchemaEntity201909.tt"
+        #line 3892 "SchemaEntity201909.tt"
 
     }
     
@@ -11597,13 +11886,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3814 "SchemaEntity201909.tt"
+        #line 3895 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3815 "SchemaEntity201909.tt"
+        #line 3896 "SchemaEntity201909.tt"
 
     if (IsImplicitObject)
     {
@@ -11612,7 +11901,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3819 "SchemaEntity201909.tt"
+        #line 3900 "SchemaEntity201909.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonObject""/>.
         /// </summary>
@@ -11633,7 +11922,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3834 "SchemaEntity201909.tt"
+        #line 3915 "SchemaEntity201909.tt"
 
     }
     
@@ -11641,13 +11930,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3837 "SchemaEntity201909.tt"
+        #line 3918 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3838 "SchemaEntity201909.tt"
+        #line 3919 "SchemaEntity201909.tt"
 
     if (IsImplicitArray)
     {
@@ -11656,7 +11945,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3842 "SchemaEntity201909.tt"
+        #line 3923 "SchemaEntity201909.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonArray""/>.
         /// </summary>
@@ -11677,7 +11966,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3857 "SchemaEntity201909.tt"
+        #line 3938 "SchemaEntity201909.tt"
 
     }
     
@@ -11685,13 +11974,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3860 "SchemaEntity201909.tt"
+        #line 3941 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3861 "SchemaEntity201909.tt"
+        #line 3942 "SchemaEntity201909.tt"
 
     if (IsImplicitNumber)
     {
@@ -11700,7 +11989,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3865 "SchemaEntity201909.tt"
+        #line 3946 "SchemaEntity201909.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonNumber""/>.
         /// </summary>
@@ -11721,7 +12010,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3880 "SchemaEntity201909.tt"
+        #line 3961 "SchemaEntity201909.tt"
 
     }
     
@@ -11729,13 +12018,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3883 "SchemaEntity201909.tt"
+        #line 3964 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3884 "SchemaEntity201909.tt"
+        #line 3965 "SchemaEntity201909.tt"
 
     if (IsImplicitString)
     {
@@ -11744,7 +12033,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3888 "SchemaEntity201909.tt"
+        #line 3969 "SchemaEntity201909.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonString""/>.
         /// </summary>
@@ -11765,7 +12054,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3903 "SchemaEntity201909.tt"
+        #line 3984 "SchemaEntity201909.tt"
 
     }
     
@@ -11773,13 +12062,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3906 "SchemaEntity201909.tt"
+        #line 3987 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3907 "SchemaEntity201909.tt"
+        #line 3988 "SchemaEntity201909.tt"
 
     if (IsImplicitBoolean)
     {
@@ -11788,7 +12077,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3911 "SchemaEntity201909.tt"
+        #line 3992 "SchemaEntity201909.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonBoolean""/>.
         /// </summary>
@@ -11808,7 +12097,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3925 "SchemaEntity201909.tt"
+        #line 4006 "SchemaEntity201909.tt"
 
     }
     
@@ -11816,13 +12105,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3928 "SchemaEntity201909.tt"
+        #line 4009 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3929 "SchemaEntity201909.tt"
+        #line 4010 "SchemaEntity201909.tt"
 
     if (HasRef)
     {
@@ -11831,7 +12120,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3933 "SchemaEntity201909.tt"
+        #line 4014 "SchemaEntity201909.tt"
         this.Write("        private ValidationContext ValidateRef(in ValidationContext validationCont" +
                 "ext, ValidationLevel level)\r\n        {\r\n            ValidationContext result = v" +
                 "alidationContext;\r\n\r\n\r\n            ValidationContext refResult = this.As<");
@@ -11839,13 +12128,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3938 "SchemaEntity201909.tt"
+        #line 4019 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( RefDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3938 "SchemaEntity201909.tt"
+        #line 4019 "SchemaEntity201909.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
             if (!refResult.IsValid)
@@ -11880,7 +12169,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3967 "SchemaEntity201909.tt"
+        #line 4048 "SchemaEntity201909.tt"
 
     }
     
@@ -11888,13 +12177,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3970 "SchemaEntity201909.tt"
+        #line 4051 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3971 "SchemaEntity201909.tt"
+        #line 4052 "SchemaEntity201909.tt"
 
     if (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasAdditionalItems)
     {
@@ -11903,7 +12192,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3975 "SchemaEntity201909.tt"
+        #line 4056 "SchemaEntity201909.tt"
         this.Write(@"        private ValidationContext ValidateArray(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
             ValidationContext result = validationContext;
@@ -11918,7 +12207,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3984 "SchemaEntity201909.tt"
+        #line 4065 "SchemaEntity201909.tt"
 
         if (HasItems || HasContains || HasUniqueItems || HasUnevaluatedItems || HasAdditionalItems)
         {
@@ -11927,13 +12216,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3988 "SchemaEntity201909.tt"
+        #line 4069 "SchemaEntity201909.tt"
         this.Write("\r\n            int arrayLength = 0;\r\n         ");
         
         #line default
         #line hidden
         
-        #line 3990 "SchemaEntity201909.tt"
+        #line 4071 "SchemaEntity201909.tt"
 
         }
         else
@@ -11943,13 +12232,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3995 "SchemaEntity201909.tt"
+        #line 4076 "SchemaEntity201909.tt"
         this.Write("            int arrayLength = this.Length;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3996 "SchemaEntity201909.tt"
+        #line 4077 "SchemaEntity201909.tt"
 
         }
         
@@ -11957,13 +12246,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3999 "SchemaEntity201909.tt"
+        #line 4080 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4000 "SchemaEntity201909.tt"
+        #line 4081 "SchemaEntity201909.tt"
 
         if (HasContains)
         {
@@ -11972,13 +12261,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4004 "SchemaEntity201909.tt"
+        #line 4085 "SchemaEntity201909.tt"
         this.Write("            int containsCount = 0;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4006 "SchemaEntity201909.tt"
+        #line 4087 "SchemaEntity201909.tt"
 
         }
 
@@ -11987,13 +12276,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4010 "SchemaEntity201909.tt"
+        #line 4091 "SchemaEntity201909.tt"
         this.Write("\r\n         ");
         
         #line default
         #line hidden
         
-        #line 4011 "SchemaEntity201909.tt"
+        #line 4092 "SchemaEntity201909.tt"
 
         if (HasItems || HasContains || HasUniqueItems || HasUnevaluatedItems || HasAdditionalItems)
         {
@@ -12002,14 +12291,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4015 "SchemaEntity201909.tt"
+        #line 4096 "SchemaEntity201909.tt"
         this.Write("            JsonArrayEnumerator arrayEnumerator = this.EnumerateArray();\r\n\r\n     " +
                 "       while (arrayEnumerator.MoveNext())\r\n            {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4019 "SchemaEntity201909.tt"
+        #line 4100 "SchemaEntity201909.tt"
 
             if (HasUniqueItems)
             {
@@ -12018,7 +12307,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4023 "SchemaEntity201909.tt"
+        #line 4104 "SchemaEntity201909.tt"
         this.Write(@"                JsonArrayEnumerator innerEnumerator = this.EnumerateArray();
                 int innerIndex = -1;
                 while (innerIndex < arrayLength && innerEnumerator.MoveNext())
@@ -12050,7 +12339,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4049 "SchemaEntity201909.tt"
+        #line 4130 "SchemaEntity201909.tt"
 
             }
         
@@ -12058,13 +12347,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4052 "SchemaEntity201909.tt"
+        #line 4133 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4053 "SchemaEntity201909.tt"
+        #line 4134 "SchemaEntity201909.tt"
 
             if (HasContains)
             {
@@ -12073,19 +12362,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4057 "SchemaEntity201909.tt"
+        #line 4138 "SchemaEntity201909.tt"
         this.Write("                ValidationContext containsResult = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4057 "SchemaEntity201909.tt"
+        #line 4138 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     ContainsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4057 "SchemaEntity201909.tt"
+        #line 4138 "SchemaEntity201909.tt"
         this.Write(">().Validate(result.CreateChildContext(), level);\r\n\r\n                if (contains" +
                 "Result.IsValid)\r\n                {\r\n                    result = result.WithLoca" +
                 "lItemIndex(arrayLength);\r\n                    containsCount++;\r\n\r\n            ");
@@ -12093,7 +12382,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4064 "SchemaEntity201909.tt"
+        #line 4145 "SchemaEntity201909.tt"
 
                 if (HasMaxContains)
                 {
@@ -12102,26 +12391,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4068 "SchemaEntity201909.tt"
+        #line 4149 "SchemaEntity201909.tt"
         this.Write("                    if (level == ValidationLevel.Flag && containsCount > ");
         
         #line default
         #line hidden
         
-        #line 4068 "SchemaEntity201909.tt"
+        #line 4149 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4068 "SchemaEntity201909.tt"
+        #line 4149 "SchemaEntity201909.tt"
         this.Write(")\r\n                    {\r\n                        return result.WithResult(isVali" +
                 "d: false);\r\n                    }\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4072 "SchemaEntity201909.tt"
+        #line 4153 "SchemaEntity201909.tt"
 
                 }
             
@@ -12129,13 +12418,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4075 "SchemaEntity201909.tt"
+        #line 4156 "SchemaEntity201909.tt"
         this.Write("                }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4077 "SchemaEntity201909.tt"
+        #line 4158 "SchemaEntity201909.tt"
 
             }
         
@@ -12143,13 +12432,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4080 "SchemaEntity201909.tt"
+        #line 4161 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4081 "SchemaEntity201909.tt"
+        #line 4162 "SchemaEntity201909.tt"
 
             if (HasSingleItemsType)
             {
@@ -12158,19 +12447,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4085 "SchemaEntity201909.tt"
+        #line 4166 "SchemaEntity201909.tt"
         this.Write("                result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4085 "SchemaEntity201909.tt"
+        #line 4166 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4085 "SchemaEntity201909.tt"
+        #line 4166 "SchemaEntity201909.tt"
         this.Write(">().Validate(result, level);\r\n                if (level == ValidationLevel.Flag &" +
                 "& !result.IsValid)\r\n                {\r\n                    return result;\r\n     " +
                 "           }\r\n\r\n                result = result.WithLocalItemIndex(arrayLength);" +
@@ -12179,7 +12468,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4093 "SchemaEntity201909.tt"
+        #line 4174 "SchemaEntity201909.tt"
 
             }
             else if (HasMultipleItemsType)
@@ -12189,13 +12478,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4098 "SchemaEntity201909.tt"
+        #line 4179 "SchemaEntity201909.tt"
         this.Write("                switch (arrayLength)\r\n                {\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4100 "SchemaEntity201909.tt"
+        #line 4181 "SchemaEntity201909.tt"
 
                 int itemsIndex = 0;
                 foreach (var item in Items)
@@ -12205,31 +12494,31 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4105 "SchemaEntity201909.tt"
+        #line 4186 "SchemaEntity201909.tt"
         this.Write("                    case ");
         
         #line default
         #line hidden
         
-        #line 4105 "SchemaEntity201909.tt"
+        #line 4186 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  itemsIndex ));
         
         #line default
         #line hidden
         
-        #line 4105 "SchemaEntity201909.tt"
+        #line 4186 "SchemaEntity201909.tt"
         this.Write(":\r\n                        result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4106 "SchemaEntity201909.tt"
+        #line 4187 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  item ));
         
         #line default
         #line hidden
         
-        #line 4106 "SchemaEntity201909.tt"
+        #line 4187 "SchemaEntity201909.tt"
         this.Write(@">().Validate(result, level);
                         if (level == ValidationLevel.Flag && !result.IsValid)
                         {
@@ -12243,7 +12532,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4114 "SchemaEntity201909.tt"
+        #line 4195 "SchemaEntity201909.tt"
 
                     itemsIndex++;
                 }
@@ -12252,13 +12541,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4118 "SchemaEntity201909.tt"
+        #line 4199 "SchemaEntity201909.tt"
         this.Write("\r\n                    default:\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4120 "SchemaEntity201909.tt"
+        #line 4201 "SchemaEntity201909.tt"
 
                 if (!AllowsAdditionalItems)
                 {
@@ -12267,7 +12556,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4124 "SchemaEntity201909.tt"
+        #line 4205 "SchemaEntity201909.tt"
         this.Write(@"                        if (level >= ValidationLevel.Detailed)
                         {
                             result = result.WithResult(isValid: false, $""9.3.1.2. additionalItems - Additional items are not permitted at index {arrayLength}."");
@@ -12286,7 +12575,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4137 "SchemaEntity201909.tt"
+        #line 4218 "SchemaEntity201909.tt"
 
                 }
             
@@ -12294,13 +12583,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4140 "SchemaEntity201909.tt"
+        #line 4221 "SchemaEntity201909.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4141 "SchemaEntity201909.tt"
+        #line 4222 "SchemaEntity201909.tt"
 
                 if (AllowsAdditionalItems)
                 {
@@ -12309,13 +12598,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4145 "SchemaEntity201909.tt"
+        #line 4226 "SchemaEntity201909.tt"
         this.Write("                ");
         
         #line default
         #line hidden
         
-        #line 4145 "SchemaEntity201909.tt"
+        #line 4226 "SchemaEntity201909.tt"
 
                     if (HasAdditionalItems)
                     {
@@ -12324,13 +12613,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4149 "SchemaEntity201909.tt"
+        #line 4230 "SchemaEntity201909.tt"
         this.Write("                    ");
         
         #line default
         #line hidden
         
-        #line 4149 "SchemaEntity201909.tt"
+        #line 4230 "SchemaEntity201909.tt"
 
                         if (HasAdditionalItemsSchema)
                         {
@@ -12339,19 +12628,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4153 "SchemaEntity201909.tt"
+        #line 4234 "SchemaEntity201909.tt"
         this.Write("                        result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4153 "SchemaEntity201909.tt"
+        #line 4234 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(      AdditionalItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4153 "SchemaEntity201909.tt"
+        #line 4234 "SchemaEntity201909.tt"
         this.Write(">().Validate(result, level);\r\n                        if (level == ValidationLeve" +
                 "l.Flag && !result.IsValid)\r\n                        {\r\n                         " +
                 "   return result;\r\n                        }\r\n                    ");
@@ -12359,7 +12648,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4158 "SchemaEntity201909.tt"
+        #line 4239 "SchemaEntity201909.tt"
 
                         }
                     
@@ -12367,14 +12656,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4161 "SchemaEntity201909.tt"
+        #line 4242 "SchemaEntity201909.tt"
         this.Write("                        \r\n                        result = result.WithLocalItemIn" +
                 "dex(arrayLength);\r\n\r\n                ");
         
         #line default
         #line hidden
         
-        #line 4164 "SchemaEntity201909.tt"
+        #line 4245 "SchemaEntity201909.tt"
 
                     }
                     else if (HasUnevaluatedItems)
@@ -12384,7 +12673,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4169 "SchemaEntity201909.tt"
+        #line 4250 "SchemaEntity201909.tt"
         this.Write("                        if (!result.HasEvaluatedLocalOrAppliedItemIndex(arrayLeng" +
                 "th))\r\n                        {\r\n\r\n                            result = arrayEnu" +
                 "merator.Current.As<");
@@ -12392,13 +12681,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4172 "SchemaEntity201909.tt"
+        #line 4253 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  UnevaluatedItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4172 "SchemaEntity201909.tt"
+        #line 4253 "SchemaEntity201909.tt"
         this.Write(@">().Validate(result, level);
 
                             if (level == ValidationLevel.Flag && !result.IsValid)
@@ -12413,7 +12702,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4181 "SchemaEntity201909.tt"
+        #line 4262 "SchemaEntity201909.tt"
 
                     }
                 
@@ -12421,13 +12710,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4184 "SchemaEntity201909.tt"
+        #line 4265 "SchemaEntity201909.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4185 "SchemaEntity201909.tt"
+        #line 4266 "SchemaEntity201909.tt"
 
                 }
             
@@ -12435,13 +12724,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4188 "SchemaEntity201909.tt"
+        #line 4269 "SchemaEntity201909.tt"
         this.Write("                        break;\r\n                }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4191 "SchemaEntity201909.tt"
+        #line 4272 "SchemaEntity201909.tt"
 
             }
             else
@@ -12451,13 +12740,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4196 "SchemaEntity201909.tt"
+        #line 4277 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4196 "SchemaEntity201909.tt"
+        #line 4277 "SchemaEntity201909.tt"
 
                 if (AllowsAdditionalItems)
                 {
@@ -12466,13 +12755,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4200 "SchemaEntity201909.tt"
+        #line 4281 "SchemaEntity201909.tt"
         this.Write("                ");
         
         #line default
         #line hidden
         
-        #line 4200 "SchemaEntity201909.tt"
+        #line 4281 "SchemaEntity201909.tt"
 
                     if (!HasAdditionalItems && HasUnevaluatedItems)
                     {
@@ -12481,7 +12770,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4204 "SchemaEntity201909.tt"
+        #line 4285 "SchemaEntity201909.tt"
         this.Write("                        if (!result.HasEvaluatedLocalOrAppliedItemIndex(arrayLeng" +
                 "th))\r\n                        {\r\n                            result = arrayEnume" +
                 "rator.Current.As<");
@@ -12489,13 +12778,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4206 "SchemaEntity201909.tt"
+        #line 4287 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  UnevaluatedItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4206 "SchemaEntity201909.tt"
+        #line 4287 "SchemaEntity201909.tt"
         this.Write(@">().Validate(result, level);
 
                             if (level == ValidationLevel.Flag && !result.IsValid)
@@ -12511,7 +12800,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4216 "SchemaEntity201909.tt"
+        #line 4297 "SchemaEntity201909.tt"
 
                     }
                 
@@ -12519,13 +12808,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4219 "SchemaEntity201909.tt"
+        #line 4300 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4219 "SchemaEntity201909.tt"
+        #line 4300 "SchemaEntity201909.tt"
 
                 }
             
@@ -12533,13 +12822,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4222 "SchemaEntity201909.tt"
+        #line 4303 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4223 "SchemaEntity201909.tt"
+        #line 4304 "SchemaEntity201909.tt"
 
             }
         
@@ -12547,13 +12836,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4226 "SchemaEntity201909.tt"
+        #line 4307 "SchemaEntity201909.tt"
         this.Write("\r\n                arrayLength++;\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4229 "SchemaEntity201909.tt"
+        #line 4310 "SchemaEntity201909.tt"
 
         }
         
@@ -12561,13 +12850,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4232 "SchemaEntity201909.tt"
+        #line 4313 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4233 "SchemaEntity201909.tt"
+        #line 4314 "SchemaEntity201909.tt"
 
         if (HasMaxItems)
         {
@@ -12576,19 +12865,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4237 "SchemaEntity201909.tt"
+        #line 4318 "SchemaEntity201909.tt"
         this.Write("            if (arrayLength > ");
         
         #line default
         #line hidden
         
-        #line 4237 "SchemaEntity201909.tt"
+        #line 4318 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4237 "SchemaEntity201909.tt"
+        #line 4318 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".1. maxItems - {arrayLength} exceeds maximum number of items ");
@@ -12596,13 +12885,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4241 "SchemaEntity201909.tt"
+        #line 4322 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4241 "SchemaEntity201909.tt"
+        #line 4322 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.1. maxItems - item count exceeds maximum number of items ");
@@ -12610,13 +12899,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4245 "SchemaEntity201909.tt"
+        #line 4326 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4245 "SchemaEntity201909.tt"
+        #line 4326 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n\r\n           " +
                 " }\r\n        ");
@@ -12624,7 +12913,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4253 "SchemaEntity201909.tt"
+        #line 4334 "SchemaEntity201909.tt"
 
         }
         
@@ -12632,13 +12921,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4256 "SchemaEntity201909.tt"
+        #line 4337 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4257 "SchemaEntity201909.tt"
+        #line 4338 "SchemaEntity201909.tt"
 
         if (HasMinItems)
         {
@@ -12647,19 +12936,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4261 "SchemaEntity201909.tt"
+        #line 4342 "SchemaEntity201909.tt"
         this.Write("            if (arrayLength < ");
         
         #line default
         #line hidden
         
-        #line 4261 "SchemaEntity201909.tt"
+        #line 4342 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4261 "SchemaEntity201909.tt"
+        #line 4342 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".2. minItems - {arrayLength} is less than the minimum number of items ");
@@ -12667,13 +12956,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4265 "SchemaEntity201909.tt"
+        #line 4346 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4265 "SchemaEntity201909.tt"
+        #line 4346 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.2. minItems - item count is less than the minimum number of items ");
@@ -12681,13 +12970,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4269 "SchemaEntity201909.tt"
+        #line 4350 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4269 "SchemaEntity201909.tt"
+        #line 4350 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n\r\n           " +
                 " }\r\n        ");
@@ -12695,7 +12984,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4277 "SchemaEntity201909.tt"
+        #line 4358 "SchemaEntity201909.tt"
 
         }
         
@@ -12703,13 +12992,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4280 "SchemaEntity201909.tt"
+        #line 4361 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4281 "SchemaEntity201909.tt"
+        #line 4362 "SchemaEntity201909.tt"
 
         if (HasContains)
         {
@@ -12718,13 +13007,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4285 "SchemaEntity201909.tt"
+        #line 4366 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4285 "SchemaEntity201909.tt"
+        #line 4366 "SchemaEntity201909.tt"
 
             if (HasMaxContains)
             {
@@ -12733,19 +13022,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4289 "SchemaEntity201909.tt"
+        #line 4370 "SchemaEntity201909.tt"
         this.Write("\r\n            if (containsCount > ");
         
         #line default
         #line hidden
         
-        #line 4290 "SchemaEntity201909.tt"
+        #line 4371 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4290 "SchemaEntity201909.tt"
+        #line 4371 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".4. maxContains - {containsCount} exceeds maximum number of matching items ");
@@ -12753,13 +13042,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4294 "SchemaEntity201909.tt"
+        #line 4375 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4294 "SchemaEntity201909.tt"
+        #line 4375 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.4. maxContains - item count exceeds maximum number of matching items ");
@@ -12767,13 +13056,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4298 "SchemaEntity201909.tt"
+        #line 4379 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4298 "SchemaEntity201909.tt"
+        #line 4379 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n            ");
@@ -12781,7 +13070,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4306 "SchemaEntity201909.tt"
+        #line 4387 "SchemaEntity201909.tt"
 
             }
             
@@ -12789,13 +13078,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4309 "SchemaEntity201909.tt"
+        #line 4390 "SchemaEntity201909.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4310 "SchemaEntity201909.tt"
+        #line 4391 "SchemaEntity201909.tt"
 
             if (HasMinContains)
             {
@@ -12804,19 +13093,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4314 "SchemaEntity201909.tt"
+        #line 4395 "SchemaEntity201909.tt"
         this.Write("            if (containsCount < ");
         
         #line default
         #line hidden
         
-        #line 4314 "SchemaEntity201909.tt"
+        #line 4395 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4314 "SchemaEntity201909.tt"
+        #line 4395 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".5. minContains - {containsCount} is less than minimum number of matching items " +
@@ -12825,13 +13114,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4318 "SchemaEntity201909.tt"
+        #line 4399 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4318 "SchemaEntity201909.tt"
+        #line 4399 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.5. minContains - item count is less than minimum number of matching ite" +
@@ -12840,13 +13129,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4322 "SchemaEntity201909.tt"
+        #line 4403 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4322 "SchemaEntity201909.tt"
+        #line 4403 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n            ");
@@ -12854,7 +13143,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4330 "SchemaEntity201909.tt"
+        #line 4411 "SchemaEntity201909.tt"
 
             }
             else
@@ -12864,7 +13153,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4335 "SchemaEntity201909.tt"
+        #line 4416 "SchemaEntity201909.tt"
         this.Write(@"            if (containsCount == 0)
             {
                 if (level >= ValidationLevel.Detailed)
@@ -12886,7 +13175,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4351 "SchemaEntity201909.tt"
+        #line 4432 "SchemaEntity201909.tt"
 
             }
             
@@ -12894,13 +13183,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4354 "SchemaEntity201909.tt"
+        #line 4435 "SchemaEntity201909.tt"
         this.Write("\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4356 "SchemaEntity201909.tt"
+        #line 4437 "SchemaEntity201909.tt"
 
         }
         
@@ -12908,13 +13197,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4359 "SchemaEntity201909.tt"
+        #line 4440 "SchemaEntity201909.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4363 "SchemaEntity201909.tt"
+        #line 4444 "SchemaEntity201909.tt"
 
     }
     
@@ -12922,13 +13211,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4366 "SchemaEntity201909.tt"
+        #line 4447 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4367 "SchemaEntity201909.tt"
+        #line 4448 "SchemaEntity201909.tt"
 
     if (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties|| HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)) || !AllowsAdditionalProperties))
     {
@@ -12937,7 +13226,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4371 "SchemaEntity201909.tt"
+        #line 4452 "SchemaEntity201909.tt"
         this.Write(@"        private ValidationContext ValidateObject(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
             ValidationContext result = validationContext;
@@ -12952,7 +13241,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4380 "SchemaEntity201909.tt"
+        #line 4461 "SchemaEntity201909.tt"
 
         if (HasMaxProperties || HasMinProperties || HasLocalProperties || HasRequired || HasDependentSchemas || HasPatternProperties || HasAdditionalProperties || HasUnevaluatedProperties)
         {
@@ -12961,13 +13250,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4384 "SchemaEntity201909.tt"
+        #line 4465 "SchemaEntity201909.tt"
         this.Write("            int propertyCount = 0;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4385 "SchemaEntity201909.tt"
+        #line 4466 "SchemaEntity201909.tt"
 
         }
         
@@ -12975,13 +13264,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4388 "SchemaEntity201909.tt"
+        #line 4469 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4389 "SchemaEntity201909.tt"
+        #line 4470 "SchemaEntity201909.tt"
 
         if (HasRequired)
         {
@@ -12990,13 +13279,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4393 "SchemaEntity201909.tt"
+        #line 4474 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4393 "SchemaEntity201909.tt"
+        #line 4474 "SchemaEntity201909.tt"
  
             foreach(var property in RequiredProperties)
             {
@@ -13005,25 +13294,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4397 "SchemaEntity201909.tt"
+        #line 4478 "SchemaEntity201909.tt"
         this.Write("            bool found");
         
         #line default
         #line hidden
         
-        #line 4397 "SchemaEntity201909.tt"
+        #line 4478 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4397 "SchemaEntity201909.tt"
+        #line 4478 "SchemaEntity201909.tt"
         this.Write(" = false;\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4398 "SchemaEntity201909.tt"
+        #line 4479 "SchemaEntity201909.tt"
 
             }
             
@@ -13031,13 +13320,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4401 "SchemaEntity201909.tt"
+        #line 4482 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4401 "SchemaEntity201909.tt"
+        #line 4482 "SchemaEntity201909.tt"
 
         }
         
@@ -13045,14 +13334,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4404 "SchemaEntity201909.tt"
+        #line 4485 "SchemaEntity201909.tt"
         this.Write("\r\n            foreach (Property property in this.EnumerateObject())\r\n            " +
                 "{\r\n                string propertyName = property.Name;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4409 "SchemaEntity201909.tt"
+        #line 4490 "SchemaEntity201909.tt"
 
         if (HasDependentRequired)
         {
@@ -13061,7 +13350,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4413 "SchemaEntity201909.tt"
+        #line 4494 "SchemaEntity201909.tt"
         this.Write(@"                if (__CorvusDependentRequired.TryGetValue(propertyName, out ImmutableArray<ReadOnlyMemory<byte>> dependencies))
                 {
                     foreach (ReadOnlyMemory<byte> dependency in dependencies)
@@ -13072,7 +13361,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4418 "SchemaEntity201909.tt"
+        #line 4499 "SchemaEntity201909.tt"
 
             if (HasDefaults)
             {
@@ -13081,13 +13370,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4422 "SchemaEntity201909.tt"
+        #line 4503 "SchemaEntity201909.tt"
         this.Write("                        && !this.HasDefault(dependency.Span)\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4423 "SchemaEntity201909.tt"
+        #line 4504 "SchemaEntity201909.tt"
 
             }
             
@@ -13095,7 +13384,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4426 "SchemaEntity201909.tt"
+        #line 4507 "SchemaEntity201909.tt"
         this.Write(@"                        )
                         {
                             if (level >= ValidationLevel.Detailed)
@@ -13119,7 +13408,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4444 "SchemaEntity201909.tt"
+        #line 4525 "SchemaEntity201909.tt"
 
         }
         
@@ -13127,13 +13416,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4447 "SchemaEntity201909.tt"
+        #line 4528 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4448 "SchemaEntity201909.tt"
+        #line 4529 "SchemaEntity201909.tt"
 
         if (HasLocalProperties || HasRequired)
         {
@@ -13142,20 +13431,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4452 "SchemaEntity201909.tt"
+        #line 4533 "SchemaEntity201909.tt"
         this.Write("                if (__CorvusLocalProperties.TryGetValue(propertyName, out Propert" +
                 "yValidator<");
         
         #line default
         #line hidden
         
-        #line 4452 "SchemaEntity201909.tt"
+        #line 4533 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4452 "SchemaEntity201909.tt"
+        #line 4533 "SchemaEntity201909.tt"
         this.Write(@">? propertyValidator))
                 {
                     result = result.WithLocalProperty(propertyCount);
@@ -13171,7 +13460,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4462 "SchemaEntity201909.tt"
+        #line 4543 "SchemaEntity201909.tt"
 
             if (HasRequired)
             {
@@ -13185,13 +13474,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4471 "SchemaEntity201909.tt"
+        #line 4552 "SchemaEntity201909.tt"
         this.Write("                else \r\n                    ");
         
         #line default
         #line hidden
         
-        #line 4472 "SchemaEntity201909.tt"
+        #line 4553 "SchemaEntity201909.tt"
 
                     }
                     else
@@ -13203,38 +13492,38 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4479 "SchemaEntity201909.tt"
+        #line 4560 "SchemaEntity201909.tt"
         this.Write("\r\n                if (");
         
         #line default
         #line hidden
         
-        #line 4480 "SchemaEntity201909.tt"
+        #line 4561 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4480 "SchemaEntity201909.tt"
+        #line 4561 "SchemaEntity201909.tt"
         this.Write("JsonPropertyName.Equals(propertyName))\r\n                {\r\n                    fo" +
                 "und");
         
         #line default
         #line hidden
         
-        #line 4482 "SchemaEntity201909.tt"
+        #line 4563 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  property.DotnetPropertyName));
         
         #line default
         #line hidden
         
-        #line 4482 "SchemaEntity201909.tt"
+        #line 4563 "SchemaEntity201909.tt"
         this.Write(" = true;\r\n                }\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4484 "SchemaEntity201909.tt"
+        #line 4565 "SchemaEntity201909.tt"
 
                 }
             }
@@ -13243,13 +13532,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4488 "SchemaEntity201909.tt"
+        #line 4569 "SchemaEntity201909.tt"
         this.Write("\r\n                }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4490 "SchemaEntity201909.tt"
+        #line 4571 "SchemaEntity201909.tt"
 
         }
         
@@ -13257,13 +13546,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4493 "SchemaEntity201909.tt"
+        #line 4574 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4494 "SchemaEntity201909.tt"
+        #line 4575 "SchemaEntity201909.tt"
 
         if (HasDependentSchemas)
         {
@@ -13272,20 +13561,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4498 "SchemaEntity201909.tt"
+        #line 4579 "SchemaEntity201909.tt"
         this.Write("                if (__CorvusDependentSchema.TryGetValue(propertyName, out Propert" +
                 "yValidator<");
         
         #line default
         #line hidden
         
-        #line 4498 "SchemaEntity201909.tt"
+        #line 4579 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4498 "SchemaEntity201909.tt"
+        #line 4579 "SchemaEntity201909.tt"
         this.Write(@">? dependentSchemaValidator))
                 {
                     result = result.WithLocalProperty(propertyCount);
@@ -13300,7 +13589,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4507 "SchemaEntity201909.tt"
+        #line 4588 "SchemaEntity201909.tt"
 
         }
         
@@ -13308,13 +13597,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4510 "SchemaEntity201909.tt"
+        #line 4591 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4511 "SchemaEntity201909.tt"
+        #line 4592 "SchemaEntity201909.tt"
 
         if (HasPropertyNames || HasPatternProperties)
         {
@@ -13323,13 +13612,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4515 "SchemaEntity201909.tt"
+        #line 4596 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4515 "SchemaEntity201909.tt"
+        #line 4596 "SchemaEntity201909.tt"
 
             if (HasPropertyNames)
             {
@@ -13338,19 +13627,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4519 "SchemaEntity201909.tt"
+        #line 4600 "SchemaEntity201909.tt"
         this.Write("                result = new JsonString(propertyName).As<");
         
         #line default
         #line hidden
         
-        #line 4519 "SchemaEntity201909.tt"
+        #line 4600 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     PropertyNamesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4519 "SchemaEntity201909.tt"
+        #line 4600 "SchemaEntity201909.tt"
         this.Write(">().Validate(result, level);\r\n                if (level == ValidationLevel.Flag &" +
                 "& !result.IsValid)\r\n                {\r\n                    return result;\r\n     " +
                 "           }\r\n            ");
@@ -13358,7 +13647,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4524 "SchemaEntity201909.tt"
+        #line 4605 "SchemaEntity201909.tt"
 
             }
             
@@ -13366,13 +13655,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4527 "SchemaEntity201909.tt"
+        #line 4608 "SchemaEntity201909.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4528 "SchemaEntity201909.tt"
+        #line 4609 "SchemaEntity201909.tt"
 
             if (HasPatternProperties)
             {
@@ -13381,7 +13670,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4532 "SchemaEntity201909.tt"
+        #line 4613 "SchemaEntity201909.tt"
         this.Write(@"                foreach (System.Collections.Generic.KeyValuePair<Regex, PatternPropertyValidator> patternProperty in __CorvusPatternProperties)
                 {
                     if (patternProperty.Key.IsMatch(propertyName))
@@ -13400,7 +13689,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4545 "SchemaEntity201909.tt"
+        #line 4626 "SchemaEntity201909.tt"
 
             }
             
@@ -13408,13 +13697,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4548 "SchemaEntity201909.tt"
+        #line 4629 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4548 "SchemaEntity201909.tt"
+        #line 4629 "SchemaEntity201909.tt"
 
         }
         
@@ -13422,13 +13711,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4551 "SchemaEntity201909.tt"
+        #line 4632 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4552 "SchemaEntity201909.tt"
+        #line 4633 "SchemaEntity201909.tt"
 
         if (AllowsAdditionalProperties && HasAdditionalProperties)
         {
@@ -13437,20 +13726,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4556 "SchemaEntity201909.tt"
+        #line 4637 "SchemaEntity201909.tt"
         this.Write("                if (!result.HasEvaluatedLocalProperty(propertyCount))\r\n          " +
                 "      {\r\n                    result = property.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 4558 "SchemaEntity201909.tt"
+        #line 4639 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4558 "SchemaEntity201909.tt"
+        #line 4639 "SchemaEntity201909.tt"
         this.Write(@">().Validate(result, level);
                     if (level == ValidationLevel.Flag && !result.IsValid)
                     {
@@ -13463,7 +13752,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4565 "SchemaEntity201909.tt"
+        #line 4646 "SchemaEntity201909.tt"
 
         }
         
@@ -13471,13 +13760,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4568 "SchemaEntity201909.tt"
+        #line 4649 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4569 "SchemaEntity201909.tt"
+        #line 4650 "SchemaEntity201909.tt"
 
         if (AllowsAdditionalProperties && HasUnevaluatedProperties)
         {
@@ -13486,20 +13775,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4573 "SchemaEntity201909.tt"
+        #line 4654 "SchemaEntity201909.tt"
         this.Write("        \r\n                if (!result.HasEvaluatedLocalOrAppliedProperty(property" +
                 "Count))\r\n                {\r\n\r\n                    result = property.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 4577 "SchemaEntity201909.tt"
+        #line 4658 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4577 "SchemaEntity201909.tt"
+        #line 4658 "SchemaEntity201909.tt"
         this.Write(@">().Validate(result, level);
                     if (level == ValidationLevel.Flag && !result.IsValid)
                     {
@@ -13513,7 +13802,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4585 "SchemaEntity201909.tt"
+        #line 4666 "SchemaEntity201909.tt"
 
         }
         
@@ -13521,13 +13810,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4588 "SchemaEntity201909.tt"
+        #line 4669 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4589 "SchemaEntity201909.tt"
+        #line 4670 "SchemaEntity201909.tt"
 
         if (!AllowsAdditionalProperties)
         {
@@ -13536,7 +13825,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4593 "SchemaEntity201909.tt"
+        #line 4674 "SchemaEntity201909.tt"
         this.Write(@"        
                 if (!result.HasEvaluatedLocalProperty(propertyCount))
                 {
@@ -13559,7 +13848,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4610 "SchemaEntity201909.tt"
+        #line 4691 "SchemaEntity201909.tt"
 
         }
         
@@ -13567,13 +13856,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4613 "SchemaEntity201909.tt"
+        #line 4694 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4614 "SchemaEntity201909.tt"
+        #line 4695 "SchemaEntity201909.tt"
 
         if (HasMaxProperties || HasMinProperties || HasLocalProperties || HasRequired || HasDependentSchemas || HasPatternProperties || HasAdditionalProperties || HasUnevaluatedProperties)
         {
@@ -13582,13 +13871,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4618 "SchemaEntity201909.tt"
+        #line 4699 "SchemaEntity201909.tt"
         this.Write("        \r\n                propertyCount++;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4621 "SchemaEntity201909.tt"
+        #line 4702 "SchemaEntity201909.tt"
 
         }
         
@@ -13596,13 +13885,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4624 "SchemaEntity201909.tt"
+        #line 4705 "SchemaEntity201909.tt"
         this.Write("            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4626 "SchemaEntity201909.tt"
+        #line 4707 "SchemaEntity201909.tt"
 
         if (HasRequired)
         {
@@ -13611,13 +13900,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4630 "SchemaEntity201909.tt"
+        #line 4711 "SchemaEntity201909.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4631 "SchemaEntity201909.tt"
+        #line 4712 "SchemaEntity201909.tt"
 
             foreach (var property in RequiredProperties)
             {
@@ -13628,19 +13917,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4637 "SchemaEntity201909.tt"
+        #line 4718 "SchemaEntity201909.tt"
         this.Write("            if (!found");
         
         #line default
         #line hidden
         
-        #line 4637 "SchemaEntity201909.tt"
+        #line 4718 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4637 "SchemaEntity201909.tt"
+        #line 4718 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".3. required - required property \\\"");
@@ -13648,13 +13937,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4641 "SchemaEntity201909.tt"
+        #line 4722 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                        Formatting.FormatLiteralOrNull(property.JsonPropertyName, true).Trim('"') ));
         
         #line default
         #line hidden
         
-        #line 4641 "SchemaEntity201909.tt"
+        #line 4722 "SchemaEntity201909.tt"
         this.Write(@"\"" not present."");
                 }
                 else if (level >= ValidationLevel.Basic)
@@ -13671,7 +13960,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4652 "SchemaEntity201909.tt"
+        #line 4733 "SchemaEntity201909.tt"
 
                 }
             }
@@ -13680,13 +13969,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4656 "SchemaEntity201909.tt"
+        #line 4737 "SchemaEntity201909.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4656 "SchemaEntity201909.tt"
+        #line 4737 "SchemaEntity201909.tt"
 
         }
         
@@ -13694,13 +13983,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4659 "SchemaEntity201909.tt"
+        #line 4740 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4660 "SchemaEntity201909.tt"
+        #line 4741 "SchemaEntity201909.tt"
 
         if (HasMaxProperties)
         {
@@ -13709,19 +13998,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4664 "SchemaEntity201909.tt"
+        #line 4745 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (propertyCount > ");
         
         #line default
         #line hidden
         
-        #line 4665 "SchemaEntity201909.tt"
+        #line 4746 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4665 "SchemaEntity201909.tt"
+        #line 4746 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".1. maxProperties - property count of {propertyCount} is greater than ");
@@ -13729,13 +14018,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4669 "SchemaEntity201909.tt"
+        #line 4750 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4669 "SchemaEntity201909.tt"
+        #line 4750 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.5.1. maxProperties - property count greater than ");
@@ -13743,13 +14032,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4673 "SchemaEntity201909.tt"
+        #line 4754 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4673 "SchemaEntity201909.tt"
+        #line 4754 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n        ");
@@ -13757,7 +14046,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4680 "SchemaEntity201909.tt"
+        #line 4761 "SchemaEntity201909.tt"
 
         }
         
@@ -13765,13 +14054,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4683 "SchemaEntity201909.tt"
+        #line 4764 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4684 "SchemaEntity201909.tt"
+        #line 4765 "SchemaEntity201909.tt"
 
         if (HasMinProperties)
         {
@@ -13780,19 +14069,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4688 "SchemaEntity201909.tt"
+        #line 4769 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (propertyCount < ");
         
         #line default
         #line hidden
         
-        #line 4689 "SchemaEntity201909.tt"
+        #line 4770 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4689 "SchemaEntity201909.tt"
+        #line 4770 "SchemaEntity201909.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".2. minProperties - property count of {propertyCount} is lezs than ");
@@ -13800,13 +14089,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4693 "SchemaEntity201909.tt"
+        #line 4774 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4693 "SchemaEntity201909.tt"
+        #line 4774 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.5.2. minProperties - property count less than ");
@@ -13814,13 +14103,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4697 "SchemaEntity201909.tt"
+        #line 4778 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4697 "SchemaEntity201909.tt"
+        #line 4778 "SchemaEntity201909.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n        ");
@@ -13828,7 +14117,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4705 "SchemaEntity201909.tt"
+        #line 4786 "SchemaEntity201909.tt"
 
         }
         
@@ -13836,13 +14125,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4708 "SchemaEntity201909.tt"
+        #line 4789 "SchemaEntity201909.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4712 "SchemaEntity201909.tt"
+        #line 4793 "SchemaEntity201909.tt"
 
     }
     
@@ -13850,13 +14139,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4715 "SchemaEntity201909.tt"
+        #line 4796 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4716 "SchemaEntity201909.tt"
+        #line 4797 "SchemaEntity201909.tt"
 
     if (HasOneOf)
     {
@@ -13865,7 +14154,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4720 "SchemaEntity201909.tt"
+        #line 4801 "SchemaEntity201909.tt"
         this.Write("        \r\n        private ValidationContext ValidateOneOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n            int oneOfCount = 0;\r\n\r\n        ");
@@ -13873,7 +14162,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4727 "SchemaEntity201909.tt"
+        #line 4808 "SchemaEntity201909.tt"
 
         int oneOfIndex = 0;
         foreach (var oneOf in OneOf)
@@ -13883,64 +14172,64 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4732 "SchemaEntity201909.tt"
+        #line 4813 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n            ValidationContext oneOfResult");
         
         #line default
         #line hidden
         
-        #line 4734 "SchemaEntity201909.tt"
+        #line 4815 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex));
         
         #line default
         #line hidden
         
-        #line 4734 "SchemaEntity201909.tt"
+        #line 4815 "SchemaEntity201909.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 4734 "SchemaEntity201909.tt"
+        #line 4815 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOf ));
         
         #line default
         #line hidden
         
-        #line 4734 "SchemaEntity201909.tt"
+        #line 4815 "SchemaEntity201909.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (o" +
                 "neOfResult");
         
         #line default
         #line hidden
         
-        #line 4736 "SchemaEntity201909.tt"
+        #line 4817 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4736 "SchemaEntity201909.tt"
+        #line 4817 "SchemaEntity201909.tt"
         this.Write(".IsValid)\r\n            {\r\n                result = result.MergeChildContext(oneOf" +
                 "Result");
         
         #line default
         #line hidden
         
-        #line 4738 "SchemaEntity201909.tt"
+        #line 4819 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4738 "SchemaEntity201909.tt"
+        #line 4819 "SchemaEntity201909.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n                oneOfCount += 1;\r\n        " +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 4740 "SchemaEntity201909.tt"
+        #line 4821 "SchemaEntity201909.tt"
 
             if (!HasUnevaluatedItems && !HasUnevaluatedProperties)
             {
@@ -13949,7 +14238,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4744 "SchemaEntity201909.tt"
+        #line 4825 "SchemaEntity201909.tt"
         this.Write("                if (oneOfCount > 1 && level == ValidationLevel.Flag)\r\n           " +
                 "     {\r\n                    result = result.WithResult(isValid: false);\r\n       " +
                 "             return result;\r\n                }\r\n            ");
@@ -13957,7 +14246,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4749 "SchemaEntity201909.tt"
+        #line 4830 "SchemaEntity201909.tt"
 
             }
             
@@ -13965,7 +14254,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4752 "SchemaEntity201909.tt"
+        #line 4833 "SchemaEntity201909.tt"
         this.Write("            }\r\n            else\r\n            {\r\n                if (level >= Vali" +
                 "dationLevel.Detailed)\r\n                {\r\n                    result = result.Me" +
                 "rgeResults(result.IsValid, level, oneOfResult");
@@ -13973,13 +14262,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4757 "SchemaEntity201909.tt"
+        #line 4838 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4757 "SchemaEntity201909.tt"
+        #line 4838 "SchemaEntity201909.tt"
         this.Write(");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)\r\n" +
                 "                {\r\n                    result = result.MergeResults(result.IsVal" +
                 "id, level, oneOfResult");
@@ -13987,32 +14276,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4761 "SchemaEntity201909.tt"
+        #line 4842 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4761 "SchemaEntity201909.tt"
+        #line 4842 "SchemaEntity201909.tt"
         this.Write(");\r\n                }\r\n                else\r\n                {\r\n                 " +
                 "   result = result.MergeResults(result.IsValid, level, oneOfResult");
         
         #line default
         #line hidden
         
-        #line 4765 "SchemaEntity201909.tt"
+        #line 4846 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4765 "SchemaEntity201909.tt"
+        #line 4846 "SchemaEntity201909.tt"
         this.Write(");\r\n                }\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4769 "SchemaEntity201909.tt"
+        #line 4850 "SchemaEntity201909.tt"
 
             oneOfIndex++;
         }
@@ -14021,7 +14310,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4773 "SchemaEntity201909.tt"
+        #line 4854 "SchemaEntity201909.tt"
         this.Write("\r\n            if (oneOfCount == 1)\r\n            {\r\n                if (level >= V" +
                 "alidationLevel.Detailed)\r\n                {\r\n                    result = result" +
                 ".WithResult(isValid: true, \"Validation 10.2.1.3. onef - validated against the on" +
@@ -14048,7 +14337,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4815 "SchemaEntity201909.tt"
+        #line 4896 "SchemaEntity201909.tt"
 
     }
     
@@ -14056,13 +14345,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4818 "SchemaEntity201909.tt"
+        #line 4899 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4820 "SchemaEntity201909.tt"
+        #line 4901 "SchemaEntity201909.tt"
 
     if (HasAnyOf)
     {
@@ -14071,7 +14360,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4824 "SchemaEntity201909.tt"
+        #line 4905 "SchemaEntity201909.tt"
         this.Write("        \r\n        private ValidationContext ValidateAnyOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n            bool foundValid = false;\r\n\r\n       " +
@@ -14080,7 +14369,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4831 "SchemaEntity201909.tt"
+        #line 4912 "SchemaEntity201909.tt"
 
         int anyOfIndex = 0;
         foreach (var anyOf in AnyOf)
@@ -14090,63 +14379,63 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4836 "SchemaEntity201909.tt"
+        #line 4917 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n            ValidationContext anyOfResult");
         
         #line default
         #line hidden
         
-        #line 4838 "SchemaEntity201909.tt"
+        #line 4919 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4838 "SchemaEntity201909.tt"
+        #line 4919 "SchemaEntity201909.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 4838 "SchemaEntity201909.tt"
+        #line 4919 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOf ));
         
         #line default
         #line hidden
         
-        #line 4838 "SchemaEntity201909.tt"
+        #line 4919 "SchemaEntity201909.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (a" +
                 "nyOfResult");
         
         #line default
         #line hidden
         
-        #line 4840 "SchemaEntity201909.tt"
+        #line 4921 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4840 "SchemaEntity201909.tt"
+        #line 4921 "SchemaEntity201909.tt"
         this.Write(".IsValid)\r\n            {\r\n                result = result.MergeChildContext(anyOf" +
                 "Result");
         
         #line default
         #line hidden
         
-        #line 4842 "SchemaEntity201909.tt"
+        #line 4923 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4842 "SchemaEntity201909.tt"
+        #line 4923 "SchemaEntity201909.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4843 "SchemaEntity201909.tt"
+        #line 4924 "SchemaEntity201909.tt"
 
             if (!HasUnevaluatedItems && !HasUnevaluatedProperties)
             {
@@ -14155,7 +14444,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4847 "SchemaEntity201909.tt"
+        #line 4928 "SchemaEntity201909.tt"
         this.Write("                if (level == ValidationLevel.Flag)\r\n                {\r\n          " +
                 "          return result;\r\n                }\r\n                else\r\n             " +
                 "   {\r\n                    foundValid = true;\r\n                }\r\n            ");
@@ -14163,7 +14452,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4855 "SchemaEntity201909.tt"
+        #line 4936 "SchemaEntity201909.tt"
 
             }
             else
@@ -14173,13 +14462,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4860 "SchemaEntity201909.tt"
+        #line 4941 "SchemaEntity201909.tt"
         this.Write("                    foundValid = true;\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4861 "SchemaEntity201909.tt"
+        #line 4942 "SchemaEntity201909.tt"
 
             }
             
@@ -14187,7 +14476,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4864 "SchemaEntity201909.tt"
+        #line 4945 "SchemaEntity201909.tt"
         this.Write("            }\r\n            else\r\n            {\r\n                if (level >= Vali" +
                 "dationLevel.Detailed)\r\n                {\r\n                    result = result.Me" +
                 "rgeResults(result.IsValid, level, anyOfResult");
@@ -14195,13 +14484,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4869 "SchemaEntity201909.tt"
+        #line 4950 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4869 "SchemaEntity201909.tt"
+        #line 4950 "SchemaEntity201909.tt"
         this.Write(");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)\r\n" +
                 "                {\r\n                    result = result.MergeResults(result.IsVal" +
                 "id, level, anyOfResult");
@@ -14209,19 +14498,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4873 "SchemaEntity201909.tt"
+        #line 4954 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4873 "SchemaEntity201909.tt"
+        #line 4954 "SchemaEntity201909.tt"
         this.Write(");\r\n                }\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4877 "SchemaEntity201909.tt"
+        #line 4958 "SchemaEntity201909.tt"
 
             anyOfIndex++;
         }
@@ -14230,7 +14519,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4881 "SchemaEntity201909.tt"
+        #line 4962 "SchemaEntity201909.tt"
         this.Write(@"
             if (foundValid)
             {
@@ -14263,7 +14552,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4908 "SchemaEntity201909.tt"
+        #line 4989 "SchemaEntity201909.tt"
 
     }
     
@@ -14271,13 +14560,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4911 "SchemaEntity201909.tt"
+        #line 4992 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4913 "SchemaEntity201909.tt"
+        #line 4994 "SchemaEntity201909.tt"
 
     if (HasAllOf)
     {
@@ -14286,7 +14575,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4917 "SchemaEntity201909.tt"
+        #line 4998 "SchemaEntity201909.tt"
         this.Write("        \r\n        private ValidationContext ValidateAllOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n        ");
@@ -14294,7 +14583,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4922 "SchemaEntity201909.tt"
+        #line 5003 "SchemaEntity201909.tt"
 
         int allOfIndex = 0;
         foreach (var allOf in AllOf)
@@ -14304,44 +14593,44 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4927 "SchemaEntity201909.tt"
+        #line 5008 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n            ValidationContext allOfResult");
         
         #line default
         #line hidden
         
-        #line 4929 "SchemaEntity201909.tt"
+        #line 5010 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4929 "SchemaEntity201909.tt"
+        #line 5010 "SchemaEntity201909.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 4929 "SchemaEntity201909.tt"
+        #line 5010 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOf ));
         
         #line default
         #line hidden
         
-        #line 4929 "SchemaEntity201909.tt"
+        #line 5010 "SchemaEntity201909.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (!" +
                 "allOfResult");
         
         #line default
         #line hidden
         
-        #line 4931 "SchemaEntity201909.tt"
+        #line 5012 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4931 "SchemaEntity201909.tt"
+        #line 5012 "SchemaEntity201909.tt"
         this.Write(".IsValid)\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r" +
                 "\n                {\r\n                    result = result.MergeChildContext(allOfR" +
                 "esult");
@@ -14349,13 +14638,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4935 "SchemaEntity201909.tt"
+        #line 5016 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4935 "SchemaEntity201909.tt"
+        #line 5016 "SchemaEntity201909.tt"
         this.Write(@", true).WithResult(isValid: false, ""Validation 10.2.1.1. allOf - failed to validate against the allOf schema."");
                 }
                 else if (level >= ValidationLevel.Basic)
@@ -14365,13 +14654,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4939 "SchemaEntity201909.tt"
+        #line 5020 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4939 "SchemaEntity201909.tt"
+        #line 5020 "SchemaEntity201909.tt"
         this.Write(", true).WithResult(isValid: false, \"Validation 10.2.1.1. allOf - failed to valida" +
                 "te against the allOf schema.\");\r\n                }\r\n                else\r\n      " +
                 "          {\r\n                    result = result.MergeChildContext(allOfResult");
@@ -14379,13 +14668,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4943 "SchemaEntity201909.tt"
+        #line 5024 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4943 "SchemaEntity201909.tt"
+        #line 5024 "SchemaEntity201909.tt"
         this.Write(", false).WithResult(isValid: false);\r\n                    return result;\r\n       " +
                 "         }\r\n            }\r\n            else\r\n            {\r\n                resu" +
                 "lt = result.MergeChildContext(allOfResult");
@@ -14393,19 +14682,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4949 "SchemaEntity201909.tt"
+        #line 5030 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4949 "SchemaEntity201909.tt"
+        #line 5030 "SchemaEntity201909.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4952 "SchemaEntity201909.tt"
+        #line 5033 "SchemaEntity201909.tt"
 
             allOfIndex++;
         }
@@ -14414,13 +14703,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4956 "SchemaEntity201909.tt"
+        #line 5037 "SchemaEntity201909.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4960 "SchemaEntity201909.tt"
+        #line 5041 "SchemaEntity201909.tt"
 
     }
     
@@ -14428,13 +14717,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4963 "SchemaEntity201909.tt"
+        #line 5044 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4965 "SchemaEntity201909.tt"
+        #line 5046 "SchemaEntity201909.tt"
 
     if (HasNot)
     {
@@ -14443,7 +14732,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4969 "SchemaEntity201909.tt"
+        #line 5050 "SchemaEntity201909.tt"
         this.Write("        \r\n        private ValidationContext ValidateNot(ValidationContext validat" +
                 "ionContext, ValidationLevel level)\r\n        {\r\n            ValidationContext res" +
                 "ult = validationContext;\r\n\r\n            ValidationContext notResult = this.As<");
@@ -14451,13 +14740,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4974 "SchemaEntity201909.tt"
+        #line 5055 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( NotDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4974 "SchemaEntity201909.tt"
+        #line 5055 "SchemaEntity201909.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
             if (notResult.IsValid)
             {
@@ -14487,7 +14776,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4998 "SchemaEntity201909.tt"
+        #line 5079 "SchemaEntity201909.tt"
 
     }
     
@@ -14495,13 +14784,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5001 "SchemaEntity201909.tt"
+        #line 5082 "SchemaEntity201909.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5003 "SchemaEntity201909.tt"
+        #line 5084 "SchemaEntity201909.tt"
 
     if (HasIfThenElse)
     {
@@ -14510,7 +14799,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5007 "SchemaEntity201909.tt"
+        #line 5088 "SchemaEntity201909.tt"
         this.Write("        \r\n        private ValidationContext ValidateIfThenElse(in ValidationConte" +
                 "xt validationContext, ValidationLevel level)\r\n        {\r\n            ValidationC" +
                 "ontext result = validationContext;\r\n\r\n            ValidationContext ifResult = t" +
@@ -14519,13 +14808,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5012 "SchemaEntity201909.tt"
+        #line 5093 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( IfFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5012 "SchemaEntity201909.tt"
+        #line 5093 "SchemaEntity201909.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
             if (!ifResult.IsValid)
@@ -14555,7 +14844,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5036 "SchemaEntity201909.tt"
+        #line 5117 "SchemaEntity201909.tt"
 
         if (HasThen)
         {
@@ -14564,20 +14853,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5040 "SchemaEntity201909.tt"
+        #line 5121 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (ifResult.IsValid)\r\n            {\r\n                Valid" +
                 "ationContext thenResult = this.As<");
         
         #line default
         #line hidden
         
-        #line 5043 "SchemaEntity201909.tt"
+        #line 5124 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ThenFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5043 "SchemaEntity201909.tt"
+        #line 5124 "SchemaEntity201909.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
                 if (!thenResult.IsValid)
@@ -14611,7 +14900,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5071 "SchemaEntity201909.tt"
+        #line 5152 "SchemaEntity201909.tt"
 
         }
         
@@ -14619,13 +14908,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5074 "SchemaEntity201909.tt"
+        #line 5155 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5075 "SchemaEntity201909.tt"
+        #line 5156 "SchemaEntity201909.tt"
 
         if (HasElse)
         {
@@ -14634,20 +14923,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5079 "SchemaEntity201909.tt"
+        #line 5160 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (!ifResult.IsValid)\r\n            {\r\n                Vali" +
                 "dationContext elseResult = this.As<");
         
         #line default
         #line hidden
         
-        #line 5082 "SchemaEntity201909.tt"
+        #line 5163 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ElseFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5082 "SchemaEntity201909.tt"
+        #line 5163 "SchemaEntity201909.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
                 if (!elseResult.IsValid)
@@ -14681,7 +14970,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5110 "SchemaEntity201909.tt"
+        #line 5191 "SchemaEntity201909.tt"
 
         }
         
@@ -14689,13 +14978,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5113 "SchemaEntity201909.tt"
+        #line 5194 "SchemaEntity201909.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5117 "SchemaEntity201909.tt"
+        #line 5198 "SchemaEntity201909.tt"
 
     }
     
@@ -14703,13 +14992,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5120 "SchemaEntity201909.tt"
+        #line 5201 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5121 "SchemaEntity201909.tt"
+        #line 5202 "SchemaEntity201909.tt"
 
     if (HasMediaTypeOrEncoding)
     {
@@ -14718,14 +15007,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5125 "SchemaEntity201909.tt"
+        #line 5206 "SchemaEntity201909.tt"
         this.Write("        private ValidationContext ValidateMediaTypeAndEncoding(JsonValueKind valu" +
                 "eKind, ValidationContext result, ValidationLevel level)\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5127 "SchemaEntity201909.tt"
+        #line 5208 "SchemaEntity201909.tt"
 
         if (IsJsonBase64Content)
         {
@@ -14734,195 +15023,10 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5131 "SchemaEntity201909.tt"
+        #line 5212 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return this.As<JsonBase64Content>().Validate(result, level);\r\n      " +
                 "      }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5136 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5139 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5140 "SchemaEntity201909.tt"
-
-        if (IsJsonBase64String)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5144 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return this.As<JsonBase64String>().Validate(result, level);\r\n       " +
-                "     }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5150 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5153 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5154 "SchemaEntity201909.tt"
-
-        if (IsJsonContent)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5158 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return this.As<JsonContent>().Validate(result, level);\r\n            " +
-                "}\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5163 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5166 "SchemaEntity201909.tt"
-        this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 5170 "SchemaEntity201909.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 5173 "SchemaEntity201909.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 5174 "SchemaEntity201909.tt"
-
-    if (HasFormat)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 5178 "SchemaEntity201909.tt"
-        this.Write("        \r\n        private ValidationContext ValidateFormat(JsonValueKind valueKin" +
-                "d, ValidationContext result, ValidationLevel level)\r\n        {\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5181 "SchemaEntity201909.tt"
-
-        if (IsJsonRelativePointer)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5185 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
-                "vel);\r\n            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5190 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5193 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5194 "SchemaEntity201909.tt"
-
-        if (IsJsonDate)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5198 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeDate(this, result, level);\r\n        " +
-                "    }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5204 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5207 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5208 "SchemaEntity201909.tt"
-
-        if (IsJsonDateTime)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5212 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeDateTime(this, result, level);\r\n    " +
-                "        }\r\n        ");
         
         #line default
         #line hidden
@@ -14943,7 +15047,7 @@ namespace ");
         
         #line 5221 "SchemaEntity201909.tt"
 
-        if (IsJsonDuration)
+        if (IsJsonBase64String)
         {
         
         
@@ -14952,13 +15056,13 @@ namespace ");
         
         #line 5225 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeDuration(this, result, level);\r\n    " +
-                "        }\r\n        ");
+                "            return this.As<JsonBase64String>().Validate(result, level);\r\n       " +
+                "     }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5230 "SchemaEntity201909.tt"
+        #line 5231 "SchemaEntity201909.tt"
 
         }
         
@@ -14966,13 +15070,198 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5233 "SchemaEntity201909.tt"
+        #line 5234 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5234 "SchemaEntity201909.tt"
+        #line 5235 "SchemaEntity201909.tt"
+
+        if (IsJsonContent)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5239 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return this.As<JsonContent>().Validate(result, level);\r\n            " +
+                "}\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5244 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5247 "SchemaEntity201909.tt"
+        this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 5251 "SchemaEntity201909.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 5254 "SchemaEntity201909.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 5255 "SchemaEntity201909.tt"
+
+    if (HasFormat)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 5259 "SchemaEntity201909.tt"
+        this.Write("        \r\n        private ValidationContext ValidateFormat(JsonValueKind valueKin" +
+                "d, ValidationContext result, ValidationLevel level)\r\n        {\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5262 "SchemaEntity201909.tt"
+
+        if (IsJsonRelativePointer)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5266 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
+                "vel);\r\n            }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5271 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5274 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5275 "SchemaEntity201909.tt"
+
+        if (IsJsonDate)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5279 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeDate(this, result, level);\r\n        " +
+                "    }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5285 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5288 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5289 "SchemaEntity201909.tt"
+
+        if (IsJsonDateTime)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5293 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeDateTime(this, result, level);\r\n    " +
+                "        }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5298 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5301 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5302 "SchemaEntity201909.tt"
+
+        if (IsJsonDuration)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5306 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeDuration(this, result, level);\r\n    " +
+                "        }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5311 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5314 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5315 "SchemaEntity201909.tt"
 
         if (IsJsonTime)
         {
@@ -14981,7 +15270,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5238 "SchemaEntity201909.tt"
+        #line 5319 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeTime(this, result, level);\r\n        " +
                 "    }\r\n        ");
@@ -14989,7 +15278,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5243 "SchemaEntity201909.tt"
+        #line 5324 "SchemaEntity201909.tt"
 
         }
         
@@ -14997,13 +15286,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5246 "SchemaEntity201909.tt"
+        #line 5327 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5247 "SchemaEntity201909.tt"
+        #line 5328 "SchemaEntity201909.tt"
 
         if (IsJsonEmail)
         {
@@ -15012,196 +15301,10 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5251 "SchemaEntity201909.tt"
+        #line 5332 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeEmail(this, result, level);\r\n       " +
                 "     }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5256 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5259 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5260 "SchemaEntity201909.tt"
-
-        if (IsJsonHostname)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5264 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeHostname(this, result, level);\r\n    " +
-                "        }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5269 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5272 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5273 "SchemaEntity201909.tt"
-
-        if (IsJsonIdnEmail)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5277 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIdnEmail(this, result, level);\r\n    " +
-                "        }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5283 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5286 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5287 "SchemaEntity201909.tt"
-
-        if (IsJsonIdnHostname)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5291 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIdnHostname(this, result, level);\r\n " +
-                "           }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5296 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5299 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5300 "SchemaEntity201909.tt"
-
-        if (IsJsonInteger)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5304 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.Number)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeInteger(this, result, level);\r\n     " +
-                "       }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5309 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5312 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5313 "SchemaEntity201909.tt"
-
-        if (IsJsonIpV4)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5317 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIpV4(this, result, level);\r\n        " +
-                "    }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5323 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5326 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5327 "SchemaEntity201909.tt"
-
-        if (IsJsonIpV6)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5331 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIpV6(this, result, level);\r\n        " +
-                "    }\r\n\r\n        ");
         
         #line default
         #line hidden
@@ -15222,7 +15325,7 @@ namespace ");
         
         #line 5341 "SchemaEntity201909.tt"
 
-        if (IsJsonIri)
+        if (IsJsonHostname)
         {
         
         
@@ -15231,8 +15334,8 @@ namespace ");
         
         #line 5345 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIri(this, result, level);\r\n         " +
-                "   }\r\n        ");
+                "            return Corvus.Json.Validate.TypeHostname(this, result, level);\r\n    " +
+                "        }\r\n        ");
         
         #line default
         #line hidden
@@ -15253,7 +15356,7 @@ namespace ");
         
         #line 5354 "SchemaEntity201909.tt"
 
-        if (IsJsonIriReference)
+        if (IsJsonIdnEmail)
         {
         
         
@@ -15262,13 +15365,13 @@ namespace ");
         
         #line 5358 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIriReference(this, result, level);\r\n" +
-                "            }\r\n        ");
+                "            return Corvus.Json.Validate.TypeIdnEmail(this, result, level);\r\n    " +
+                "        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5363 "SchemaEntity201909.tt"
+        #line 5364 "SchemaEntity201909.tt"
 
         }
         
@@ -15276,13 +15379,199 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5366 "SchemaEntity201909.tt"
+        #line 5367 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5367 "SchemaEntity201909.tt"
+        #line 5368 "SchemaEntity201909.tt"
+
+        if (IsJsonIdnHostname)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5372 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeIdnHostname(this, result, level);\r\n " +
+                "           }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5377 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5380 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5381 "SchemaEntity201909.tt"
+
+        if (IsJsonInteger)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5385 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.Number)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeInteger(this, result, level);\r\n     " +
+                "       }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5390 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5393 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5394 "SchemaEntity201909.tt"
+
+        if (IsJsonIpV4)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5398 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeIpV4(this, result, level);\r\n        " +
+                "    }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5404 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5407 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5408 "SchemaEntity201909.tt"
+
+        if (IsJsonIpV6)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5412 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeIpV6(this, result, level);\r\n        " +
+                "    }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5418 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5421 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5422 "SchemaEntity201909.tt"
+
+        if (IsJsonIri)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5426 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeIri(this, result, level);\r\n         " +
+                "   }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5431 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5434 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5435 "SchemaEntity201909.tt"
+
+        if (IsJsonIriReference)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5439 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeIriReference(this, result, level);\r\n" +
+                "            }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5444 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5447 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5448 "SchemaEntity201909.tt"
 
         if (IsJsonPointer)
         {
@@ -15291,196 +15580,10 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5371 "SchemaEntity201909.tt"
+        #line 5452 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeJsonPointer(this, result, level);\r\n " +
                 "           }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5376 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5379 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5380 "SchemaEntity201909.tt"
-
-        if (IsJsonRegex)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5384 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeRegex(this, result, level);\r\n       " +
-                "     }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5389 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5392 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5393 "SchemaEntity201909.tt"
-
-        if (IsJsonRelativePointer)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5397 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
-                "vel);\r\n            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5402 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5405 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5406 "SchemaEntity201909.tt"
-
-        if (IsJsonTime)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5410 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeTime(this, result, level);\r\n        " +
-                "    }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5416 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5419 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5420 "SchemaEntity201909.tt"
-
-        if (IsJsonUri)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5424 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeUri(this, result, level);\r\n         " +
-                "   }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5430 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5433 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5434 "SchemaEntity201909.tt"
-
-        if (IsJsonUriReference)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5438 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeUriReference(this, result, level);\r\n" +
-                "            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5443 "SchemaEntity201909.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5446 "SchemaEntity201909.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5447 "SchemaEntity201909.tt"
-
-        if (IsJsonUriTemplate)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5451 "SchemaEntity201909.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeUriTemplate(this, result, level);\r\n " +
-                "           }\r\n\r\n        ");
         
         #line default
         #line hidden
@@ -15501,7 +15604,7 @@ namespace ");
         
         #line 5461 "SchemaEntity201909.tt"
 
-        if (IsJsonUuid)
+        if (IsJsonRegex)
         {
         
         
@@ -15510,13 +15613,13 @@ namespace ");
         
         #line 5465 "SchemaEntity201909.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeUuid(this, result, level);\r\n        " +
-                "    }\r\n\r\n        ");
+                "            return Corvus.Json.Validate.TypeRegex(this, result, level);\r\n       " +
+                "     }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5471 "SchemaEntity201909.tt"
+        #line 5470 "SchemaEntity201909.tt"
 
         }
         
@@ -15524,13 +15627,199 @@ namespace ");
         #line default
         #line hidden
         
+        #line 5473 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
         #line 5474 "SchemaEntity201909.tt"
-        this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
+
+        if (IsJsonRelativePointer)
+        {
+        
         
         #line default
         #line hidden
         
         #line 5478 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
+                "vel);\r\n            }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5483 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5486 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5487 "SchemaEntity201909.tt"
+
+        if (IsJsonTime)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5491 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeTime(this, result, level);\r\n        " +
+                "    }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5497 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5500 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5501 "SchemaEntity201909.tt"
+
+        if (IsJsonUri)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5505 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeUri(this, result, level);\r\n         " +
+                "   }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5511 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5514 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5515 "SchemaEntity201909.tt"
+
+        if (IsJsonUriReference)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5519 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeUriReference(this, result, level);\r\n" +
+                "            }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5524 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5527 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5528 "SchemaEntity201909.tt"
+
+        if (IsJsonUriTemplate)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5532 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeUriTemplate(this, result, level);\r\n " +
+                "           }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5538 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5541 "SchemaEntity201909.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5542 "SchemaEntity201909.tt"
+
+        if (IsJsonUuid)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5546 "SchemaEntity201909.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeUuid(this, result, level);\r\n        " +
+                "    }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5552 "SchemaEntity201909.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5555 "SchemaEntity201909.tt"
+        this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 5559 "SchemaEntity201909.tt"
 
     }
     
@@ -15538,13 +15827,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5481 "SchemaEntity201909.tt"
+        #line 5562 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5482 "SchemaEntity201909.tt"
+        #line 5563 "SchemaEntity201909.tt"
 
     if (HasType)
     {
@@ -15553,7 +15842,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5486 "SchemaEntity201909.tt"
+        #line 5567 "SchemaEntity201909.tt"
         this.Write(@"        
         private ValidationContext ValidateType(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
@@ -15565,7 +15854,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5492 "SchemaEntity201909.tt"
+        #line 5573 "SchemaEntity201909.tt"
 
         if (HasStringType)
         {
@@ -15574,7 +15863,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5496 "SchemaEntity201909.tt"
+        #line 5577 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultString = Corvus.Json.Validate.TypeString(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultString.IsValid)
@@ -15592,7 +15881,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5508 "SchemaEntity201909.tt"
+        #line 5589 "SchemaEntity201909.tt"
 
         }
         
@@ -15600,13 +15889,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5511 "SchemaEntity201909.tt"
+        #line 5592 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5512 "SchemaEntity201909.tt"
+        #line 5593 "SchemaEntity201909.tt"
 
         if (HasObjectType)
         {
@@ -15615,7 +15904,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5516 "SchemaEntity201909.tt"
+        #line 5597 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultObject = Corvus.Json.Validate.TypeObject(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultObject.IsValid)
@@ -15633,7 +15922,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5528 "SchemaEntity201909.tt"
+        #line 5609 "SchemaEntity201909.tt"
 
         }
         
@@ -15641,13 +15930,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5531 "SchemaEntity201909.tt"
+        #line 5612 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5532 "SchemaEntity201909.tt"
+        #line 5613 "SchemaEntity201909.tt"
 
         if (HasArrayType)
         {
@@ -15656,7 +15945,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5536 "SchemaEntity201909.tt"
+        #line 5617 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultArray = Corvus.Json.Validate.TypeArray(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultArray.IsValid)
@@ -15674,7 +15963,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5548 "SchemaEntity201909.tt"
+        #line 5629 "SchemaEntity201909.tt"
 
         }
         
@@ -15682,13 +15971,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5551 "SchemaEntity201909.tt"
+        #line 5632 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5552 "SchemaEntity201909.tt"
+        #line 5633 "SchemaEntity201909.tt"
 
         if (HasNumberType)
         {
@@ -15697,7 +15986,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5556 "SchemaEntity201909.tt"
+        #line 5637 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultNumber = Corvus.Json.Validate.TypeNumber(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultNumber.IsValid)
@@ -15715,7 +16004,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5568 "SchemaEntity201909.tt"
+        #line 5649 "SchemaEntity201909.tt"
 
         }
         
@@ -15723,13 +16012,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5571 "SchemaEntity201909.tt"
+        #line 5652 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5572 "SchemaEntity201909.tt"
+        #line 5653 "SchemaEntity201909.tt"
 
         if (HasIntegerType)
         {
@@ -15738,7 +16027,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5576 "SchemaEntity201909.tt"
+        #line 5657 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultInteger = Corvus.Json.Validate.TypeInteger(this, result, level);
             if (level == ValidationLevel.Flag && localResultInteger.IsValid)
@@ -15756,7 +16045,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5588 "SchemaEntity201909.tt"
+        #line 5669 "SchemaEntity201909.tt"
 
         }
         
@@ -15764,13 +16053,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5591 "SchemaEntity201909.tt"
+        #line 5672 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5592 "SchemaEntity201909.tt"
+        #line 5673 "SchemaEntity201909.tt"
 
         if (HasBooleanType)
         {
@@ -15779,7 +16068,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5596 "SchemaEntity201909.tt"
+        #line 5677 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultBoolean = Corvus.Json.Validate.TypeBoolean(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultBoolean.IsValid)
@@ -15797,7 +16086,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5608 "SchemaEntity201909.tt"
+        #line 5689 "SchemaEntity201909.tt"
 
         }
         
@@ -15805,13 +16094,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5611 "SchemaEntity201909.tt"
+        #line 5692 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5612 "SchemaEntity201909.tt"
+        #line 5693 "SchemaEntity201909.tt"
 
         if (HasNullType)
         {
@@ -15820,7 +16109,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5616 "SchemaEntity201909.tt"
+        #line 5697 "SchemaEntity201909.tt"
         this.Write(@"        
             ValidationContext localResultNull = Corvus.Json.Validate.TypeNull(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultNull.IsValid)
@@ -15838,7 +16127,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5628 "SchemaEntity201909.tt"
+        #line 5709 "SchemaEntity201909.tt"
 
         }
         
@@ -15846,14 +16135,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5631 "SchemaEntity201909.tt"
+        #line 5712 "SchemaEntity201909.tt"
         this.Write("\r\n            result = result.MergeResults(\r\n                isValid,\r\n          " +
                 "      level\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5635 "SchemaEntity201909.tt"
+        #line 5716 "SchemaEntity201909.tt"
 
         if (HasStringType)
         {
@@ -15862,13 +16151,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5639 "SchemaEntity201909.tt"
+        #line 5720 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultString\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5641 "SchemaEntity201909.tt"
+        #line 5722 "SchemaEntity201909.tt"
 
         }
         
@@ -15876,13 +16165,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5644 "SchemaEntity201909.tt"
+        #line 5725 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5645 "SchemaEntity201909.tt"
+        #line 5726 "SchemaEntity201909.tt"
 
         if (HasObjectType)
         {
@@ -15891,13 +16180,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5649 "SchemaEntity201909.tt"
+        #line 5730 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultObject\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5651 "SchemaEntity201909.tt"
+        #line 5732 "SchemaEntity201909.tt"
 
         }
         
@@ -15905,13 +16194,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5654 "SchemaEntity201909.tt"
+        #line 5735 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5655 "SchemaEntity201909.tt"
+        #line 5736 "SchemaEntity201909.tt"
 
         if (HasArrayType)
         {
@@ -15920,13 +16209,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5659 "SchemaEntity201909.tt"
+        #line 5740 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultArray\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5661 "SchemaEntity201909.tt"
+        #line 5742 "SchemaEntity201909.tt"
 
         }
         
@@ -15934,13 +16223,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5664 "SchemaEntity201909.tt"
+        #line 5745 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5665 "SchemaEntity201909.tt"
+        #line 5746 "SchemaEntity201909.tt"
 
         if (HasNumberType)
         {
@@ -15949,13 +16238,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5669 "SchemaEntity201909.tt"
+        #line 5750 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultNumber\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5671 "SchemaEntity201909.tt"
+        #line 5752 "SchemaEntity201909.tt"
 
         }
         
@@ -15963,13 +16252,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5674 "SchemaEntity201909.tt"
+        #line 5755 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5675 "SchemaEntity201909.tt"
+        #line 5756 "SchemaEntity201909.tt"
 
         if (HasIntegerType)
         {
@@ -15978,13 +16267,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5679 "SchemaEntity201909.tt"
+        #line 5760 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultInteger\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5681 "SchemaEntity201909.tt"
+        #line 5762 "SchemaEntity201909.tt"
 
         }
         
@@ -15992,13 +16281,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5684 "SchemaEntity201909.tt"
+        #line 5765 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5685 "SchemaEntity201909.tt"
+        #line 5766 "SchemaEntity201909.tt"
 
         if (HasBooleanType)
         {
@@ -16007,13 +16296,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5689 "SchemaEntity201909.tt"
+        #line 5770 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultBoolean\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5691 "SchemaEntity201909.tt"
+        #line 5772 "SchemaEntity201909.tt"
 
         }
         
@@ -16021,13 +16310,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5694 "SchemaEntity201909.tt"
+        #line 5775 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5695 "SchemaEntity201909.tt"
+        #line 5776 "SchemaEntity201909.tt"
 
         if (HasNullType)
         {
@@ -16036,13 +16325,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5699 "SchemaEntity201909.tt"
+        #line 5780 "SchemaEntity201909.tt"
         this.Write("        \r\n                , localResultNull\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5701 "SchemaEntity201909.tt"
+        #line 5782 "SchemaEntity201909.tt"
 
         }
         
@@ -16050,13 +16339,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5704 "SchemaEntity201909.tt"
+        #line 5785 "SchemaEntity201909.tt"
         this.Write("                );\r\n\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5709 "SchemaEntity201909.tt"
+        #line 5790 "SchemaEntity201909.tt"
 
     }
     
@@ -16064,13 +16353,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5712 "SchemaEntity201909.tt"
+        #line 5793 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5713 "SchemaEntity201909.tt"
+        #line 5794 "SchemaEntity201909.tt"
 
     if (HasEnum)
     {
@@ -16079,14 +16368,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5717 "SchemaEntity201909.tt"
+        #line 5798 "SchemaEntity201909.tt"
         this.Write("        \r\n        /// <summary>\r\n        /// Permitted values.\r\n        /// </sum" +
                 "mary>\r\n        public static class EnumValues\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5723 "SchemaEntity201909.tt"
+        #line 5804 "SchemaEntity201909.tt"
 
         int enumItemIndex = 0;
         foreach (var enumValue in EnumValues)
@@ -16096,13 +16385,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5728 "SchemaEntity201909.tt"
+        #line 5809 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 5728 "SchemaEntity201909.tt"
+        #line 5809 "SchemaEntity201909.tt"
 
             if (enumValue.IsString)
             {
@@ -16111,7 +16400,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5732 "SchemaEntity201909.tt"
+        #line 5813 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// enumValue.AsPropertyName.\r\n           " +
                 " /// </summary>\r\n            /// <remarks>\r\n            /// {Description}.\r\n    " +
                 "        /// </remarks>\r\n            public static readonly ");
@@ -16119,43 +16408,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5738 "SchemaEntity201909.tt"
+        #line 5819 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5738 "SchemaEntity201909.tt"
+        #line 5819 "SchemaEntity201909.tt"
         this.Write(" ");
         
         #line default
         #line hidden
         
-        #line 5738 "SchemaEntity201909.tt"
+        #line 5819 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    enumValue.AsPropertyName));
         
         #line default
         #line hidden
         
-        #line 5738 "SchemaEntity201909.tt"
+        #line 5819 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5738 "SchemaEntity201909.tt"
+        #line 5819 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5738 "SchemaEntity201909.tt"
+        #line 5819 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5739 "SchemaEntity201909.tt"
+        #line 5820 "SchemaEntity201909.tt"
 
             }
             else if (enumValue.IsBoolean)
@@ -16165,19 +16454,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5744 "SchemaEntity201909.tt"
+        #line 5825 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5745 "SchemaEntity201909.tt"
+        #line 5826 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5745 "SchemaEntity201909.tt"
+        #line 5826 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16185,43 +16474,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5750 "SchemaEntity201909.tt"
+        #line 5831 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5750 "SchemaEntity201909.tt"
+        #line 5831 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5750 "SchemaEntity201909.tt"
+        #line 5831 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5750 "SchemaEntity201909.tt"
+        #line 5831 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5750 "SchemaEntity201909.tt"
+        #line 5831 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5750 "SchemaEntity201909.tt"
+        #line 5831 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5751 "SchemaEntity201909.tt"
+        #line 5832 "SchemaEntity201909.tt"
 
             }
             else if (enumValue.IsNumber)
@@ -16231,19 +16520,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5756 "SchemaEntity201909.tt"
+        #line 5837 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5757 "SchemaEntity201909.tt"
+        #line 5838 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5757 "SchemaEntity201909.tt"
+        #line 5838 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16251,43 +16540,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5762 "SchemaEntity201909.tt"
+        #line 5843 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5762 "SchemaEntity201909.tt"
+        #line 5843 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5762 "SchemaEntity201909.tt"
+        #line 5843 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5762 "SchemaEntity201909.tt"
+        #line 5843 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5762 "SchemaEntity201909.tt"
+        #line 5843 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5762 "SchemaEntity201909.tt"
+        #line 5843 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5763 "SchemaEntity201909.tt"
+        #line 5844 "SchemaEntity201909.tt"
 
             }
             else if (enumValue.IsObject)
@@ -16297,19 +16586,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5768 "SchemaEntity201909.tt"
+        #line 5849 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5769 "SchemaEntity201909.tt"
+        #line 5850 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5769 "SchemaEntity201909.tt"
+        #line 5850 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16317,43 +16606,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5774 "SchemaEntity201909.tt"
+        #line 5855 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5774 "SchemaEntity201909.tt"
+        #line 5855 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5774 "SchemaEntity201909.tt"
+        #line 5855 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5774 "SchemaEntity201909.tt"
+        #line 5855 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5774 "SchemaEntity201909.tt"
+        #line 5855 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5774 "SchemaEntity201909.tt"
+        #line 5855 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5775 "SchemaEntity201909.tt"
+        #line 5856 "SchemaEntity201909.tt"
 
             }
             else if (enumValue.IsArray)
@@ -16363,19 +16652,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5780 "SchemaEntity201909.tt"
+        #line 5861 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5781 "SchemaEntity201909.tt"
+        #line 5862 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5781 "SchemaEntity201909.tt"
+        #line 5862 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16383,43 +16672,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5786 "SchemaEntity201909.tt"
+        #line 5867 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5786 "SchemaEntity201909.tt"
+        #line 5867 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5786 "SchemaEntity201909.tt"
+        #line 5867 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5786 "SchemaEntity201909.tt"
+        #line 5867 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5786 "SchemaEntity201909.tt"
+        #line 5867 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5786 "SchemaEntity201909.tt"
+        #line 5867 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5787 "SchemaEntity201909.tt"
+        #line 5868 "SchemaEntity201909.tt"
 
             }
             else if (enumValue.IsNull)
@@ -16429,19 +16718,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5792 "SchemaEntity201909.tt"
+        #line 5873 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5793 "SchemaEntity201909.tt"
+        #line 5874 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5793 "SchemaEntity201909.tt"
+        #line 5874 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16449,31 +16738,31 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5798 "SchemaEntity201909.tt"
+        #line 5879 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5798 "SchemaEntity201909.tt"
+        #line 5879 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5798 "SchemaEntity201909.tt"
+        #line 5879 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5798 "SchemaEntity201909.tt"
+        #line 5879 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(\"null\");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5799 "SchemaEntity201909.tt"
+        #line 5880 "SchemaEntity201909.tt"
 
             }
             
@@ -16481,13 +16770,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5802 "SchemaEntity201909.tt"
+        #line 5883 "SchemaEntity201909.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5803 "SchemaEntity201909.tt"
+        #line 5884 "SchemaEntity201909.tt"
 
             ++enumItemIndex;
         }
@@ -16496,13 +16785,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5807 "SchemaEntity201909.tt"
+        #line 5888 "SchemaEntity201909.tt"
         this.Write("\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5809 "SchemaEntity201909.tt"
+        #line 5890 "SchemaEntity201909.tt"
 
         enumItemIndex = 0;
         foreach (var enumValue in EnumValues)
@@ -16512,13 +16801,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5814 "SchemaEntity201909.tt"
+        #line 5895 "SchemaEntity201909.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 5814 "SchemaEntity201909.tt"
+        #line 5895 "SchemaEntity201909.tt"
 
             if (enumValue.IsString)
             {
@@ -16527,19 +16816,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5818 "SchemaEntity201909.tt"
+        #line 5899 "SchemaEntity201909.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5819 "SchemaEntity201909.tt"
+        #line 5900 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5819 "SchemaEntity201909.tt"
+        #line 5900 "SchemaEntity201909.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            inte" +
                 "rnal static readonly ");
@@ -16547,43 +16836,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5824 "SchemaEntity201909.tt"
+        #line 5905 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5824 "SchemaEntity201909.tt"
+        #line 5905 "SchemaEntity201909.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5824 "SchemaEntity201909.tt"
+        #line 5905 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5824 "SchemaEntity201909.tt"
+        #line 5905 "SchemaEntity201909.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5824 "SchemaEntity201909.tt"
+        #line 5905 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5824 "SchemaEntity201909.tt"
+        #line 5905 "SchemaEntity201909.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5825 "SchemaEntity201909.tt"
+        #line 5906 "SchemaEntity201909.tt"
 
             }
             enumItemIndex++;
@@ -16593,13 +16882,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5830 "SchemaEntity201909.tt"
+        #line 5911 "SchemaEntity201909.tt"
         this.Write("        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5831 "SchemaEntity201909.tt"
+        #line 5912 "SchemaEntity201909.tt"
 
     }
     
@@ -16607,13 +16896,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5834 "SchemaEntity201909.tt"
+        #line 5915 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5835 "SchemaEntity201909.tt"
+        #line 5916 "SchemaEntity201909.tt"
 
     foreach(var nestedType in NestedTypes)
     {
@@ -16622,25 +16911,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5839 "SchemaEntity201909.tt"
+        #line 5920 "SchemaEntity201909.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5840 "SchemaEntity201909.tt"
+        #line 5921 "SchemaEntity201909.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( WriteNestedType(nestedType) ));
         
         #line default
         #line hidden
         
-        #line 5840 "SchemaEntity201909.tt"
+        #line 5921 "SchemaEntity201909.tt"
         this.Write("\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5842 "SchemaEntity201909.tt"
+        #line 5923 "SchemaEntity201909.tt"
 
     }
     
@@ -16648,13 +16937,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5845 "SchemaEntity201909.tt"
+        #line 5926 "SchemaEntity201909.tt"
         this.Write("\r\n    }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5847 "SchemaEntity201909.tt"
+        #line 5928 "SchemaEntity201909.tt"
 
     if (!IsNested)
     {
@@ -16663,13 +16952,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5851 "SchemaEntity201909.tt"
+        #line 5932 "SchemaEntity201909.tt"
         this.Write("}\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5852 "SchemaEntity201909.tt"
+        #line 5933 "SchemaEntity201909.tt"
 
     }
     

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntity201909.tt
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntity201909.tt
@@ -2426,6 +2426,7 @@ namespace <#= Namespace #>
                 builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, <#= property.DotnetParameterName #>__);
             }            
         <#
+            }
         }
         #>
             return builder.ToImmutable();

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntity201909.tt
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntity201909.tt
@@ -2426,15 +2426,6 @@ namespace <#= Namespace #>
                 builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, <#= property.DotnetParameterName #>__);
             }            
         <#
-            if (IsConst(property.Type))
-            {
-        #>
-            else
-            {
-                builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, new <#= property.Type.FullyQualifiedDotnetTypeName #>());
-            }
-        <#
-            }
         }
         #>
             return builder.ToImmutable();

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntity201909.tt
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntity201909.tt
@@ -251,6 +251,62 @@ namespace <#= Namespace #>
     }
     #>
 
+    <#
+    if (HasConst)
+    {
+    #>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="<#= TypeDeclaration.DotnetTypeName #>"/> struct.
+        /// </summary>
+        public <#= TypeDeclaration.DotnetTypeName #>()
+        {
+            this.jsonElementBacking = __CorvusConstValue.jsonElementBacking;
+    <#
+    if(IsImplicitObject)
+    {
+    #>
+            this.objectBacking = __CorvusConstValue.objectBacking;
+    <#
+    }
+    #>
+    <#
+    if(IsImplicitArray)
+    {
+    #>
+            this.arrayBacking = __CorvusConstValue.arrayBacking;
+    <#
+    }
+    #>
+    <#
+    if(IsImplicitNumber)
+    {
+    #>
+            this.numberBacking = __CorvusConstValue.numberBacking;
+    <#
+    }
+    #>
+    <#
+    if(IsImplicitString)
+    {
+    #>
+            this.stringBacking = __CorvusConstValue.stringBacking;
+    <#
+    }
+    #>
+    <#
+    if(IsImplicitBoolean)
+    {
+    #>
+            this.booleanBacking = __CorvusConstValue.booleanBacking;
+    <#
+    }
+    #>
+        }
+
+    <#
+    }
+    #>
+
         /// <summary>
         /// Initializes a new instance of the <see cref="<#= TypeDeclaration.DotnetTypeName #>"/> struct.
         /// </summary>
@@ -2308,17 +2364,20 @@ namespace <#= Namespace #>
         bool isFirstCreateParameter = true;
         foreach(var property in RequiredAllOfAndRefProperties)
         {
-            if (isFirstCreateParameter)
-            {
-                isFirstCreateParameter = false;
-            }
-            else
-            {
+            if (!IsConst(property.Type))
+            {           
+                if (isFirstCreateParameter)
+                {
+                    isFirstCreateParameter = false;
+                }
+                else
+                {
         #>, <#
-            }
+                }
         #>
            <#= property.Type.FullyQualifiedDotnetTypeName #> <#= property.DotnetParameterName #>
         <#
+            }
         }
         #>
         <#
@@ -2344,9 +2403,18 @@ namespace <#= Namespace #>
         <#
         foreach(var property in RequiredAllOfAndRefProperties)
         {
+            if (IsConst(property.Type))
+            {
+        #>
+            builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, new <#= property.Type.FullyQualifiedDotnetTypeName #>());
+        <#
+            }
+            else
+            {
         #>
             builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, <#= property.DotnetParameterName #>);
         <#
+            }
         }
         #>
         <#
@@ -2356,8 +2424,17 @@ namespace <#= Namespace #>
             if (<#= property.DotnetParameterName #> is <#= property.Type.FullyQualifiedDotnetTypeName #> <#= property.DotnetParameterName #>__)
             {
                 builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, <#= property.DotnetParameterName #>__);
+            }            
+        <#
+            if (IsConst(property.Type))
+            {
+        #>
+            else
+            {
+                builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, new <#= property.Type.FullyQualifiedDotnetTypeName #>());
             }
         <#
+            }
         }
         #>
             return builder.ToImmutable();
@@ -2366,6 +2443,10 @@ namespace <#= Namespace #>
         <#
         foreach(var property in Properties)
         {
+            if (IsConst(property.Type))
+            {
+                continue;
+            }
         #>
 
         /// <summary>

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntityPartial201909.cs
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/SchemaEntityPartial201909.cs
@@ -1960,6 +1960,16 @@ public partial class SchemaEntity201909
     }
 
     /// <summary>
+    /// Determines whether a particular child type declaration is a constant value.
+    /// </summary>
+    /// <param name="typeDeclaration">The type declaration to check.</param>
+    /// <returns><c>True</c> if the type declaration represents a const value.</returns>
+    public static bool IsConst(TypeDeclaration typeDeclaration)
+    {
+        return typeDeclaration.Schema.Const.IsNotUndefined();
+    }
+
+    /// <summary>
     /// Emits code for the UTF8 encoded byte array for the given string.
     /// </summary>
     /// <param name="name">The string to encode.</param>

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/TypeDeclaration.cs
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/TypeDeclaration.cs
@@ -355,21 +355,6 @@ namespace Corvus.Json.JsonSchema.TypeBuilder.Draft201909
             }
         }
 
-        private void MergeProperties(int index, PropertyDeclaration propertyDeclaration)
-        {
-            PropertyDeclaration? original = this.properties[index];
-
-            // Merge whether this is a required property with the parent
-            var propertyToAdd =
-                new PropertyDeclaration(
-                    propertyDeclaration.Type,
-                    propertyDeclaration.JsonPropertyName,
-                    propertyDeclaration.IsRequired || original.IsRequired,
-                    propertyDeclaration.IsDefinedInLocalScope);
-
-            this.properties = this.properties.SetItem(index, propertyToAdd);
-        }
-
         /// <summary>
         /// Normalizes the property set, ensuring we don't have any duplicate types or names.
         /// </summary>
@@ -458,6 +443,21 @@ namespace Corvus.Json.JsonSchema.TypeBuilder.Draft201909
             }
 
             this.Namespace = ns;
+        }
+
+        private void MergeProperties(int index, PropertyDeclaration propertyDeclaration)
+        {
+            PropertyDeclaration? original = this.properties[index];
+
+            // Merge whether this is a required property with the parent
+            var propertyToAdd =
+                new PropertyDeclaration(
+                    propertyDeclaration.Type,
+                    propertyDeclaration.JsonPropertyName,
+                    propertyDeclaration.IsRequired || original.IsRequired,
+                    propertyDeclaration.IsDefinedInLocalScope);
+
+            this.properties = this.properties.SetItem(index, propertyToAdd);
         }
 
         private class PropertyDeclarationEqualityComparer : IEqualityComparer<PropertyDeclaration>

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/TypeDeclaration.cs
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft201909/TypeDeclaration.cs
@@ -347,12 +347,27 @@ namespace Corvus.Json.JsonSchema.TypeBuilder.Draft201909
             int index = this.properties.IndexOf(propertyDeclaration, PropertyDeclarationEqualityComparer.Instance);
             if (index >= 0)
             {
-                this.properties = this.properties.SetItem(index, propertyDeclaration);
+                this.MergeProperties(index, propertyDeclaration);
             }
             else
             {
                 this.properties = this.properties.Add(propertyDeclaration);
             }
+        }
+
+        private void MergeProperties(int index, PropertyDeclaration propertyDeclaration)
+        {
+            PropertyDeclaration? original = this.properties[index];
+
+            // Merge whether this is a required property with the parent
+            var propertyToAdd =
+                new PropertyDeclaration(
+                    propertyDeclaration.Type,
+                    propertyDeclaration.JsonPropertyName,
+                    propertyDeclaration.IsRequired || original.IsRequired,
+                    propertyDeclaration.IsDefinedInLocalScope);
+
+            this.properties = this.properties.SetItem(index, propertyToAdd);
         }
 
         /// <summary>

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntity202012.cs
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntity202012.cs
@@ -7885,59 +7885,19 @@ namespace ");
         
         #line 2432 "SchemaEntity202012.tt"
 
-            if (IsConst(property.Type))
-            {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 2436 "SchemaEntity202012.tt"
-        this.Write("            else\r\n            {\r\n                builder.Add(");
-        
-        #line default
-        #line hidden
-        
-        #line 2438 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName));
-        
-        #line default
-        #line hidden
-        
-        #line 2438 "SchemaEntity202012.tt"
-        this.Write("JsonPropertyName, new ");
-        
-        #line default
-        #line hidden
-        
-        #line 2438 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 2438 "SchemaEntity202012.tt"
-        this.Write("());\r\n            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 2440 "SchemaEntity202012.tt"
-
-            }
         }
         
         
         #line default
         #line hidden
         
-        #line 2444 "SchemaEntity202012.tt"
+        #line 2435 "SchemaEntity202012.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2447 "SchemaEntity202012.tt"
+        #line 2438 "SchemaEntity202012.tt"
 
         foreach(var property in Properties)
         {
@@ -7950,19 +7910,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2455 "SchemaEntity202012.tt"
+        #line 2446 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Sets ");
         
         #line default
         #line hidden
         
-        #line 2457 "SchemaEntity202012.tt"
+        #line 2448 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(property.JsonPropertyName, true).Trim('"') ));
         
         #line default
         #line hidden
         
-        #line 2457 "SchemaEntity202012.tt"
+        #line 2448 "SchemaEntity202012.tt"
         this.Write(".\r\n        /// </summary>\r\n        /// <param name=\"value\">The value to set.</par" +
                 "am>\r\n        /// <returns>The entity with the updated property.</returns>\r\n     " +
                 "   public ");
@@ -7970,55 +7930,55 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2461 "SchemaEntity202012.tt"
+        #line 2452 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2461 "SchemaEntity202012.tt"
+        #line 2452 "SchemaEntity202012.tt"
         this.Write(" With");
         
         #line default
         #line hidden
         
-        #line 2461 "SchemaEntity202012.tt"
+        #line 2452 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 2461 "SchemaEntity202012.tt"
+        #line 2452 "SchemaEntity202012.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 2461 "SchemaEntity202012.tt"
+        #line 2452 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2461 "SchemaEntity202012.tt"
+        #line 2452 "SchemaEntity202012.tt"
         this.Write(" value)\r\n        {\r\n            return this.SetProperty(");
         
         #line default
         #line hidden
         
-        #line 2463 "SchemaEntity202012.tt"
+        #line 2454 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 2463 "SchemaEntity202012.tt"
+        #line 2454 "SchemaEntity202012.tt"
         this.Write("JsonPropertyName, value);\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2466 "SchemaEntity202012.tt"
+        #line 2457 "SchemaEntity202012.tt"
 
         }
         
@@ -8026,13 +7986,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2469 "SchemaEntity202012.tt"
+        #line 2460 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2470 "SchemaEntity202012.tt"
+        #line 2461 "SchemaEntity202012.tt"
 
     }
     
@@ -8040,7 +8000,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2473 "SchemaEntity202012.tt"
+        #line 2464 "SchemaEntity202012.tt"
         this.Write(@"
         /// <inheritdoc/>
         public override string ToString()
@@ -8071,7 +8031,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2498 "SchemaEntity202012.tt"
+        #line 2489 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -8080,13 +8040,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2502 "SchemaEntity202012.tt"
+        #line 2493 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2503 "SchemaEntity202012.tt"
+        #line 2494 "SchemaEntity202012.tt"
 
     }
     else
@@ -8096,13 +8056,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2508 "SchemaEntity202012.tt"
+        #line 2499 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2509 "SchemaEntity202012.tt"
+        #line 2500 "SchemaEntity202012.tt"
 
     }
     
@@ -8110,13 +8070,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2512 "SchemaEntity202012.tt"
+        #line 2503 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2512 "SchemaEntity202012.tt"
+        #line 2503 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -8125,13 +8085,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2516 "SchemaEntity202012.tt"
+        #line 2507 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2517 "SchemaEntity202012.tt"
+        #line 2508 "SchemaEntity202012.tt"
 
     }
     else
@@ -8141,13 +8101,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2522 "SchemaEntity202012.tt"
+        #line 2513 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2523 "SchemaEntity202012.tt"
+        #line 2514 "SchemaEntity202012.tt"
 
     }
     
@@ -8155,13 +8115,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2526 "SchemaEntity202012.tt"
+        #line 2517 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2526 "SchemaEntity202012.tt"
+        #line 2517 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -8170,13 +8130,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2530 "SchemaEntity202012.tt"
+        #line 2521 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2531 "SchemaEntity202012.tt"
+        #line 2522 "SchemaEntity202012.tt"
 
     }
     else
@@ -8186,13 +8146,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2536 "SchemaEntity202012.tt"
+        #line 2527 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2537 "SchemaEntity202012.tt"
+        #line 2528 "SchemaEntity202012.tt"
 
     }
     
@@ -8200,13 +8160,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2540 "SchemaEntity202012.tt"
+        #line 2531 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2540 "SchemaEntity202012.tt"
+        #line 2531 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -8215,13 +8175,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2544 "SchemaEntity202012.tt"
+        #line 2535 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2545 "SchemaEntity202012.tt"
+        #line 2536 "SchemaEntity202012.tt"
 
     }
     else
@@ -8231,13 +8191,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2550 "SchemaEntity202012.tt"
+        #line 2541 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2551 "SchemaEntity202012.tt"
+        #line 2542 "SchemaEntity202012.tt"
 
     }
     
@@ -8245,13 +8205,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2554 "SchemaEntity202012.tt"
+        #line 2545 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2554 "SchemaEntity202012.tt"
+        #line 2545 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -8260,14 +8220,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2558 "SchemaEntity202012.tt"
+        #line 2549 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.GetHa" +
                 "shCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2559 "SchemaEntity202012.tt"
+        #line 2550 "SchemaEntity202012.tt"
 
     }
     else
@@ -8277,14 +8237,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2564 "SchemaEntity202012.tt"
+        #line 2555 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Get" +
                 "HashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2565 "SchemaEntity202012.tt"
+        #line 2556 "SchemaEntity202012.tt"
 
     }
     
@@ -8292,7 +8252,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2568 "SchemaEntity202012.tt"
+        #line 2559 "SchemaEntity202012.tt"
         this.Write(@"                JsonValueKind.Null => JsonNull.NullHashCode,
                 _ => JsonAny.UndefinedHashCode,
             };
@@ -8309,7 +8269,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2579 "SchemaEntity202012.tt"
+        #line 2570 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -8318,7 +8278,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2583 "SchemaEntity202012.tt"
+        #line 2574 "SchemaEntity202012.tt"
         this.Write("            if (this.objectBacking is ImmutableDictionary<string, JsonAny> object" +
                 "Backing)\r\n            {\r\n                JsonObject.WriteProperties(objectBackin" +
                 "g, writer);\r\n                return;\r\n            }\r\n\r\n    ");
@@ -8326,7 +8286,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2589 "SchemaEntity202012.tt"
+        #line 2580 "SchemaEntity202012.tt"
 
     }
     
@@ -8334,13 +8294,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2592 "SchemaEntity202012.tt"
+        #line 2583 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2593 "SchemaEntity202012.tt"
+        #line 2584 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -8349,7 +8309,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2597 "SchemaEntity202012.tt"
+        #line 2588 "SchemaEntity202012.tt"
         this.Write("            if (this.arrayBacking is ImmutableList<JsonAny> arrayBacking)\r\n      " +
                 "      {\r\n                JsonArray.WriteItems(arrayBacking, writer);\r\n          " +
                 "      return;\r\n            }\r\n\r\n    ");
@@ -8357,7 +8317,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2603 "SchemaEntity202012.tt"
+        #line 2594 "SchemaEntity202012.tt"
 
     }
     
@@ -8365,13 +8325,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2606 "SchemaEntity202012.tt"
+        #line 2597 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2607 "SchemaEntity202012.tt"
+        #line 2598 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -8380,7 +8340,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2611 "SchemaEntity202012.tt"
+        #line 2602 "SchemaEntity202012.tt"
         this.Write("            if (this.numberBacking is double numberBacking)\r\n            {\r\n     " +
                 "           writer.WriteNumberValue(numberBacking);\r\n                return;\r\n   " +
                 "         }\r\n\r\n    ");
@@ -8388,7 +8348,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2617 "SchemaEntity202012.tt"
+        #line 2608 "SchemaEntity202012.tt"
 
     }
     
@@ -8396,13 +8356,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2620 "SchemaEntity202012.tt"
+        #line 2611 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2621 "SchemaEntity202012.tt"
+        #line 2612 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -8411,7 +8371,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2625 "SchemaEntity202012.tt"
+        #line 2616 "SchemaEntity202012.tt"
         this.Write("            if (this.stringBacking is string stringBacking)\r\n            {\r\n     " +
                 "           writer.WriteStringValue(stringBacking);\r\n                return;\r\n   " +
                 "         }\r\n\r\n    ");
@@ -8419,7 +8379,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2631 "SchemaEntity202012.tt"
+        #line 2622 "SchemaEntity202012.tt"
 
     }
     
@@ -8427,13 +8387,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2634 "SchemaEntity202012.tt"
+        #line 2625 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2635 "SchemaEntity202012.tt"
+        #line 2626 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -8442,7 +8402,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2639 "SchemaEntity202012.tt"
+        #line 2630 "SchemaEntity202012.tt"
         this.Write("            if (this.booleanBacking is bool booleanBacking)\r\n            {\r\n     " +
                 "           writer.WriteBooleanValue(booleanBacking);\r\n                return;\r\n " +
                 "           }\r\n    ");
@@ -8450,7 +8410,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2644 "SchemaEntity202012.tt"
+        #line 2635 "SchemaEntity202012.tt"
 
     }
     
@@ -8458,7 +8418,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2647 "SchemaEntity202012.tt"
+        #line 2638 "SchemaEntity202012.tt"
         this.Write("\r\n            if (this.jsonElementBacking.ValueKind != JsonValueKind.Undefined)\r\n" +
                 "            {\r\n                this.jsonElementBacking.WriteTo(writer);\r\n       " +
                 "         return;\r\n            }\r\n\r\n            writer.WriteNullValue();\r\n       " +
@@ -8467,7 +8427,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2657 "SchemaEntity202012.tt"
+        #line 2648 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -8476,13 +8436,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2661 "SchemaEntity202012.tt"
+        #line 2652 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2662 "SchemaEntity202012.tt"
+        #line 2653 "SchemaEntity202012.tt"
 
         if (HasAdditionalPropertiesObject && !HasUnevaluatedPropertiesObject)
         {
@@ -8491,20 +8451,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2666 "SchemaEntity202012.tt"
+        #line 2657 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the object as the given item type\r\n " +
                 "       /// </summary>\r\n        public JsonObjectEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2669 "SchemaEntity202012.tt"
+        #line 2660 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2669 "SchemaEntity202012.tt"
+        #line 2660 "SchemaEntity202012.tt"
         this.Write("> EnumerateProperties()\r\n        {\r\n            if (this.objectBacking is Immutab" +
                 "leDictionary<string, JsonAny> properties)\r\n            {\r\n                return" +
                 " new JsonObjectEnumerator<");
@@ -8512,13 +8472,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2673 "SchemaEntity202012.tt"
+        #line 2664 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2673 "SchemaEntity202012.tt"
+        #line 2664 "SchemaEntity202012.tt"
         this.Write(">(properties);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKin" +
                 "d == JsonValueKind.Object)\r\n            {\r\n                return new JsonObject" +
                 "Enumerator<");
@@ -8526,20 +8486,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2678 "SchemaEntity202012.tt"
+        #line 2669 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2678 "SchemaEntity202012.tt"
+        #line 2669 "SchemaEntity202012.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n\r\n    " +
                 "    }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2684 "SchemaEntity202012.tt"
+        #line 2675 "SchemaEntity202012.tt"
 
         }
         
@@ -8547,13 +8507,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2687 "SchemaEntity202012.tt"
+        #line 2678 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2688 "SchemaEntity202012.tt"
+        #line 2679 "SchemaEntity202012.tt"
 
         if (!HasAdditionalPropertiesObject && HasUnevaluatedPropertiesObject)
         {
@@ -8562,20 +8522,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2692 "SchemaEntity202012.tt"
+        #line 2683 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the object as the given item type\r\n " +
                 "       /// </summary>\r\n        public JsonObjectEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2695 "SchemaEntity202012.tt"
+        #line 2686 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2695 "SchemaEntity202012.tt"
+        #line 2686 "SchemaEntity202012.tt"
         this.Write("> EnumerateProperties()\r\n        {\r\n            if (this.objectBacking is Immutab" +
                 "leDictionary<string, JsonAny> properties)\r\n            {\r\n                return" +
                 " new JsonObjectEnumerator<");
@@ -8583,13 +8543,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2699 "SchemaEntity202012.tt"
+        #line 2690 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2699 "SchemaEntity202012.tt"
+        #line 2690 "SchemaEntity202012.tt"
         this.Write(">(properties);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKin" +
                 "d == JsonValueKind.Object)\r\n            {\r\n                return new JsonObject" +
                 "Enumerator<");
@@ -8597,20 +8557,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2704 "SchemaEntity202012.tt"
+        #line 2695 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2704 "SchemaEntity202012.tt"
+        #line 2695 "SchemaEntity202012.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n\r\n    " +
                 "    }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2710 "SchemaEntity202012.tt"
+        #line 2701 "SchemaEntity202012.tt"
 
         }
         
@@ -8618,7 +8578,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2713 "SchemaEntity202012.tt"
+        #line 2704 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public JsonObjectEnumerator EnumerateObject(" +
                 ")\r\n        {\r\n            return this.AsObject.EnumerateObject();\r\n        }\r\n\r\n" +
                 "    ");
@@ -8626,7 +8586,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2720 "SchemaEntity202012.tt"
+        #line 2711 "SchemaEntity202012.tt"
 
     }
     
@@ -8634,13 +8594,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2723 "SchemaEntity202012.tt"
+        #line 2714 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2724 "SchemaEntity202012.tt"
+        #line 2715 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -8649,13 +8609,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2728 "SchemaEntity202012.tt"
+        #line 2719 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2729 "SchemaEntity202012.tt"
+        #line 2720 "SchemaEntity202012.tt"
 
         if (CanEnumerateAsSpecificType)
         {
@@ -8664,32 +8624,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2733 "SchemaEntity202012.tt"
+        #line 2724 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the items in the array as a <see cre" +
                 "f=\"");
         
         #line default
         #line hidden
         
-        #line 2734 "SchemaEntity202012.tt"
+        #line 2725 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2734 "SchemaEntity202012.tt"
+        #line 2725 "SchemaEntity202012.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public JsonArrayEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2736 "SchemaEntity202012.tt"
+        #line 2727 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2736 "SchemaEntity202012.tt"
+        #line 2727 "SchemaEntity202012.tt"
         this.Write("> EnumerateItems()\r\n        {\r\n            if (this.arrayBacking is ImmutableList" +
                 "<JsonAny> items)\r\n            {\r\n                return new JsonArrayEnumerator<" +
                 "");
@@ -8697,13 +8657,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2740 "SchemaEntity202012.tt"
+        #line 2731 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2740 "SchemaEntity202012.tt"
+        #line 2731 "SchemaEntity202012.tt"
         this.Write(">(items);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKind == " +
                 "JsonValueKind.Array)\r\n            {\r\n                return new JsonArrayEnumera" +
                 "tor<");
@@ -8711,20 +8671,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2745 "SchemaEntity202012.tt"
+        #line 2736 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2745 "SchemaEntity202012.tt"
+        #line 2736 "SchemaEntity202012.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n      " +
                 "  }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2750 "SchemaEntity202012.tt"
+        #line 2741 "SchemaEntity202012.tt"
 
         }
         
@@ -8732,14 +8692,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2753 "SchemaEntity202012.tt"
+        #line 2744 "SchemaEntity202012.tt"
         this.Write("        /// <inheritdoc/>\r\n        public JsonArrayEnumerator EnumerateArray()\r\n " +
                 "       {\r\n            return this.AsArray.EnumerateArray();\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2758 "SchemaEntity202012.tt"
+        #line 2749 "SchemaEntity202012.tt"
 
     }
     
@@ -8747,13 +8707,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2761 "SchemaEntity202012.tt"
+        #line 2752 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2762 "SchemaEntity202012.tt"
+        #line 2753 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -8762,7 +8722,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2766 "SchemaEntity202012.tt"
+        #line 2757 "SchemaEntity202012.tt"
         this.Write(@"
         /// <inheritdoc/>
         public bool TryGetProperty(string name, out JsonAny value)
@@ -8787,7 +8747,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2785 "SchemaEntity202012.tt"
+        #line 2776 "SchemaEntity202012.tt"
 
         if (HasDefaults)
         {
@@ -8796,7 +8756,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2789 "SchemaEntity202012.tt"
+        #line 2780 "SchemaEntity202012.tt"
         this.Write(@"        /// <inheritdoc/>
         public bool TryGetDefault(string name, out JsonAny value)
         {
@@ -8838,7 +8798,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2825 "SchemaEntity202012.tt"
+        #line 2816 "SchemaEntity202012.tt"
 
         }
         
@@ -8846,13 +8806,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2828 "SchemaEntity202012.tt"
+        #line 2819 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2829 "SchemaEntity202012.tt"
+        #line 2820 "SchemaEntity202012.tt"
 
     }
     
@@ -8860,7 +8820,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2832 "SchemaEntity202012.tt"
+        #line 2823 "SchemaEntity202012.tt"
         this.Write(@"
         /// <inheritdoc/>
         public bool Equals<T>(T other)
@@ -8880,7 +8840,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2846 "SchemaEntity202012.tt"
+        #line 2837 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -8889,14 +8849,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2850 "SchemaEntity202012.tt"
+        #line 2841 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.Equals(other.AsObject()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2851 "SchemaEntity202012.tt"
+        #line 2842 "SchemaEntity202012.tt"
 
     }
     else
@@ -8906,14 +8866,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2856 "SchemaEntity202012.tt"
+        #line 2847 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().Equals(other.AsObject())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2857 "SchemaEntity202012.tt"
+        #line 2848 "SchemaEntity202012.tt"
 
     }
     
@@ -8921,13 +8881,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2860 "SchemaEntity202012.tt"
+        #line 2851 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2860 "SchemaEntity202012.tt"
+        #line 2851 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -8936,14 +8896,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2864 "SchemaEntity202012.tt"
+        #line 2855 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.Equals(other.AsArray()),\r\n   " +
                 " ");
         
         #line default
         #line hidden
         
-        #line 2865 "SchemaEntity202012.tt"
+        #line 2856 "SchemaEntity202012.tt"
 
     }
     else
@@ -8953,14 +8913,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2870 "SchemaEntity202012.tt"
+        #line 2861 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().Equals(other.AsArray()),\r\n " +
                 "   ");
         
         #line default
         #line hidden
         
-        #line 2871 "SchemaEntity202012.tt"
+        #line 2862 "SchemaEntity202012.tt"
 
     }
     
@@ -8968,13 +8928,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2874 "SchemaEntity202012.tt"
+        #line 2865 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2874 "SchemaEntity202012.tt"
+        #line 2865 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -8983,14 +8943,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2878 "SchemaEntity202012.tt"
+        #line 2869 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.Equals(other.AsNumber()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2879 "SchemaEntity202012.tt"
+        #line 2870 "SchemaEntity202012.tt"
 
     }
     else
@@ -9000,14 +8960,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2884 "SchemaEntity202012.tt"
+        #line 2875 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().Equals(other.AsNumber())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2885 "SchemaEntity202012.tt"
+        #line 2876 "SchemaEntity202012.tt"
 
     }
     
@@ -9015,13 +8975,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2888 "SchemaEntity202012.tt"
+        #line 2879 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2888 "SchemaEntity202012.tt"
+        #line 2879 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -9030,14 +8990,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2892 "SchemaEntity202012.tt"
+        #line 2883 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString.Equals(other.AsString()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2893 "SchemaEntity202012.tt"
+        #line 2884 "SchemaEntity202012.tt"
 
     }
     else
@@ -9047,14 +9007,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2898 "SchemaEntity202012.tt"
+        #line 2889 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString().Equals(other.AsString())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2899 "SchemaEntity202012.tt"
+        #line 2890 "SchemaEntity202012.tt"
 
     }
     
@@ -9062,13 +9022,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2902 "SchemaEntity202012.tt"
+        #line 2893 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2902 "SchemaEntity202012.tt"
+        #line 2893 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -9077,14 +9037,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2906 "SchemaEntity202012.tt"
+        #line 2897 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.Equal" +
                 "s(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2907 "SchemaEntity202012.tt"
+        #line 2898 "SchemaEntity202012.tt"
 
     }
     else
@@ -9094,14 +9054,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2912 "SchemaEntity202012.tt"
+        #line 2903 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Equ" +
                 "als(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2913 "SchemaEntity202012.tt"
+        #line 2904 "SchemaEntity202012.tt"
 
     }
     
@@ -9109,20 +9069,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2916 "SchemaEntity202012.tt"
+        #line 2907 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Null => true,\r\n                _ => false,\r\n       " +
                 "     };\r\n        }\r\n\r\n        /// <inheritdoc/>\r\n        public bool Equals(");
         
         #line default
         #line hidden
         
-        #line 2922 "SchemaEntity202012.tt"
+        #line 2913 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2922 "SchemaEntity202012.tt"
+        #line 2913 "SchemaEntity202012.tt"
         this.Write(" other)\r\n        {\r\n            JsonValueKind valueKind = this.ValueKind;\r\n\r\n    " +
                 "        if (other.ValueKind != valueKind)\r\n            {\r\n                return" +
                 " false;\r\n            }\r\n\r\n            return valueKind switch\r\n            {\r\n  " +
@@ -9131,7 +9091,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2933 "SchemaEntity202012.tt"
+        #line 2924 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -9140,14 +9100,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2937 "SchemaEntity202012.tt"
+        #line 2928 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.Equals(other.AsObject),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2938 "SchemaEntity202012.tt"
+        #line 2929 "SchemaEntity202012.tt"
 
     }
     else
@@ -9157,14 +9117,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2943 "SchemaEntity202012.tt"
+        #line 2934 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().Equals(other.AsObject())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2944 "SchemaEntity202012.tt"
+        #line 2935 "SchemaEntity202012.tt"
 
     }
     
@@ -9172,13 +9132,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2947 "SchemaEntity202012.tt"
+        #line 2938 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2947 "SchemaEntity202012.tt"
+        #line 2938 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -9187,13 +9147,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2951 "SchemaEntity202012.tt"
+        #line 2942 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.Equals(other.AsArray),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2952 "SchemaEntity202012.tt"
+        #line 2943 "SchemaEntity202012.tt"
 
     }
     else
@@ -9203,14 +9163,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2957 "SchemaEntity202012.tt"
+        #line 2948 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().Equals(other.AsArray()),\r\n " +
                 "   ");
         
         #line default
         #line hidden
         
-        #line 2958 "SchemaEntity202012.tt"
+        #line 2949 "SchemaEntity202012.tt"
 
     }
     
@@ -9218,13 +9178,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2961 "SchemaEntity202012.tt"
+        #line 2952 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2961 "SchemaEntity202012.tt"
+        #line 2952 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -9233,14 +9193,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2965 "SchemaEntity202012.tt"
+        #line 2956 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.Equals(other.AsNumber),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2966 "SchemaEntity202012.tt"
+        #line 2957 "SchemaEntity202012.tt"
 
     }
     else
@@ -9250,14 +9210,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2971 "SchemaEntity202012.tt"
+        #line 2962 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().Equals(other.AsNumber())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2972 "SchemaEntity202012.tt"
+        #line 2963 "SchemaEntity202012.tt"
 
     }
     
@@ -9265,13 +9225,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2975 "SchemaEntity202012.tt"
+        #line 2966 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2975 "SchemaEntity202012.tt"
+        #line 2966 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -9280,14 +9240,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2979 "SchemaEntity202012.tt"
+        #line 2970 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString.Equals(other.AsString),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2980 "SchemaEntity202012.tt"
+        #line 2971 "SchemaEntity202012.tt"
 
     }
     else
@@ -9297,14 +9257,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2985 "SchemaEntity202012.tt"
+        #line 2976 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString().Equals(other.AsString())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2986 "SchemaEntity202012.tt"
+        #line 2977 "SchemaEntity202012.tt"
 
     }
     
@@ -9312,13 +9272,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2989 "SchemaEntity202012.tt"
+        #line 2980 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2989 "SchemaEntity202012.tt"
+        #line 2980 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -9327,14 +9287,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2993 "SchemaEntity202012.tt"
+        #line 2984 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.Equal" +
                 "s(other.AsBoolean),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2994 "SchemaEntity202012.tt"
+        #line 2985 "SchemaEntity202012.tt"
 
     }
     else
@@ -9344,14 +9304,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2999 "SchemaEntity202012.tt"
+        #line 2990 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Equ" +
                 "als(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3000 "SchemaEntity202012.tt"
+        #line 2991 "SchemaEntity202012.tt"
 
     }
     
@@ -9359,14 +9319,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3003 "SchemaEntity202012.tt"
+        #line 2994 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Null => true,\r\n                _ => false,\r\n       " +
                 "     };\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3008 "SchemaEntity202012.tt"
+        #line 2999 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -9375,7 +9335,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3012 "SchemaEntity202012.tt"
+        #line 3003 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public bool HasProperty(string name)\r\n      " +
                 "  {\r\n            if (this.objectBacking is ImmutableDictionary<string, JsonAny> " +
                 "properties)\r\n            {\r\n                return properties.TryGetValue(name, " +
@@ -9401,13 +9361,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3060 "SchemaEntity202012.tt"
+        #line 3051 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3060 "SchemaEntity202012.tt"
+        #line 3051 "SchemaEntity202012.tt"
         this.Write(@" SetProperty<TValue>(string name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9425,13 +9385,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3072 "SchemaEntity202012.tt"
+        #line 3063 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3072 "SchemaEntity202012.tt"
+        #line 3063 "SchemaEntity202012.tt"
         this.Write(@" SetProperty<TValue>(ReadOnlySpan<char> name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9449,13 +9409,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3084 "SchemaEntity202012.tt"
+        #line 3075 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3084 "SchemaEntity202012.tt"
+        #line 3075 "SchemaEntity202012.tt"
         this.Write(@" SetProperty<TValue>(ReadOnlySpan<byte> utf8name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9473,13 +9433,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3096 "SchemaEntity202012.tt"
+        #line 3087 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3096 "SchemaEntity202012.tt"
+        #line 3087 "SchemaEntity202012.tt"
         this.Write(@" RemoveProperty(string name)
         {
             if (this.ValueKind == JsonValueKind.Object)
@@ -9496,13 +9456,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3107 "SchemaEntity202012.tt"
+        #line 3098 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3107 "SchemaEntity202012.tt"
+        #line 3098 "SchemaEntity202012.tt"
         this.Write(@" RemoveProperty(ReadOnlySpan<char> name)
         {
             if (this.ValueKind == JsonValueKind.Object)
@@ -9519,13 +9479,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3118 "SchemaEntity202012.tt"
+        #line 3109 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3118 "SchemaEntity202012.tt"
+        #line 3109 "SchemaEntity202012.tt"
         this.Write(" RemoveProperty(ReadOnlySpan<byte> utf8Name)\r\n        {\r\n            if (this.Val" +
                 "ueKind == JsonValueKind.Object)\r\n            {\r\n                return this.AsOb" +
                 "ject.RemoveProperty(utf8Name);\r\n            }\r\n\r\n            return this;\r\n     " +
@@ -9534,7 +9494,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3128 "SchemaEntity202012.tt"
+        #line 3119 "SchemaEntity202012.tt"
 
     }
     
@@ -9542,13 +9502,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3131 "SchemaEntity202012.tt"
+        #line 3122 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3132 "SchemaEntity202012.tt"
+        #line 3123 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -9557,19 +9517,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3136 "SchemaEntity202012.tt"
+        #line 3127 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 3138 "SchemaEntity202012.tt"
+        #line 3129 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3138 "SchemaEntity202012.tt"
+        #line 3129 "SchemaEntity202012.tt"
         this.Write(@" Add<TItem>(TItem item)
             where TItem : struct, IJsonValue
         {
@@ -9587,13 +9547,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3150 "SchemaEntity202012.tt"
+        #line 3141 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3150 "SchemaEntity202012.tt"
+        #line 3141 "SchemaEntity202012.tt"
         this.Write(@" Add<TItem1, TItem2>(TItem1 item1, TItem2 item2)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9612,13 +9572,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3163 "SchemaEntity202012.tt"
+        #line 3154 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3163 "SchemaEntity202012.tt"
+        #line 3154 "SchemaEntity202012.tt"
         this.Write(@" Add<TItem1, TItem2, TItem3>(TItem1 item1, TItem2 item2, TItem3 item3)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9638,13 +9598,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3177 "SchemaEntity202012.tt"
+        #line 3168 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3177 "SchemaEntity202012.tt"
+        #line 3168 "SchemaEntity202012.tt"
         this.Write(@" Add<TItem1, TItem2, TItem3, TItem4>(TItem1 item1, TItem2 item2, TItem3 item3, TItem4 item4)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9665,13 +9625,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3192 "SchemaEntity202012.tt"
+        #line 3183 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3192 "SchemaEntity202012.tt"
+        #line 3183 "SchemaEntity202012.tt"
         this.Write(@" Add<TItem>(params TItem[] items)
             where TItem : struct, IJsonValue
         {
@@ -9689,13 +9649,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3204 "SchemaEntity202012.tt"
+        #line 3195 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3204 "SchemaEntity202012.tt"
+        #line 3195 "SchemaEntity202012.tt"
         this.Write(@" AddRange<TItem>(IEnumerable<TItem> items)
             where TItem : struct, IJsonValue
         {
@@ -9713,13 +9673,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3216 "SchemaEntity202012.tt"
+        #line 3207 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3216 "SchemaEntity202012.tt"
+        #line 3207 "SchemaEntity202012.tt"
         this.Write(@" Insert<TItem>(int index, TItem item)
             where TItem : struct, IJsonValue
         {
@@ -9737,13 +9697,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3228 "SchemaEntity202012.tt"
+        #line 3219 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3228 "SchemaEntity202012.tt"
+        #line 3219 "SchemaEntity202012.tt"
         this.Write(@" Replace<TItem>(TItem oldValue, TItem newValue)
             where TItem : struct, IJsonValue
         {
@@ -9761,13 +9721,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3240 "SchemaEntity202012.tt"
+        #line 3231 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3240 "SchemaEntity202012.tt"
+        #line 3231 "SchemaEntity202012.tt"
         this.Write(@" RemoveAt(int index)
         {
             if (this.ValueKind == JsonValueKind.Array)
@@ -9784,13 +9744,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3251 "SchemaEntity202012.tt"
+        #line 3242 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3251 "SchemaEntity202012.tt"
+        #line 3242 "SchemaEntity202012.tt"
         this.Write(@" RemoveRange(int index, int count)
         {
             if (this.ValueKind == JsonValueKind.Array)
@@ -9807,13 +9767,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3262 "SchemaEntity202012.tt"
+        #line 3253 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3262 "SchemaEntity202012.tt"
+        #line 3253 "SchemaEntity202012.tt"
         this.Write(@" SetItem<TItem>(int index, TItem value)
             where TItem : struct, IJsonValue
         {
@@ -9830,7 +9790,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3273 "SchemaEntity202012.tt"
+        #line 3264 "SchemaEntity202012.tt"
 
     }
     
@@ -9838,26 +9798,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3276 "SchemaEntity202012.tt"
+        #line 3267 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public T As<T>()\r\n            where T : stru" +
                 "ct, IJsonValue\r\n        {\r\n            return this.As<");
         
         #line default
         #line hidden
         
-        #line 3281 "SchemaEntity202012.tt"
+        #line 3272 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3281 "SchemaEntity202012.tt"
+        #line 3272 "SchemaEntity202012.tt"
         this.Write(", T>();\r\n        }\r\n\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3285 "SchemaEntity202012.tt"
+        #line 3276 "SchemaEntity202012.tt"
 
     if(HasPatternProperties)
     {
@@ -9866,13 +9826,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3289 "SchemaEntity202012.tt"
+        #line 3280 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3290 "SchemaEntity202012.tt"
+        #line 3281 "SchemaEntity202012.tt"
 
         foreach(var patternProperty in PatternProperties)
         {
@@ -9881,122 +9841,122 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3294 "SchemaEntity202012.tt"
+        #line 3285 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Determines if a property matches ");
         
         #line default
         #line hidden
         
-        #line 3295 "SchemaEntity202012.tt"
+        #line 3286 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                Formatting.FormatLiteralOrNull(patternProperty.Pattern, true).Trim('"')));
         
         #line default
         #line hidden
         
-        #line 3295 "SchemaEntity202012.tt"
+        #line 3286 "SchemaEntity202012.tt"
         this.Write(" producing a <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 3295 "SchemaEntity202012.tt"
+        #line 3286 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3295 "SchemaEntity202012.tt"
+        #line 3286 "SchemaEntity202012.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public bool MatchesPattern");
         
         #line default
         #line hidden
         
-        #line 3297 "SchemaEntity202012.tt"
+        #line 3288 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3297 "SchemaEntity202012.tt"
+        #line 3288 "SchemaEntity202012.tt"
         this.Write("(in Property property)\r\n        {\r\n            return PatternProperty");
         
         #line default
         #line hidden
         
-        #line 3299 "SchemaEntity202012.tt"
+        #line 3290 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3299 "SchemaEntity202012.tt"
+        #line 3290 "SchemaEntity202012.tt"
         this.Write(".IsMatch(property.Name);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Get a p" +
                 "roperty as the matching property type ");
         
         #line default
         #line hidden
         
-        #line 3303 "SchemaEntity202012.tt"
+        #line 3294 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                Formatting.FormatLiteralOrNull(patternProperty.Pattern, true).Trim('"')));
         
         #line default
         #line hidden
         
-        #line 3303 "SchemaEntity202012.tt"
+        #line 3294 "SchemaEntity202012.tt"
         this.Write(" as a <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 3303 "SchemaEntity202012.tt"
+        #line 3294 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3303 "SchemaEntity202012.tt"
+        #line 3294 "SchemaEntity202012.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 3305 "SchemaEntity202012.tt"
+        #line 3296 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3305 "SchemaEntity202012.tt"
+        #line 3296 "SchemaEntity202012.tt"
         this.Write(" AsPattern");
         
         #line default
         #line hidden
         
-        #line 3305 "SchemaEntity202012.tt"
+        #line 3296 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3305 "SchemaEntity202012.tt"
+        #line 3296 "SchemaEntity202012.tt"
         this.Write("(in Property property)\r\n        {\r\n            return property.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 3307 "SchemaEntity202012.tt"
+        #line 3298 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3307 "SchemaEntity202012.tt"
+        #line 3298 "SchemaEntity202012.tt"
         this.Write(">();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3310 "SchemaEntity202012.tt"
+        #line 3301 "SchemaEntity202012.tt"
 
         }
         
@@ -10004,13 +9964,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3313 "SchemaEntity202012.tt"
+        #line 3304 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 3313 "SchemaEntity202012.tt"
+        #line 3304 "SchemaEntity202012.tt"
 
     }
     
@@ -10018,7 +9978,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3316 "SchemaEntity202012.tt"
+        #line 3307 "SchemaEntity202012.tt"
         this.Write(@"
         /// <inheritdoc/>
         public ValidationContext Validate(in ValidationContext? validationContext = null, ValidationLevel level = ValidationLevel.Flag)
@@ -10033,7 +9993,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3325 "SchemaEntity202012.tt"
+        #line 3316 "SchemaEntity202012.tt"
 
         if (HasAdditionalProperties || HasUnevaluatedProperties)
         {
@@ -10042,8 +10002,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3329 "SchemaEntity202012.tt"
+        #line 3320 "SchemaEntity202012.tt"
         this.Write("            result = result.UsingEvaluatedProperties();\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3321 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3324 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3325 "SchemaEntity202012.tt"
+
+        if (HasUnevaluatedItems)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3329 "SchemaEntity202012.tt"
+        this.Write("            result = result.UsingEvaluatedItems();\r\n        ");
         
         #line default
         #line hidden
@@ -10057,41 +10046,12 @@ namespace ");
         #line hidden
         
         #line 3333 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3334 "SchemaEntity202012.tt"
-
-        if (HasUnevaluatedItems)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3338 "SchemaEntity202012.tt"
-        this.Write("            result = result.UsingEvaluatedItems();\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3339 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3342 "SchemaEntity202012.tt"
         this.Write("\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3344 "SchemaEntity202012.tt"
+        #line 3335 "SchemaEntity202012.tt"
 
     if (HasRef)
     {    
@@ -10100,10 +10060,39 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3348 "SchemaEntity202012.tt"
+        #line 3339 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateRef(result, level);\r\n            if (level == V" +
                 "alidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return r" +
                 "esult;\r\n            }\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3344 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3347 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3348 "SchemaEntity202012.tt"
+
+    if ((HasExplicitType || HasFormat || HasMediaTypeOrEncoding) || (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasPrefixItems) || (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties || HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)))))
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3352 "SchemaEntity202012.tt"
+        this.Write("            JsonValueKind valueKind = this.ValueKind;\r\n    ");
         
         #line default
         #line hidden
@@ -10124,35 +10113,6 @@ namespace ");
         
         #line 3357 "SchemaEntity202012.tt"
 
-    if ((HasExplicitType || HasFormat || HasMediaTypeOrEncoding) || (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasPrefixItems) || (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties || HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)))))
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3361 "SchemaEntity202012.tt"
-        this.Write("            JsonValueKind valueKind = this.ValueKind;\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3362 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3365 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3366 "SchemaEntity202012.tt"
-
     if (HasExplicitType || HasFormat || HasMediaTypeOrEncoding)
     {
     
@@ -10160,13 +10120,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3370 "SchemaEntity202012.tt"
+        #line 3361 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3371 "SchemaEntity202012.tt"
+        #line 3362 "SchemaEntity202012.tt"
 
         if (HasExplicitType)
         {
@@ -10175,7 +10135,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3375 "SchemaEntity202012.tt"
+        #line 3366 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateType(valueKind, result, level);\r\n            if" +
                 " (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n            " +
                 "    return result;\r\n            }\r\n        ");
@@ -10183,7 +10143,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3380 "SchemaEntity202012.tt"
+        #line 3371 "SchemaEntity202012.tt"
 
         }
         
@@ -10191,13 +10151,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3383 "SchemaEntity202012.tt"
+        #line 3374 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3384 "SchemaEntity202012.tt"
+        #line 3375 "SchemaEntity202012.tt"
 
         if (HasFormat)
         {
@@ -10206,7 +10166,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3388 "SchemaEntity202012.tt"
+        #line 3379 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateFormat(valueKind, result, level);\r\n            " +
                 "if (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n          " +
                 "      return result;\r\n            }\r\n        ");
@@ -10214,7 +10174,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3393 "SchemaEntity202012.tt"
+        #line 3384 "SchemaEntity202012.tt"
 
         }
         
@@ -10222,13 +10182,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3396 "SchemaEntity202012.tt"
+        #line 3387 "SchemaEntity202012.tt"
         this.Write("\r\n        \r\n        ");
         
         #line default
         #line hidden
         
-        #line 3398 "SchemaEntity202012.tt"
+        #line 3389 "SchemaEntity202012.tt"
 
         if (HasMediaTypeOrEncoding)
         {
@@ -10237,7 +10197,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3402 "SchemaEntity202012.tt"
+        #line 3393 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateMediaTypeAndEncoding(valueKind, result, level);" +
                 "\r\n            if (level == ValidationLevel.Flag && !result.IsValid)\r\n           " +
                 " {\r\n                return result;\r\n            }\r\n        ");
@@ -10245,7 +10205,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3407 "SchemaEntity202012.tt"
+        #line 3398 "SchemaEntity202012.tt"
 
         }
         
@@ -10253,13 +10213,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3410 "SchemaEntity202012.tt"
+        #line 3401 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3411 "SchemaEntity202012.tt"
+        #line 3402 "SchemaEntity202012.tt"
 
     }
     
@@ -10267,13 +10227,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3414 "SchemaEntity202012.tt"
+        #line 3405 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3415 "SchemaEntity202012.tt"
+        #line 3406 "SchemaEntity202012.tt"
 
     if (HasConst)
     {
@@ -10282,7 +10242,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3419 "SchemaEntity202012.tt"
+        #line 3410 "SchemaEntity202012.tt"
         this.Write("            result = Corvus.Json.Validate.ValidateConst(this, result, level, __Co" +
                 "rvusConstValue);\r\n            if (level == ValidationLevel.Flag && !result.IsVal" +
                 "id)\r\n            {\r\n                return result;\r\n            }\r\n\r\n    ");
@@ -10290,7 +10250,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3425 "SchemaEntity202012.tt"
+        #line 3416 "SchemaEntity202012.tt"
 
     }
     
@@ -10298,13 +10258,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3428 "SchemaEntity202012.tt"
+        #line 3419 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3429 "SchemaEntity202012.tt"
+        #line 3420 "SchemaEntity202012.tt"
 
     if (HasEnum)
     {
@@ -10313,14 +10273,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3433 "SchemaEntity202012.tt"
+        #line 3424 "SchemaEntity202012.tt"
         this.Write("            result = Corvus.Json.Validate.ValidateEnum(\r\n                this,\r\n " +
                 "               result,\r\n                level\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3437 "SchemaEntity202012.tt"
+        #line 3428 "SchemaEntity202012.tt"
 
         for(int enumIndex = 0; enumIndex < EnumValues.Length; ++enumIndex)
         {
@@ -10329,25 +10289,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3441 "SchemaEntity202012.tt"
+        #line 3432 "SchemaEntity202012.tt"
         this.Write("                , EnumValues.Item");
         
         #line default
         #line hidden
         
-        #line 3441 "SchemaEntity202012.tt"
+        #line 3432 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( enumIndex ));
         
         #line default
         #line hidden
         
-        #line 3441 "SchemaEntity202012.tt"
+        #line 3432 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3442 "SchemaEntity202012.tt"
+        #line 3433 "SchemaEntity202012.tt"
 
         }
         
@@ -10355,14 +10315,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3445 "SchemaEntity202012.tt"
+        #line 3436 "SchemaEntity202012.tt"
         this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
                 "Valid)\r\n            {\r\n                return result;\r\n            }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3451 "SchemaEntity202012.tt"
+        #line 3442 "SchemaEntity202012.tt"
 
     }
     
@@ -10370,13 +10330,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3454 "SchemaEntity202012.tt"
+        #line 3445 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3455 "SchemaEntity202012.tt"
+        #line 3446 "SchemaEntity202012.tt"
 
     if (HasMultipleOf || HasMaximum || HasExclusiveMaximum|| HasMinimum || HasExclusiveMinimum)
     {
@@ -10385,14 +10345,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3459 "SchemaEntity202012.tt"
+        #line 3450 "SchemaEntity202012.tt"
         this.Write("            result = Corvus.Json.Validate.ValidateNumber(\r\n                this,\r" +
                 "\n                result,\r\n                level,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3463 "SchemaEntity202012.tt"
+        #line 3454 "SchemaEntity202012.tt"
 
         if (HasMultipleOf)
         {
@@ -10401,25 +10361,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3467 "SchemaEntity202012.tt"
+        #line 3458 "SchemaEntity202012.tt"
         this.Write("                ");
         
         #line default
         #line hidden
         
-        #line 3467 "SchemaEntity202012.tt"
+        #line 3458 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MultipleOf ));
         
         #line default
         #line hidden
         
-        #line 3467 "SchemaEntity202012.tt"
+        #line 3458 "SchemaEntity202012.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3468 "SchemaEntity202012.tt"
+        #line 3459 "SchemaEntity202012.tt"
 
         }
         else
@@ -10429,13 +10389,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3473 "SchemaEntity202012.tt"
+        #line 3464 "SchemaEntity202012.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3474 "SchemaEntity202012.tt"
+        #line 3465 "SchemaEntity202012.tt"
 
         }
         
@@ -10443,13 +10403,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3477 "SchemaEntity202012.tt"
+        #line 3468 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3477 "SchemaEntity202012.tt"
+        #line 3468 "SchemaEntity202012.tt"
 
         if (HasMaximum)
         {
@@ -10458,25 +10418,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3481 "SchemaEntity202012.tt"
+        #line 3472 "SchemaEntity202012.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3481 "SchemaEntity202012.tt"
+        #line 3472 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Maximum ));
         
         #line default
         #line hidden
         
-        #line 3481 "SchemaEntity202012.tt"
+        #line 3472 "SchemaEntity202012.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3482 "SchemaEntity202012.tt"
+        #line 3473 "SchemaEntity202012.tt"
 
         }
         else
@@ -10486,13 +10446,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3487 "SchemaEntity202012.tt"
+        #line 3478 "SchemaEntity202012.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3488 "SchemaEntity202012.tt"
+        #line 3479 "SchemaEntity202012.tt"
 
         }
         
@@ -10500,13 +10460,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3491 "SchemaEntity202012.tt"
+        #line 3482 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3491 "SchemaEntity202012.tt"
+        #line 3482 "SchemaEntity202012.tt"
 
         if (HasExclusiveMaximum)
         {
@@ -10515,25 +10475,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3495 "SchemaEntity202012.tt"
+        #line 3486 "SchemaEntity202012.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3495 "SchemaEntity202012.tt"
+        #line 3486 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ExclusiveMaximum ));
         
         #line default
         #line hidden
         
-        #line 3495 "SchemaEntity202012.tt"
+        #line 3486 "SchemaEntity202012.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3496 "SchemaEntity202012.tt"
+        #line 3487 "SchemaEntity202012.tt"
 
         }
         else
@@ -10543,13 +10503,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3501 "SchemaEntity202012.tt"
+        #line 3492 "SchemaEntity202012.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3502 "SchemaEntity202012.tt"
+        #line 3493 "SchemaEntity202012.tt"
 
         }
         
@@ -10557,13 +10517,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3505 "SchemaEntity202012.tt"
+        #line 3496 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3505 "SchemaEntity202012.tt"
+        #line 3496 "SchemaEntity202012.tt"
 
         if (HasMinimum)
         {
@@ -10572,25 +10532,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3509 "SchemaEntity202012.tt"
+        #line 3500 "SchemaEntity202012.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3509 "SchemaEntity202012.tt"
+        #line 3500 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Minimum ));
         
         #line default
         #line hidden
         
-        #line 3509 "SchemaEntity202012.tt"
+        #line 3500 "SchemaEntity202012.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3510 "SchemaEntity202012.tt"
+        #line 3501 "SchemaEntity202012.tt"
 
         }
         else
@@ -10600,13 +10560,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3515 "SchemaEntity202012.tt"
+        #line 3506 "SchemaEntity202012.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3516 "SchemaEntity202012.tt"
+        #line 3507 "SchemaEntity202012.tt"
 
         }
         
@@ -10614,13 +10574,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3519 "SchemaEntity202012.tt"
+        #line 3510 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3519 "SchemaEntity202012.tt"
+        #line 3510 "SchemaEntity202012.tt"
 
         if (HasExclusiveMinimum)
         {
@@ -10629,25 +10589,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3523 "SchemaEntity202012.tt"
+        #line 3514 "SchemaEntity202012.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3523 "SchemaEntity202012.tt"
+        #line 3514 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ExclusiveMinimum ));
         
         #line default
         #line hidden
         
-        #line 3523 "SchemaEntity202012.tt"
+        #line 3514 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3524 "SchemaEntity202012.tt"
+        #line 3515 "SchemaEntity202012.tt"
 
         }
         else
@@ -10657,13 +10617,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3529 "SchemaEntity202012.tt"
+        #line 3520 "SchemaEntity202012.tt"
         this.Write("                null\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3530 "SchemaEntity202012.tt"
+        #line 3521 "SchemaEntity202012.tt"
 
         }
         
@@ -10671,14 +10631,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3533 "SchemaEntity202012.tt"
+        #line 3524 "SchemaEntity202012.tt"
         this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
                 "Valid)\r\n            {\r\n                return result;\r\n            }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3540 "SchemaEntity202012.tt"
+        #line 3531 "SchemaEntity202012.tt"
 
     }
     
@@ -10686,13 +10646,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3543 "SchemaEntity202012.tt"
+        #line 3534 "SchemaEntity202012.tt"
         this.Write("    \r\n    ");
         
         #line default
         #line hidden
         
-        #line 3544 "SchemaEntity202012.tt"
+        #line 3535 "SchemaEntity202012.tt"
 
     if (HasMaxLength || HasMinLength || HasPattern)
     {
@@ -10701,14 +10661,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3548 "SchemaEntity202012.tt"
+        #line 3539 "SchemaEntity202012.tt"
         this.Write("            result = Corvus.Json.Validate.ValidateString(\r\n                this,\r" +
                 "\n                result,\r\n                level,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3552 "SchemaEntity202012.tt"
+        #line 3543 "SchemaEntity202012.tt"
 
         if (HasMaxLength)
         {
@@ -10717,25 +10677,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3556 "SchemaEntity202012.tt"
+        #line 3547 "SchemaEntity202012.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3556 "SchemaEntity202012.tt"
+        #line 3547 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxLength ));
         
         #line default
         #line hidden
         
-        #line 3556 "SchemaEntity202012.tt"
+        #line 3547 "SchemaEntity202012.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3557 "SchemaEntity202012.tt"
+        #line 3548 "SchemaEntity202012.tt"
 
         }
         else
@@ -10745,13 +10705,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3562 "SchemaEntity202012.tt"
+        #line 3553 "SchemaEntity202012.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3563 "SchemaEntity202012.tt"
+        #line 3554 "SchemaEntity202012.tt"
 
         }
         
@@ -10759,13 +10719,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3566 "SchemaEntity202012.tt"
+        #line 3557 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3566 "SchemaEntity202012.tt"
+        #line 3557 "SchemaEntity202012.tt"
 
         if (HasMinLength)
         {
@@ -10774,25 +10734,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3570 "SchemaEntity202012.tt"
+        #line 3561 "SchemaEntity202012.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3570 "SchemaEntity202012.tt"
+        #line 3561 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinLength ));
         
         #line default
         #line hidden
         
-        #line 3570 "SchemaEntity202012.tt"
+        #line 3561 "SchemaEntity202012.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3571 "SchemaEntity202012.tt"
+        #line 3562 "SchemaEntity202012.tt"
 
         }
         else
@@ -10802,13 +10762,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3576 "SchemaEntity202012.tt"
+        #line 3567 "SchemaEntity202012.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3577 "SchemaEntity202012.tt"
+        #line 3568 "SchemaEntity202012.tt"
 
         }
         
@@ -10816,13 +10776,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3580 "SchemaEntity202012.tt"
+        #line 3571 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3580 "SchemaEntity202012.tt"
+        #line 3571 "SchemaEntity202012.tt"
 
         if (HasPattern)
         {
@@ -10831,13 +10791,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3584 "SchemaEntity202012.tt"
+        #line 3575 "SchemaEntity202012.tt"
         this.Write("                __CorvusPatternExpression\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3585 "SchemaEntity202012.tt"
+        #line 3576 "SchemaEntity202012.tt"
 
         }
         else
@@ -10847,13 +10807,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3590 "SchemaEntity202012.tt"
+        #line 3581 "SchemaEntity202012.tt"
         this.Write("                null\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3591 "SchemaEntity202012.tt"
+        #line 3582 "SchemaEntity202012.tt"
 
         }
         
@@ -10861,14 +10821,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3594 "SchemaEntity202012.tt"
+        #line 3585 "SchemaEntity202012.tt"
         this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
                 "Valid)\r\n            {\r\n                return result;\r\n            }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3600 "SchemaEntity202012.tt"
+        #line 3591 "SchemaEntity202012.tt"
 
     }
     
@@ -10876,13 +10836,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3603 "SchemaEntity202012.tt"
+        #line 3594 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3604 "SchemaEntity202012.tt"
+        #line 3595 "SchemaEntity202012.tt"
 
     if (HasIfThenElse)
     {
@@ -10891,7 +10851,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3608 "SchemaEntity202012.tt"
+        #line 3599 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateIfThenElse(result, level);\r\n            if (lev" +
                 "el == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                r" +
                 "eturn result;\r\n            }\r\n\r\n    ");
@@ -10899,7 +10859,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3614 "SchemaEntity202012.tt"
+        #line 3605 "SchemaEntity202012.tt"
 
     }
     
@@ -10907,13 +10867,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3617 "SchemaEntity202012.tt"
+        #line 3608 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3618 "SchemaEntity202012.tt"
+        #line 3609 "SchemaEntity202012.tt"
 
     if (HasNot)
     {
@@ -10922,7 +10882,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3622 "SchemaEntity202012.tt"
+        #line 3613 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateNot(result, level);\r\n            if (level == V" +
                 "alidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return r" +
                 "esult;\r\n            }\r\n\r\n    ");
@@ -10930,7 +10890,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3628 "SchemaEntity202012.tt"
+        #line 3619 "SchemaEntity202012.tt"
 
     }
     
@@ -10938,13 +10898,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3631 "SchemaEntity202012.tt"
+        #line 3622 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3632 "SchemaEntity202012.tt"
+        #line 3623 "SchemaEntity202012.tt"
 
     if (HasAllOf)
     {
@@ -10953,7 +10913,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3636 "SchemaEntity202012.tt"
+        #line 3627 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateAllOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n    ");
@@ -10961,7 +10921,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3641 "SchemaEntity202012.tt"
+        #line 3632 "SchemaEntity202012.tt"
 
     }
     
@@ -10969,13 +10929,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3644 "SchemaEntity202012.tt"
+        #line 3635 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3645 "SchemaEntity202012.tt"
+        #line 3636 "SchemaEntity202012.tt"
 
     if (HasAnyOf)
     {
@@ -10984,7 +10944,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3649 "SchemaEntity202012.tt"
+        #line 3640 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateAnyOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n    ");
@@ -10992,7 +10952,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3654 "SchemaEntity202012.tt"
+        #line 3645 "SchemaEntity202012.tt"
 
     }
     
@@ -11000,13 +10960,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3657 "SchemaEntity202012.tt"
+        #line 3648 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3658 "SchemaEntity202012.tt"
+        #line 3649 "SchemaEntity202012.tt"
 
     if (HasOneOf)
     {
@@ -11015,7 +10975,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3662 "SchemaEntity202012.tt"
+        #line 3653 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateOneOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n\r\n    ");
@@ -11023,7 +10983,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3668 "SchemaEntity202012.tt"
+        #line 3659 "SchemaEntity202012.tt"
 
     }
     
@@ -11031,13 +10991,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3671 "SchemaEntity202012.tt"
+        #line 3662 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3672 "SchemaEntity202012.tt"
+        #line 3663 "SchemaEntity202012.tt"
 
     if (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties || HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)) || !AllowsAdditionalProperties))
     {
@@ -11046,7 +11006,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3676 "SchemaEntity202012.tt"
+        #line 3667 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateObject(valueKind, result, level);\r\n            " +
                 "if (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n          " +
                 "      return result;\r\n            }\r\n\r\n    ");
@@ -11054,7 +11014,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3682 "SchemaEntity202012.tt"
+        #line 3673 "SchemaEntity202012.tt"
 
     }
     
@@ -11062,13 +11022,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3685 "SchemaEntity202012.tt"
+        #line 3676 "SchemaEntity202012.tt"
         this.Write("\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3687 "SchemaEntity202012.tt"
+        #line 3678 "SchemaEntity202012.tt"
 
     if (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasPrefixItems)
     {
@@ -11077,7 +11037,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3691 "SchemaEntity202012.tt"
+        #line 3682 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateArray(valueKind, result, level);\r\n            i" +
                 "f (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n           " +
                 "     return result;\r\n            }\r\n    ");
@@ -11085,7 +11045,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3696 "SchemaEntity202012.tt"
+        #line 3687 "SchemaEntity202012.tt"
 
     }
     
@@ -11093,13 +11053,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3699 "SchemaEntity202012.tt"
+        #line 3690 "SchemaEntity202012.tt"
         this.Write("            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3702 "SchemaEntity202012.tt"
+        #line 3693 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -11108,7 +11068,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3706 "SchemaEntity202012.tt"
+        #line 3697 "SchemaEntity202012.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonObject""/>.
         /// </summary>
@@ -11129,7 +11089,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3721 "SchemaEntity202012.tt"
+        #line 3712 "SchemaEntity202012.tt"
 
     }
     
@@ -11137,13 +11097,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3724 "SchemaEntity202012.tt"
+        #line 3715 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3725 "SchemaEntity202012.tt"
+        #line 3716 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -11152,7 +11112,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3729 "SchemaEntity202012.tt"
+        #line 3720 "SchemaEntity202012.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonArray""/>.
         /// </summary>
@@ -11173,7 +11133,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3744 "SchemaEntity202012.tt"
+        #line 3735 "SchemaEntity202012.tt"
 
     }
     
@@ -11181,13 +11141,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3747 "SchemaEntity202012.tt"
+        #line 3738 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3748 "SchemaEntity202012.tt"
+        #line 3739 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -11196,7 +11156,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3752 "SchemaEntity202012.tt"
+        #line 3743 "SchemaEntity202012.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonNumber""/>.
         /// </summary>
@@ -11217,7 +11177,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3767 "SchemaEntity202012.tt"
+        #line 3758 "SchemaEntity202012.tt"
 
     }
     
@@ -11225,13 +11185,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3770 "SchemaEntity202012.tt"
+        #line 3761 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3771 "SchemaEntity202012.tt"
+        #line 3762 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -11240,7 +11200,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3775 "SchemaEntity202012.tt"
+        #line 3766 "SchemaEntity202012.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonString""/>.
         /// </summary>
@@ -11261,7 +11221,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3790 "SchemaEntity202012.tt"
+        #line 3781 "SchemaEntity202012.tt"
 
     }
     
@@ -11269,13 +11229,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3793 "SchemaEntity202012.tt"
+        #line 3784 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3794 "SchemaEntity202012.tt"
+        #line 3785 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -11284,7 +11244,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3798 "SchemaEntity202012.tt"
+        #line 3789 "SchemaEntity202012.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonBoolean""/>.
         /// </summary>
@@ -11305,7 +11265,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3813 "SchemaEntity202012.tt"
+        #line 3804 "SchemaEntity202012.tt"
 
     }
     
@@ -11313,13 +11273,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3816 "SchemaEntity202012.tt"
+        #line 3807 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3817 "SchemaEntity202012.tt"
+        #line 3808 "SchemaEntity202012.tt"
 
     if (HasPatternProperties)
     {
@@ -11328,7 +11288,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3821 "SchemaEntity202012.tt"
+        #line 3812 "SchemaEntity202012.tt"
         this.Write(@"        private static ImmutableDictionary<Regex, PatternPropertyValidator> CreatePatternPropertiesValidators()
         {
             ImmutableDictionary<Regex, PatternPropertyValidator>.Builder builder =
@@ -11339,7 +11299,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3826 "SchemaEntity202012.tt"
+        #line 3817 "SchemaEntity202012.tt"
 
         foreach (var patternProperty in PatternProperties)
         {
@@ -11348,37 +11308,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3830 "SchemaEntity202012.tt"
+        #line 3821 "SchemaEntity202012.tt"
         this.Write("            builder.Add(\r\n                PatternProperty");
         
         #line default
         #line hidden
         
-        #line 3831 "SchemaEntity202012.tt"
+        #line 3822 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3831 "SchemaEntity202012.tt"
+        #line 3822 "SchemaEntity202012.tt"
         this.Write(",__CorvusValidatePatternProperty");
         
         #line default
         #line hidden
         
-        #line 3831 "SchemaEntity202012.tt"
+        #line 3822 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3831 "SchemaEntity202012.tt"
+        #line 3822 "SchemaEntity202012.tt"
         this.Write(");\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3832 "SchemaEntity202012.tt"
+        #line 3823 "SchemaEntity202012.tt"
 
         }
         
@@ -11386,13 +11346,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3835 "SchemaEntity202012.tt"
+        #line 3826 "SchemaEntity202012.tt"
         this.Write("\r\n            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3839 "SchemaEntity202012.tt"
+        #line 3830 "SchemaEntity202012.tt"
 
         foreach (var patternProperty in PatternProperties)
         {
@@ -11401,38 +11361,38 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3843 "SchemaEntity202012.tt"
+        #line 3834 "SchemaEntity202012.tt"
         this.Write("        private static ValidationContext __CorvusValidatePatternProperty");
         
         #line default
         #line hidden
         
-        #line 3843 "SchemaEntity202012.tt"
+        #line 3834 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
         
         #line default
         #line hidden
         
-        #line 3843 "SchemaEntity202012.tt"
+        #line 3834 "SchemaEntity202012.tt"
         this.Write("(in Property that, in ValidationContext validationContext, ValidationLevel level)" +
                 "\r\n        {\r\n            return that.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 3845 "SchemaEntity202012.tt"
+        #line 3836 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3845 "SchemaEntity202012.tt"
+        #line 3836 "SchemaEntity202012.tt"
         this.Write(">().Validate(validationContext, level);\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3847 "SchemaEntity202012.tt"
+        #line 3838 "SchemaEntity202012.tt"
 
         }
         
@@ -11440,13 +11400,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3850 "SchemaEntity202012.tt"
+        #line 3841 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3851 "SchemaEntity202012.tt"
+        #line 3842 "SchemaEntity202012.tt"
 
     }
     
@@ -11454,13 +11414,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3854 "SchemaEntity202012.tt"
+        #line 3845 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3855 "SchemaEntity202012.tt"
+        #line 3846 "SchemaEntity202012.tt"
 
     if (HasDependentSchemas)
     {
@@ -11469,51 +11429,51 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3859 "SchemaEntity202012.tt"
+        #line 3850 "SchemaEntity202012.tt"
         this.Write("\r\n        private static ImmutableDictionary<string, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3860 "SchemaEntity202012.tt"
+        #line 3851 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3860 "SchemaEntity202012.tt"
+        #line 3851 "SchemaEntity202012.tt"
         this.Write(">> CreateDependentSchemaValidators()\r\n        {\r\n            ImmutableDictionary<" +
                 "string, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3862 "SchemaEntity202012.tt"
+        #line 3853 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3862 "SchemaEntity202012.tt"
+        #line 3853 "SchemaEntity202012.tt"
         this.Write(">>.Builder builder =\r\n                ImmutableDictionary.CreateBuilder<string, P" +
                 "ropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3863 "SchemaEntity202012.tt"
+        #line 3854 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3863 "SchemaEntity202012.tt"
+        #line 3854 "SchemaEntity202012.tt"
         this.Write(">>();\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3865 "SchemaEntity202012.tt"
+        #line 3856 "SchemaEntity202012.tt"
 
         int dsIndex = 0;
         foreach (var dependentSchema in DependentSchemas)
@@ -11524,37 +11484,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3871 "SchemaEntity202012.tt"
+        #line 3862 "SchemaEntity202012.tt"
         this.Write("            builder.Add(\r\n                \"");
         
         #line default
         #line hidden
         
-        #line 3872 "SchemaEntity202012.tt"
+        #line 3863 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dependentSchema.Name ));
         
         #line default
         #line hidden
         
-        #line 3872 "SchemaEntity202012.tt"
+        #line 3863 "SchemaEntity202012.tt"
         this.Write("\", __CorvusValidateDependentSchema");
         
         #line default
         #line hidden
         
-        #line 3872 "SchemaEntity202012.tt"
+        #line 3863 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dsIndex ));
         
         #line default
         #line hidden
         
-        #line 3872 "SchemaEntity202012.tt"
+        #line 3863 "SchemaEntity202012.tt"
         this.Write(");\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3874 "SchemaEntity202012.tt"
+        #line 3865 "SchemaEntity202012.tt"
 
         }
         
@@ -11562,13 +11522,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3877 "SchemaEntity202012.tt"
+        #line 3868 "SchemaEntity202012.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3880 "SchemaEntity202012.tt"
+        #line 3871 "SchemaEntity202012.tt"
 
         int dsIndexV = 0;
         foreach (var dependentSchema in DependentSchemas)
@@ -11579,50 +11539,50 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3886 "SchemaEntity202012.tt"
+        #line 3877 "SchemaEntity202012.tt"
         this.Write("        private static ValidationContext __CorvusValidateDependentSchema");
         
         #line default
         #line hidden
         
-        #line 3886 "SchemaEntity202012.tt"
+        #line 3877 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dsIndexV ));
         
         #line default
         #line hidden
         
-        #line 3886 "SchemaEntity202012.tt"
+        #line 3877 "SchemaEntity202012.tt"
         this.Write("(in ");
         
         #line default
         #line hidden
         
-        #line 3886 "SchemaEntity202012.tt"
+        #line 3877 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3886 "SchemaEntity202012.tt"
+        #line 3877 "SchemaEntity202012.tt"
         this.Write(" that, in ValidationContext validationContext, ValidationLevel level)\r\n        {\r" +
                 "\n            return that.As<");
         
         #line default
         #line hidden
         
-        #line 3888 "SchemaEntity202012.tt"
+        #line 3879 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( dependentSchema.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3888 "SchemaEntity202012.tt"
+        #line 3879 "SchemaEntity202012.tt"
         this.Write(">().Validate(validationContext, level);\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3890 "SchemaEntity202012.tt"
+        #line 3881 "SchemaEntity202012.tt"
 
         }
         
@@ -11630,13 +11590,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3893 "SchemaEntity202012.tt"
+        #line 3884 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3894 "SchemaEntity202012.tt"
+        #line 3885 "SchemaEntity202012.tt"
 
     }
     
@@ -11644,13 +11604,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3897 "SchemaEntity202012.tt"
+        #line 3888 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3898 "SchemaEntity202012.tt"
+        #line 3889 "SchemaEntity202012.tt"
 
     if (HasDefaults)
     {
@@ -11659,7 +11619,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3902 "SchemaEntity202012.tt"
+        #line 3893 "SchemaEntity202012.tt"
         this.Write("        private static ImmutableDictionary<string, JsonAny> BuildDefaults()\r\n    " +
                 "    {\r\n            ImmutableDictionary<string, JsonAny>.Builder builder =\r\n     " +
                 "           ImmutableDictionary.CreateBuilder<string, JsonAny>();\r\n\r\n        ");
@@ -11667,7 +11627,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3907 "SchemaEntity202012.tt"
+        #line 3898 "SchemaEntity202012.tt"
 
         foreach (var property in Defaults)
         {
@@ -11676,37 +11636,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3911 "SchemaEntity202012.tt"
+        #line 3902 "SchemaEntity202012.tt"
         this.Write("            builder.Add(");
         
         #line default
         #line hidden
         
-        #line 3911 "SchemaEntity202012.tt"
+        #line 3902 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3911 "SchemaEntity202012.tt"
+        #line 3902 "SchemaEntity202012.tt"
         this.Write("JsonPropertyName, JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 3911 "SchemaEntity202012.tt"
+        #line 3902 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(property.DefaultValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3911 "SchemaEntity202012.tt"
+        #line 3902 "SchemaEntity202012.tt"
         this.Write("));\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3912 "SchemaEntity202012.tt"
+        #line 3903 "SchemaEntity202012.tt"
 
         }
         
@@ -11714,13 +11674,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3915 "SchemaEntity202012.tt"
+        #line 3906 "SchemaEntity202012.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3917 "SchemaEntity202012.tt"
+        #line 3908 "SchemaEntity202012.tt"
 
     }
     
@@ -11728,13 +11688,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3920 "SchemaEntity202012.tt"
+        #line 3911 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3921 "SchemaEntity202012.tt"
+        #line 3912 "SchemaEntity202012.tt"
 
     if (HasDependentRequired)
     {
@@ -11743,7 +11703,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3925 "SchemaEntity202012.tt"
+        #line 3916 "SchemaEntity202012.tt"
         this.Write(@"
         private static ImmutableDictionary<string, ImmutableArray<ReadOnlyMemory<byte>>> BuildDependentRequired()
         {
@@ -11755,7 +11715,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3931 "SchemaEntity202012.tt"
+        #line 3922 "SchemaEntity202012.tt"
 
         foreach (var dependentRequired in DependentRequired)
         {
@@ -11764,26 +11724,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3935 "SchemaEntity202012.tt"
+        #line 3926 "SchemaEntity202012.tt"
         this.Write("            builder.Add(\r\n                    ");
         
         #line default
         #line hidden
         
-        #line 3936 "SchemaEntity202012.tt"
+        #line 3927 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(dependentRequired.Name, true) ));
         
         #line default
         #line hidden
         
-        #line 3936 "SchemaEntity202012.tt"
+        #line 3927 "SchemaEntity202012.tt"
         this.Write(",\r\n                    ImmutableArray.Create<ReadOnlyMemory<byte>>(\r\n            " +
                 "");
         
         #line default
         #line hidden
         
-        #line 3938 "SchemaEntity202012.tt"
+        #line 3929 "SchemaEntity202012.tt"
 
             bool isFirst1 = true;
             foreach (var dependentRequiredValue in dependentRequired.RequiredNames)
@@ -11793,13 +11753,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3943 "SchemaEntity202012.tt"
+        #line 3934 "SchemaEntity202012.tt"
         this.Write("                ");
         
         #line default
         #line hidden
         
-        #line 3943 "SchemaEntity202012.tt"
+        #line 3934 "SchemaEntity202012.tt"
 
                 if (isFirst1)
                 {
@@ -11809,25 +11769,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3948 "SchemaEntity202012.tt"
+        #line 3939 "SchemaEntity202012.tt"
         this.Write("                        System.Text.Encoding.UTF8.GetBytes(");
         
         #line default
         #line hidden
         
-        #line 3948 "SchemaEntity202012.tt"
+        #line 3939 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  Formatting.FormatLiteralOrNull(dependentRequiredValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3948 "SchemaEntity202012.tt"
+        #line 3939 "SchemaEntity202012.tt"
         this.Write(").AsMemory()\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3949 "SchemaEntity202012.tt"
+        #line 3940 "SchemaEntity202012.tt"
 
                 }
                 else
@@ -11837,25 +11797,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3954 "SchemaEntity202012.tt"
+        #line 3945 "SchemaEntity202012.tt"
         this.Write("                        , System.Text.Encoding.UTF8.GetBytes(");
         
         #line default
         #line hidden
         
-        #line 3954 "SchemaEntity202012.tt"
+        #line 3945 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  Formatting.FormatLiteralOrNull(dependentRequiredValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3954 "SchemaEntity202012.tt"
+        #line 3945 "SchemaEntity202012.tt"
         this.Write(").AsMemory()\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3955 "SchemaEntity202012.tt"
+        #line 3946 "SchemaEntity202012.tt"
 
                 }
                 
@@ -11863,13 +11823,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3958 "SchemaEntity202012.tt"
+        #line 3949 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 3958 "SchemaEntity202012.tt"
+        #line 3949 "SchemaEntity202012.tt"
 
             }
             
@@ -11877,13 +11837,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3961 "SchemaEntity202012.tt"
+        #line 3952 "SchemaEntity202012.tt"
         this.Write("                        ));\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3962 "SchemaEntity202012.tt"
+        #line 3953 "SchemaEntity202012.tt"
 
         }
         
@@ -11891,13 +11851,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3965 "SchemaEntity202012.tt"
+        #line 3956 "SchemaEntity202012.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3968 "SchemaEntity202012.tt"
+        #line 3959 "SchemaEntity202012.tt"
 
     }
     
@@ -11905,13 +11865,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3971 "SchemaEntity202012.tt"
+        #line 3962 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3972 "SchemaEntity202012.tt"
+        #line 3963 "SchemaEntity202012.tt"
 
     if (HasLocalProperties)
     {
@@ -11920,51 +11880,51 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3976 "SchemaEntity202012.tt"
+        #line 3967 "SchemaEntity202012.tt"
         this.Write("\r\n        private static ImmutableDictionary<string, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3977 "SchemaEntity202012.tt"
+        #line 3968 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3977 "SchemaEntity202012.tt"
+        #line 3968 "SchemaEntity202012.tt"
         this.Write(">> CreateLocalPropertyValidators()\r\n        {\r\n            ImmutableDictionary<st" +
                 "ring, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3979 "SchemaEntity202012.tt"
+        #line 3970 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3979 "SchemaEntity202012.tt"
+        #line 3970 "SchemaEntity202012.tt"
         this.Write(">>.Builder builder =\r\n                ImmutableDictionary.CreateBuilder<string, P" +
                 "ropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3980 "SchemaEntity202012.tt"
+        #line 3971 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3980 "SchemaEntity202012.tt"
+        #line 3971 "SchemaEntity202012.tt"
         this.Write(">>();\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3982 "SchemaEntity202012.tt"
+        #line 3973 "SchemaEntity202012.tt"
 
         foreach (var property in LocalProperties)
         {
@@ -11973,37 +11933,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3986 "SchemaEntity202012.tt"
+        #line 3977 "SchemaEntity202012.tt"
         this.Write("            builder.Add(\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3987 "SchemaEntity202012.tt"
+        #line 3978 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3987 "SchemaEntity202012.tt"
+        #line 3978 "SchemaEntity202012.tt"
         this.Write("JsonPropertyName, __CorvusValidate");
         
         #line default
         #line hidden
         
-        #line 3987 "SchemaEntity202012.tt"
+        #line 3978 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3987 "SchemaEntity202012.tt"
+        #line 3978 "SchemaEntity202012.tt"
         this.Write(");\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3988 "SchemaEntity202012.tt"
+        #line 3979 "SchemaEntity202012.tt"
 
         }
         
@@ -12011,13 +11971,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3991 "SchemaEntity202012.tt"
+        #line 3982 "SchemaEntity202012.tt"
         this.Write("\r\n            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3995 "SchemaEntity202012.tt"
+        #line 3986 "SchemaEntity202012.tt"
 
         foreach (var property in LocalProperties)
         {
@@ -12026,63 +11986,63 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3999 "SchemaEntity202012.tt"
+        #line 3990 "SchemaEntity202012.tt"
         this.Write("        private static ValidationContext __CorvusValidate");
         
         #line default
         #line hidden
         
-        #line 3999 "SchemaEntity202012.tt"
+        #line 3990 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3999 "SchemaEntity202012.tt"
+        #line 3990 "SchemaEntity202012.tt"
         this.Write("(in ");
         
         #line default
         #line hidden
         
-        #line 3999 "SchemaEntity202012.tt"
+        #line 3990 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3999 "SchemaEntity202012.tt"
+        #line 3990 "SchemaEntity202012.tt"
         this.Write(" that, in ValidationContext validationContext, ValidationLevel level)\r\n        {\r" +
                 "\n            ");
         
         #line default
         #line hidden
         
-        #line 4001 "SchemaEntity202012.tt"
+        #line 3992 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4001 "SchemaEntity202012.tt"
+        #line 3992 "SchemaEntity202012.tt"
         this.Write(" property = that.");
         
         #line default
         #line hidden
         
-        #line 4001 "SchemaEntity202012.tt"
+        #line 3992 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4001 "SchemaEntity202012.tt"
+        #line 3992 "SchemaEntity202012.tt"
         this.Write(";\r\n            return property.Validate(validationContext, level);\r\n        }\r\n  " +
                 "      ");
         
         #line default
         #line hidden
         
-        #line 4004 "SchemaEntity202012.tt"
+        #line 3995 "SchemaEntity202012.tt"
 
         }
         
@@ -12090,13 +12050,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4007 "SchemaEntity202012.tt"
+        #line 3998 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 4007 "SchemaEntity202012.tt"
+        #line 3998 "SchemaEntity202012.tt"
 
     }
     
@@ -12104,13 +12064,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4010 "SchemaEntity202012.tt"
+        #line 4001 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4011 "SchemaEntity202012.tt"
+        #line 4002 "SchemaEntity202012.tt"
 
     if (HasRef)
     {
@@ -12119,7 +12079,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4015 "SchemaEntity202012.tt"
+        #line 4006 "SchemaEntity202012.tt"
         this.Write("        private ValidationContext ValidateRef(in ValidationContext validationCont" +
                 "ext, ValidationLevel level)\r\n        {\r\n            ValidationContext result = v" +
                 "alidationContext;\r\n\r\n            ValidationContext refResult = this.As<");
@@ -12127,13 +12087,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4019 "SchemaEntity202012.tt"
+        #line 4010 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( RefDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4019 "SchemaEntity202012.tt"
+        #line 4010 "SchemaEntity202012.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
             if (!refResult.IsValid)
@@ -12168,7 +12128,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4048 "SchemaEntity202012.tt"
+        #line 4039 "SchemaEntity202012.tt"
 
     }
     
@@ -12176,13 +12136,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4051 "SchemaEntity202012.tt"
+        #line 4042 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4052 "SchemaEntity202012.tt"
+        #line 4043 "SchemaEntity202012.tt"
 
     if (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasPrefixItems)
     {
@@ -12191,7 +12151,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4056 "SchemaEntity202012.tt"
+        #line 4047 "SchemaEntity202012.tt"
         this.Write(@"        private ValidationContext ValidateArray(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
             ValidationContext result = validationContext;
@@ -12206,7 +12166,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4065 "SchemaEntity202012.tt"
+        #line 4056 "SchemaEntity202012.tt"
 
         if (HasItems || HasContains || HasUniqueItems || HasUnevaluatedItems || HasPrefixItems)
         {
@@ -12215,13 +12175,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4069 "SchemaEntity202012.tt"
+        #line 4060 "SchemaEntity202012.tt"
         this.Write("\r\n            int arrayLength = 0;\r\n         ");
         
         #line default
         #line hidden
         
-        #line 4071 "SchemaEntity202012.tt"
+        #line 4062 "SchemaEntity202012.tt"
 
         }
         else
@@ -12231,13 +12191,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4076 "SchemaEntity202012.tt"
+        #line 4067 "SchemaEntity202012.tt"
         this.Write("            int arrayLength = this.Length;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4077 "SchemaEntity202012.tt"
+        #line 4068 "SchemaEntity202012.tt"
 
         }
         
@@ -12245,13 +12205,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4080 "SchemaEntity202012.tt"
+        #line 4071 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4081 "SchemaEntity202012.tt"
+        #line 4072 "SchemaEntity202012.tt"
 
         if (HasContains)
         {
@@ -12260,13 +12220,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4085 "SchemaEntity202012.tt"
+        #line 4076 "SchemaEntity202012.tt"
         this.Write("            int containsCount = 0;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4087 "SchemaEntity202012.tt"
+        #line 4078 "SchemaEntity202012.tt"
 
         }
 
@@ -12275,13 +12235,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4091 "SchemaEntity202012.tt"
+        #line 4082 "SchemaEntity202012.tt"
         this.Write("\r\n         ");
         
         #line default
         #line hidden
         
-        #line 4092 "SchemaEntity202012.tt"
+        #line 4083 "SchemaEntity202012.tt"
 
         if (HasItems || HasContains || HasUniqueItems || HasUnevaluatedItems || HasPrefixItems)
         {
@@ -12290,14 +12250,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4096 "SchemaEntity202012.tt"
+        #line 4087 "SchemaEntity202012.tt"
         this.Write("            JsonArrayEnumerator arrayEnumerator = this.EnumerateArray();\r\n\r\n     " +
                 "       while (arrayEnumerator.MoveNext())\r\n            {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4100 "SchemaEntity202012.tt"
+        #line 4091 "SchemaEntity202012.tt"
 
             if (HasUniqueItems)
             {
@@ -12306,7 +12266,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4104 "SchemaEntity202012.tt"
+        #line 4095 "SchemaEntity202012.tt"
         this.Write(@"                JsonArrayEnumerator innerEnumerator = this.EnumerateArray();
                 int innerIndex = -1;
                 while (innerIndex < arrayLength && innerEnumerator.MoveNext())
@@ -12338,7 +12298,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4130 "SchemaEntity202012.tt"
+        #line 4121 "SchemaEntity202012.tt"
 
             }
         
@@ -12346,13 +12306,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4133 "SchemaEntity202012.tt"
+        #line 4124 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4134 "SchemaEntity202012.tt"
+        #line 4125 "SchemaEntity202012.tt"
 
             if (HasContains)
             {
@@ -12361,19 +12321,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4138 "SchemaEntity202012.tt"
+        #line 4129 "SchemaEntity202012.tt"
         this.Write("                ValidationContext containsResult = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4138 "SchemaEntity202012.tt"
+        #line 4129 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     ContainsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4138 "SchemaEntity202012.tt"
+        #line 4129 "SchemaEntity202012.tt"
         this.Write(">().Validate(result.CreateChildContext(), level);\r\n\r\n                if (contains" +
                 "Result.IsValid)\r\n                {\r\n                    result = result.WithLoca" +
                 "lItemIndex(arrayLength);\r\n                    containsCount++;\r\n\r\n            ");
@@ -12381,7 +12341,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4145 "SchemaEntity202012.tt"
+        #line 4136 "SchemaEntity202012.tt"
 
                 if (HasMaxContains && !HasUnevaluatedItems)
                 {
@@ -12390,26 +12350,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4149 "SchemaEntity202012.tt"
+        #line 4140 "SchemaEntity202012.tt"
         this.Write("                    if (level == ValidationLevel.Flag && containsCount > ");
         
         #line default
         #line hidden
         
-        #line 4149 "SchemaEntity202012.tt"
+        #line 4140 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4149 "SchemaEntity202012.tt"
+        #line 4140 "SchemaEntity202012.tt"
         this.Write(")\r\n                    {\r\n                        return result.WithResult(isVali" +
                 "d: false);\r\n                    }\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4153 "SchemaEntity202012.tt"
+        #line 4144 "SchemaEntity202012.tt"
 
                 }
             
@@ -12417,13 +12377,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4156 "SchemaEntity202012.tt"
+        #line 4147 "SchemaEntity202012.tt"
         this.Write("                }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4158 "SchemaEntity202012.tt"
+        #line 4149 "SchemaEntity202012.tt"
 
             }
         
@@ -12431,13 +12391,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4161 "SchemaEntity202012.tt"
+        #line 4152 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4162 "SchemaEntity202012.tt"
+        #line 4153 "SchemaEntity202012.tt"
 
             if (HasSingleItemsType && !HasPrefixItems)
             {
@@ -12446,19 +12406,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4166 "SchemaEntity202012.tt"
+        #line 4157 "SchemaEntity202012.tt"
         this.Write("                result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4166 "SchemaEntity202012.tt"
+        #line 4157 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4166 "SchemaEntity202012.tt"
+        #line 4157 "SchemaEntity202012.tt"
         this.Write(">().Validate(result, level);\r\n                if (level == ValidationLevel.Flag &" +
                 "& !result.IsValid)\r\n                {\r\n                    return result;\r\n     " +
                 "           }\r\n\r\n                result = result.WithLocalItemIndex(arrayLength);" +
@@ -12467,7 +12427,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4174 "SchemaEntity202012.tt"
+        #line 4165 "SchemaEntity202012.tt"
 
             }
             else if (HasMultipleItemsType || HasPrefixItems)
@@ -12478,13 +12438,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4180 "SchemaEntity202012.tt"
+        #line 4171 "SchemaEntity202012.tt"
         this.Write("                switch (arrayLength)\r\n                {\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4182 "SchemaEntity202012.tt"
+        #line 4173 "SchemaEntity202012.tt"
 
                 if (HasPrefixItems)
                 {
@@ -12496,32 +12456,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4189 "SchemaEntity202012.tt"
+        #line 4180 "SchemaEntity202012.tt"
         this.Write("                    case ");
         
         #line default
         #line hidden
         
-        #line 4189 "SchemaEntity202012.tt"
+        #line 4180 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( itemsIndex ));
         
         #line default
         #line hidden
         
-        #line 4189 "SchemaEntity202012.tt"
+        #line 4180 "SchemaEntity202012.tt"
         this.Write(":\r\n                    \r\n                        result = arrayEnumerator.Current" +
                 ".As<");
         
         #line default
         #line hidden
         
-        #line 4191 "SchemaEntity202012.tt"
+        #line 4182 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( prefixItem ));
         
         #line default
         #line hidden
         
-        #line 4191 "SchemaEntity202012.tt"
+        #line 4182 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
                         if (level == ValidationLevel.Flag && !result.IsValid)
                         {
@@ -12534,7 +12494,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4198 "SchemaEntity202012.tt"
+        #line 4189 "SchemaEntity202012.tt"
 
                         itemsIndex++;
                     }
@@ -12544,13 +12504,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4203 "SchemaEntity202012.tt"
+        #line 4194 "SchemaEntity202012.tt"
         this.Write("\r\n                    default:\r\n                ");
         
         #line default
         #line hidden
         
-        #line 4205 "SchemaEntity202012.tt"
+        #line 4196 "SchemaEntity202012.tt"
 
                 if (HasSingleItemsType)
                 {
@@ -12559,19 +12519,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4209 "SchemaEntity202012.tt"
+        #line 4200 "SchemaEntity202012.tt"
         this.Write("                        result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4209 "SchemaEntity202012.tt"
+        #line 4200 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4209 "SchemaEntity202012.tt"
+        #line 4200 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
                         if (level == ValidationLevel.Flag && !result.IsValid)
                         {
@@ -12584,7 +12544,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4216 "SchemaEntity202012.tt"
+        #line 4207 "SchemaEntity202012.tt"
 
                 }
                 else if (HasUnevaluatedItems)
@@ -12594,7 +12554,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4221 "SchemaEntity202012.tt"
+        #line 4212 "SchemaEntity202012.tt"
         this.Write("                        if (!result.HasEvaluatedLocalOrAppliedItemIndex(arrayLeng" +
                 "th))\r\n                        {\r\n\r\n                            result = arrayEnu" +
                 "merator.Current.As<");
@@ -12602,13 +12562,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4224 "SchemaEntity202012.tt"
+        #line 4215 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  UnevaluatedItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4224 "SchemaEntity202012.tt"
+        #line 4215 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
 
                             if (level == ValidationLevel.Flag && !result.IsValid)
@@ -12623,7 +12583,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4233 "SchemaEntity202012.tt"
+        #line 4224 "SchemaEntity202012.tt"
 
                 }
                 
@@ -12631,13 +12591,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4236 "SchemaEntity202012.tt"
+        #line 4227 "SchemaEntity202012.tt"
         this.Write("\r\n                        break;\r\n                }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4240 "SchemaEntity202012.tt"
+        #line 4231 "SchemaEntity202012.tt"
 
             }
             else if (HasUnevaluatedItems)
@@ -12647,20 +12607,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4245 "SchemaEntity202012.tt"
+        #line 4236 "SchemaEntity202012.tt"
         this.Write("                if (!result.HasEvaluatedLocalOrAppliedItemIndex(arrayLength))\r\n  " +
                 "              {\r\n                    result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4247 "SchemaEntity202012.tt"
+        #line 4238 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  UnevaluatedItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4247 "SchemaEntity202012.tt"
+        #line 4238 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
 
                     if (level == ValidationLevel.Flag && !result.IsValid)
@@ -12676,7 +12636,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4257 "SchemaEntity202012.tt"
+        #line 4248 "SchemaEntity202012.tt"
 
             }
         
@@ -12684,13 +12644,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4260 "SchemaEntity202012.tt"
+        #line 4251 "SchemaEntity202012.tt"
         this.Write("\r\n                arrayLength++;\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4263 "SchemaEntity202012.tt"
+        #line 4254 "SchemaEntity202012.tt"
 
         }
         
@@ -12698,13 +12658,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4266 "SchemaEntity202012.tt"
+        #line 4257 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4267 "SchemaEntity202012.tt"
+        #line 4258 "SchemaEntity202012.tt"
 
         if (HasMaxItems)
         {
@@ -12713,19 +12673,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4271 "SchemaEntity202012.tt"
+        #line 4262 "SchemaEntity202012.tt"
         this.Write("            if (arrayLength > ");
         
         #line default
         #line hidden
         
-        #line 4271 "SchemaEntity202012.tt"
+        #line 4262 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4271 "SchemaEntity202012.tt"
+        #line 4262 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".1. maxItems - {arrayLength} exceeds maximum number of items ");
@@ -12733,13 +12693,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4275 "SchemaEntity202012.tt"
+        #line 4266 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4275 "SchemaEntity202012.tt"
+        #line 4266 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.1. maxItems - item count exceeds maximum number of items ");
@@ -12747,13 +12707,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4279 "SchemaEntity202012.tt"
+        #line 4270 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4279 "SchemaEntity202012.tt"
+        #line 4270 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n\r\n           " +
                 " }\r\n        ");
@@ -12761,7 +12721,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4287 "SchemaEntity202012.tt"
+        #line 4278 "SchemaEntity202012.tt"
 
         }
         
@@ -12769,13 +12729,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4290 "SchemaEntity202012.tt"
+        #line 4281 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4291 "SchemaEntity202012.tt"
+        #line 4282 "SchemaEntity202012.tt"
 
         if (HasMinItems)
         {
@@ -12784,19 +12744,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4295 "SchemaEntity202012.tt"
+        #line 4286 "SchemaEntity202012.tt"
         this.Write("            if (arrayLength < ");
         
         #line default
         #line hidden
         
-        #line 4295 "SchemaEntity202012.tt"
+        #line 4286 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4295 "SchemaEntity202012.tt"
+        #line 4286 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".2. minItems - {arrayLength} is less than the minimum number of items ");
@@ -12804,13 +12764,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4299 "SchemaEntity202012.tt"
+        #line 4290 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4299 "SchemaEntity202012.tt"
+        #line 4290 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.2. minItems - item count is less than the minimum number of items ");
@@ -12818,13 +12778,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4303 "SchemaEntity202012.tt"
+        #line 4294 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4303 "SchemaEntity202012.tt"
+        #line 4294 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n\r\n           " +
                 " }\r\n        ");
@@ -12832,7 +12792,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4311 "SchemaEntity202012.tt"
+        #line 4302 "SchemaEntity202012.tt"
 
         }
         
@@ -12840,13 +12800,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4314 "SchemaEntity202012.tt"
+        #line 4305 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4315 "SchemaEntity202012.tt"
+        #line 4306 "SchemaEntity202012.tt"
 
         if (HasContains)
         {
@@ -12855,13 +12815,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4319 "SchemaEntity202012.tt"
+        #line 4310 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4319 "SchemaEntity202012.tt"
+        #line 4310 "SchemaEntity202012.tt"
 
             if (HasMaxContains)
             {
@@ -12870,19 +12830,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4323 "SchemaEntity202012.tt"
+        #line 4314 "SchemaEntity202012.tt"
         this.Write("\r\n            if (containsCount > ");
         
         #line default
         #line hidden
         
-        #line 4324 "SchemaEntity202012.tt"
+        #line 4315 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4324 "SchemaEntity202012.tt"
+        #line 4315 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".4. maxContains - {containsCount} exceeds maximum number of matching items ");
@@ -12890,13 +12850,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4328 "SchemaEntity202012.tt"
+        #line 4319 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4328 "SchemaEntity202012.tt"
+        #line 4319 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.4. maxContains - item count exceeds maximum number of matching items ");
@@ -12904,13 +12864,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4332 "SchemaEntity202012.tt"
+        #line 4323 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4332 "SchemaEntity202012.tt"
+        #line 4323 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n            ");
@@ -12918,7 +12878,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4340 "SchemaEntity202012.tt"
+        #line 4331 "SchemaEntity202012.tt"
 
             }
             
@@ -12926,13 +12886,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4343 "SchemaEntity202012.tt"
+        #line 4334 "SchemaEntity202012.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4344 "SchemaEntity202012.tt"
+        #line 4335 "SchemaEntity202012.tt"
 
             if (HasMinContains)
             {
@@ -12941,19 +12901,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4348 "SchemaEntity202012.tt"
+        #line 4339 "SchemaEntity202012.tt"
         this.Write("            if (containsCount < ");
         
         #line default
         #line hidden
         
-        #line 4348 "SchemaEntity202012.tt"
+        #line 4339 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4348 "SchemaEntity202012.tt"
+        #line 4339 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".5. minContains - {containsCount} is less than minimum number of matching items " +
@@ -12962,13 +12922,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4352 "SchemaEntity202012.tt"
+        #line 4343 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4352 "SchemaEntity202012.tt"
+        #line 4343 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.5. minContains - item count is less than minimum number of matching ite" +
@@ -12977,13 +12937,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4356 "SchemaEntity202012.tt"
+        #line 4347 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4356 "SchemaEntity202012.tt"
+        #line 4347 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n            ");
@@ -12991,7 +12951,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4364 "SchemaEntity202012.tt"
+        #line 4355 "SchemaEntity202012.tt"
 
             }
             else
@@ -13001,7 +12961,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4369 "SchemaEntity202012.tt"
+        #line 4360 "SchemaEntity202012.tt"
         this.Write(@"            if (containsCount == 0)
             {
                 if (level >= ValidationLevel.Detailed)
@@ -13023,7 +12983,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4385 "SchemaEntity202012.tt"
+        #line 4376 "SchemaEntity202012.tt"
 
             }
             
@@ -13031,13 +12991,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4388 "SchemaEntity202012.tt"
+        #line 4379 "SchemaEntity202012.tt"
         this.Write("\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4390 "SchemaEntity202012.tt"
+        #line 4381 "SchemaEntity202012.tt"
 
         }
         
@@ -13045,13 +13005,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4393 "SchemaEntity202012.tt"
+        #line 4384 "SchemaEntity202012.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4397 "SchemaEntity202012.tt"
+        #line 4388 "SchemaEntity202012.tt"
 
     }
     
@@ -13059,13 +13019,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4400 "SchemaEntity202012.tt"
+        #line 4391 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4401 "SchemaEntity202012.tt"
+        #line 4392 "SchemaEntity202012.tt"
 
     if (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties|| HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)) || !AllowsAdditionalProperties))
     {
@@ -13074,7 +13034,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4405 "SchemaEntity202012.tt"
+        #line 4396 "SchemaEntity202012.tt"
         this.Write(@"        private ValidationContext ValidateObject(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
             ValidationContext result = validationContext;
@@ -13089,7 +13049,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4414 "SchemaEntity202012.tt"
+        #line 4405 "SchemaEntity202012.tt"
 
         if (HasMaxProperties || HasMinProperties || HasLocalProperties || HasRequired || HasDependentSchemas || HasPatternProperties || HasAdditionalProperties || HasUnevaluatedProperties)
         {
@@ -13098,13 +13058,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4418 "SchemaEntity202012.tt"
+        #line 4409 "SchemaEntity202012.tt"
         this.Write("            int propertyCount = 0;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4419 "SchemaEntity202012.tt"
+        #line 4410 "SchemaEntity202012.tt"
 
         }
         
@@ -13112,13 +13072,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4422 "SchemaEntity202012.tt"
+        #line 4413 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4423 "SchemaEntity202012.tt"
+        #line 4414 "SchemaEntity202012.tt"
 
         if (HasRequired)
         {
@@ -13127,13 +13087,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4427 "SchemaEntity202012.tt"
+        #line 4418 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4427 "SchemaEntity202012.tt"
+        #line 4418 "SchemaEntity202012.tt"
  
             foreach(var property in RequiredProperties)
             {
@@ -13142,25 +13102,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4431 "SchemaEntity202012.tt"
+        #line 4422 "SchemaEntity202012.tt"
         this.Write("            bool found");
         
         #line default
         #line hidden
         
-        #line 4431 "SchemaEntity202012.tt"
+        #line 4422 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4431 "SchemaEntity202012.tt"
+        #line 4422 "SchemaEntity202012.tt"
         this.Write(" = false;\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4432 "SchemaEntity202012.tt"
+        #line 4423 "SchemaEntity202012.tt"
 
             }
             
@@ -13168,13 +13128,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4435 "SchemaEntity202012.tt"
+        #line 4426 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4435 "SchemaEntity202012.tt"
+        #line 4426 "SchemaEntity202012.tt"
 
         }
         
@@ -13182,14 +13142,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4438 "SchemaEntity202012.tt"
+        #line 4429 "SchemaEntity202012.tt"
         this.Write("\r\n            foreach (Property property in this.EnumerateObject())\r\n            " +
                 "{\r\n                string propertyName = property.Name;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4443 "SchemaEntity202012.tt"
+        #line 4434 "SchemaEntity202012.tt"
 
         if (HasDependentRequired)
         {
@@ -13198,7 +13158,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4447 "SchemaEntity202012.tt"
+        #line 4438 "SchemaEntity202012.tt"
         this.Write(@"                if (__CorvusDependentRequired.TryGetValue(propertyName, out ImmutableArray<ReadOnlyMemory<byte>> dependencies))
                 {
                     foreach (ReadOnlyMemory<byte> dependency in dependencies)
@@ -13209,7 +13169,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4452 "SchemaEntity202012.tt"
+        #line 4443 "SchemaEntity202012.tt"
 
             if (HasDefaults)
             {
@@ -13218,13 +13178,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4456 "SchemaEntity202012.tt"
+        #line 4447 "SchemaEntity202012.tt"
         this.Write("                        && !this.HasDefault(dependency.Span)\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4457 "SchemaEntity202012.tt"
+        #line 4448 "SchemaEntity202012.tt"
 
             }
             
@@ -13232,7 +13192,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4460 "SchemaEntity202012.tt"
+        #line 4451 "SchemaEntity202012.tt"
         this.Write(@"                        )
                         {
                             if (level >= ValidationLevel.Detailed)
@@ -13256,7 +13216,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4478 "SchemaEntity202012.tt"
+        #line 4469 "SchemaEntity202012.tt"
 
         }
         
@@ -13264,13 +13224,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4481 "SchemaEntity202012.tt"
+        #line 4472 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4482 "SchemaEntity202012.tt"
+        #line 4473 "SchemaEntity202012.tt"
 
         if (HasLocalProperties || HasRequired)
         {
@@ -13279,20 +13239,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4486 "SchemaEntity202012.tt"
+        #line 4477 "SchemaEntity202012.tt"
         this.Write("                if (__CorvusLocalProperties.TryGetValue(propertyName, out Propert" +
                 "yValidator<");
         
         #line default
         #line hidden
         
-        #line 4486 "SchemaEntity202012.tt"
+        #line 4477 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4486 "SchemaEntity202012.tt"
+        #line 4477 "SchemaEntity202012.tt"
         this.Write(@">? propertyValidator))
                 {
                     result = result.WithLocalProperty(propertyCount);
@@ -13308,7 +13268,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4496 "SchemaEntity202012.tt"
+        #line 4487 "SchemaEntity202012.tt"
 
             if (HasRequired)
             {
@@ -13322,13 +13282,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4505 "SchemaEntity202012.tt"
+        #line 4496 "SchemaEntity202012.tt"
         this.Write("                else \r\n                    ");
         
         #line default
         #line hidden
         
-        #line 4506 "SchemaEntity202012.tt"
+        #line 4497 "SchemaEntity202012.tt"
 
                     }
                     else
@@ -13340,38 +13300,38 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4513 "SchemaEntity202012.tt"
+        #line 4504 "SchemaEntity202012.tt"
         this.Write("\r\n                if (");
         
         #line default
         #line hidden
         
-        #line 4514 "SchemaEntity202012.tt"
+        #line 4505 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4514 "SchemaEntity202012.tt"
+        #line 4505 "SchemaEntity202012.tt"
         this.Write("JsonPropertyName.Equals(propertyName))\r\n                {\r\n                    fo" +
                 "und");
         
         #line default
         #line hidden
         
-        #line 4516 "SchemaEntity202012.tt"
+        #line 4507 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  property.DotnetPropertyName));
         
         #line default
         #line hidden
         
-        #line 4516 "SchemaEntity202012.tt"
+        #line 4507 "SchemaEntity202012.tt"
         this.Write(" = true;\r\n                }\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4518 "SchemaEntity202012.tt"
+        #line 4509 "SchemaEntity202012.tt"
 
                 }
             }
@@ -13380,13 +13340,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4522 "SchemaEntity202012.tt"
+        #line 4513 "SchemaEntity202012.tt"
         this.Write("\r\n                }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4524 "SchemaEntity202012.tt"
+        #line 4515 "SchemaEntity202012.tt"
 
         }
         
@@ -13394,13 +13354,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4527 "SchemaEntity202012.tt"
+        #line 4518 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4528 "SchemaEntity202012.tt"
+        #line 4519 "SchemaEntity202012.tt"
 
         if (HasDependentSchemas)
         {
@@ -13409,20 +13369,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4532 "SchemaEntity202012.tt"
+        #line 4523 "SchemaEntity202012.tt"
         this.Write("                if (__CorvusDependentSchema.TryGetValue(propertyName, out Propert" +
                 "yValidator<");
         
         #line default
         #line hidden
         
-        #line 4532 "SchemaEntity202012.tt"
+        #line 4523 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4532 "SchemaEntity202012.tt"
+        #line 4523 "SchemaEntity202012.tt"
         this.Write(@">? dependentSchemaValidator))
                 {
                     result = result.WithLocalProperty(propertyCount);
@@ -13437,7 +13397,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4541 "SchemaEntity202012.tt"
+        #line 4532 "SchemaEntity202012.tt"
 
         }
         
@@ -13445,13 +13405,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4544 "SchemaEntity202012.tt"
+        #line 4535 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4545 "SchemaEntity202012.tt"
+        #line 4536 "SchemaEntity202012.tt"
 
         if (HasPropertyNames || HasPatternProperties)
         {
@@ -13460,13 +13420,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4549 "SchemaEntity202012.tt"
+        #line 4540 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4549 "SchemaEntity202012.tt"
+        #line 4540 "SchemaEntity202012.tt"
 
             if (HasPropertyNames)
             {
@@ -13475,19 +13435,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4553 "SchemaEntity202012.tt"
+        #line 4544 "SchemaEntity202012.tt"
         this.Write("                result = new JsonString(propertyName).As<");
         
         #line default
         #line hidden
         
-        #line 4553 "SchemaEntity202012.tt"
+        #line 4544 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     PropertyNamesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4553 "SchemaEntity202012.tt"
+        #line 4544 "SchemaEntity202012.tt"
         this.Write(">().Validate(result, level);\r\n                if (level == ValidationLevel.Flag &" +
                 "& !result.IsValid)\r\n                {\r\n                    return result;\r\n     " +
                 "           }\r\n            ");
@@ -13495,7 +13455,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4558 "SchemaEntity202012.tt"
+        #line 4549 "SchemaEntity202012.tt"
 
             }
             
@@ -13503,13 +13463,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4561 "SchemaEntity202012.tt"
+        #line 4552 "SchemaEntity202012.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4562 "SchemaEntity202012.tt"
+        #line 4553 "SchemaEntity202012.tt"
 
             if (HasPatternProperties)
             {
@@ -13518,7 +13478,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4566 "SchemaEntity202012.tt"
+        #line 4557 "SchemaEntity202012.tt"
         this.Write(@"                foreach (System.Collections.Generic.KeyValuePair<Regex, PatternPropertyValidator> patternProperty in __CorvusPatternProperties)
                 {
                     if (patternProperty.Key.IsMatch(propertyName))
@@ -13537,7 +13497,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4579 "SchemaEntity202012.tt"
+        #line 4570 "SchemaEntity202012.tt"
 
             }
             
@@ -13545,13 +13505,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4582 "SchemaEntity202012.tt"
+        #line 4573 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4582 "SchemaEntity202012.tt"
+        #line 4573 "SchemaEntity202012.tt"
 
         }
         
@@ -13559,13 +13519,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4585 "SchemaEntity202012.tt"
+        #line 4576 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4586 "SchemaEntity202012.tt"
+        #line 4577 "SchemaEntity202012.tt"
 
         if (AllowsAdditionalProperties && HasAdditionalProperties)
         {
@@ -13574,20 +13534,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4590 "SchemaEntity202012.tt"
+        #line 4581 "SchemaEntity202012.tt"
         this.Write("                if (!result.HasEvaluatedLocalProperty(propertyCount))\r\n          " +
                 "      {\r\n                    result = property.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 4592 "SchemaEntity202012.tt"
+        #line 4583 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4592 "SchemaEntity202012.tt"
+        #line 4583 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
                     if (level == ValidationLevel.Flag && !result.IsValid)
                     {
@@ -13600,7 +13560,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4599 "SchemaEntity202012.tt"
+        #line 4590 "SchemaEntity202012.tt"
 
         }
         
@@ -13608,13 +13568,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4602 "SchemaEntity202012.tt"
+        #line 4593 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4603 "SchemaEntity202012.tt"
+        #line 4594 "SchemaEntity202012.tt"
 
         if (AllowsAdditionalProperties && HasUnevaluatedProperties)
         {
@@ -13623,20 +13583,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4607 "SchemaEntity202012.tt"
+        #line 4598 "SchemaEntity202012.tt"
         this.Write("        \r\n                if (!result.HasEvaluatedLocalOrAppliedProperty(property" +
                 "Count))\r\n                {\r\n\r\n                    result = property.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 4611 "SchemaEntity202012.tt"
+        #line 4602 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4611 "SchemaEntity202012.tt"
+        #line 4602 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
                     if (level == ValidationLevel.Flag && !result.IsValid)
                     {
@@ -13650,7 +13610,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4619 "SchemaEntity202012.tt"
+        #line 4610 "SchemaEntity202012.tt"
 
         }
         
@@ -13658,13 +13618,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4622 "SchemaEntity202012.tt"
+        #line 4613 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4623 "SchemaEntity202012.tt"
+        #line 4614 "SchemaEntity202012.tt"
 
         if (!AllowsAdditionalProperties)
         {
@@ -13673,7 +13633,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4627 "SchemaEntity202012.tt"
+        #line 4618 "SchemaEntity202012.tt"
         this.Write(@"        
                 if (!result.HasEvaluatedLocalProperty(propertyCount))
                 {
@@ -13696,7 +13656,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4644 "SchemaEntity202012.tt"
+        #line 4635 "SchemaEntity202012.tt"
 
         }
         
@@ -13704,13 +13664,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4647 "SchemaEntity202012.tt"
+        #line 4638 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4648 "SchemaEntity202012.tt"
+        #line 4639 "SchemaEntity202012.tt"
 
         if (HasMaxProperties || HasMinProperties || HasLocalProperties || HasRequired || HasDependentSchemas || HasPatternProperties || HasAdditionalProperties || HasUnevaluatedProperties)
         {
@@ -13719,13 +13679,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4652 "SchemaEntity202012.tt"
+        #line 4643 "SchemaEntity202012.tt"
         this.Write("        \r\n                propertyCount++;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4655 "SchemaEntity202012.tt"
+        #line 4646 "SchemaEntity202012.tt"
 
         }
         
@@ -13733,13 +13693,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4658 "SchemaEntity202012.tt"
+        #line 4649 "SchemaEntity202012.tt"
         this.Write("            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4660 "SchemaEntity202012.tt"
+        #line 4651 "SchemaEntity202012.tt"
 
         if (HasRequired)
         {
@@ -13748,13 +13708,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4664 "SchemaEntity202012.tt"
+        #line 4655 "SchemaEntity202012.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4665 "SchemaEntity202012.tt"
+        #line 4656 "SchemaEntity202012.tt"
 
             foreach (var property in RequiredProperties)
             {
@@ -13765,19 +13725,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4671 "SchemaEntity202012.tt"
+        #line 4662 "SchemaEntity202012.tt"
         this.Write("            if (!found");
         
         #line default
         #line hidden
         
-        #line 4671 "SchemaEntity202012.tt"
+        #line 4662 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4671 "SchemaEntity202012.tt"
+        #line 4662 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".3. required - required property \\\"");
@@ -13785,13 +13745,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4675 "SchemaEntity202012.tt"
+        #line 4666 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    Formatting.FormatLiteralOrNull(property.JsonPropertyName, true).Trim('"') ));
         
         #line default
         #line hidden
         
-        #line 4675 "SchemaEntity202012.tt"
+        #line 4666 "SchemaEntity202012.tt"
         this.Write(@"\"" not present."");
                 }
                 else if (level >= ValidationLevel.Basic)
@@ -13808,7 +13768,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4686 "SchemaEntity202012.tt"
+        #line 4677 "SchemaEntity202012.tt"
 
                 }
             }
@@ -13817,13 +13777,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4690 "SchemaEntity202012.tt"
+        #line 4681 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4690 "SchemaEntity202012.tt"
+        #line 4681 "SchemaEntity202012.tt"
 
         }
         
@@ -13831,13 +13791,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4693 "SchemaEntity202012.tt"
+        #line 4684 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4694 "SchemaEntity202012.tt"
+        #line 4685 "SchemaEntity202012.tt"
 
         if (HasMaxProperties)
         {
@@ -13846,19 +13806,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4698 "SchemaEntity202012.tt"
+        #line 4689 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (propertyCount > ");
         
         #line default
         #line hidden
         
-        #line 4699 "SchemaEntity202012.tt"
+        #line 4690 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4699 "SchemaEntity202012.tt"
+        #line 4690 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".1. maxProperties - property count of {propertyCount} is greater than ");
@@ -13866,13 +13826,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4703 "SchemaEntity202012.tt"
+        #line 4694 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4703 "SchemaEntity202012.tt"
+        #line 4694 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.5.1. maxProperties - property count greater than ");
@@ -13880,13 +13840,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4707 "SchemaEntity202012.tt"
+        #line 4698 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4707 "SchemaEntity202012.tt"
+        #line 4698 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n        ");
@@ -13894,7 +13854,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4714 "SchemaEntity202012.tt"
+        #line 4705 "SchemaEntity202012.tt"
 
         }
         
@@ -13902,13 +13862,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4717 "SchemaEntity202012.tt"
+        #line 4708 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4718 "SchemaEntity202012.tt"
+        #line 4709 "SchemaEntity202012.tt"
 
         if (HasMinProperties)
         {
@@ -13917,19 +13877,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4722 "SchemaEntity202012.tt"
+        #line 4713 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (propertyCount < ");
         
         #line default
         #line hidden
         
-        #line 4723 "SchemaEntity202012.tt"
+        #line 4714 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4723 "SchemaEntity202012.tt"
+        #line 4714 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".2. minProperties - property count of {propertyCount} is lezs than ");
@@ -13937,13 +13897,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4727 "SchemaEntity202012.tt"
+        #line 4718 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4727 "SchemaEntity202012.tt"
+        #line 4718 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.5.2. minProperties - property count less than ");
@@ -13951,13 +13911,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4731 "SchemaEntity202012.tt"
+        #line 4722 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4731 "SchemaEntity202012.tt"
+        #line 4722 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n        ");
@@ -13965,7 +13925,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4739 "SchemaEntity202012.tt"
+        #line 4730 "SchemaEntity202012.tt"
 
         }
         
@@ -13973,13 +13933,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4742 "SchemaEntity202012.tt"
+        #line 4733 "SchemaEntity202012.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4746 "SchemaEntity202012.tt"
+        #line 4737 "SchemaEntity202012.tt"
 
     }
     
@@ -13987,13 +13947,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4749 "SchemaEntity202012.tt"
+        #line 4740 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4750 "SchemaEntity202012.tt"
+        #line 4741 "SchemaEntity202012.tt"
 
     if (HasOneOf)
     {
@@ -14002,7 +13962,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4754 "SchemaEntity202012.tt"
+        #line 4745 "SchemaEntity202012.tt"
         this.Write("        \r\n        private ValidationContext ValidateOneOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n            int oneOfCount = 0;\r\n\r\n        ");
@@ -14010,7 +13970,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4761 "SchemaEntity202012.tt"
+        #line 4752 "SchemaEntity202012.tt"
 
         int oneOfIndex = 0;
         foreach (var oneOf in OneOf)
@@ -14020,64 +13980,64 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4766 "SchemaEntity202012.tt"
+        #line 4757 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n            ValidationContext oneOfResult");
         
         #line default
         #line hidden
         
-        #line 4768 "SchemaEntity202012.tt"
+        #line 4759 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex));
         
         #line default
         #line hidden
         
-        #line 4768 "SchemaEntity202012.tt"
+        #line 4759 "SchemaEntity202012.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 4768 "SchemaEntity202012.tt"
+        #line 4759 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOf ));
         
         #line default
         #line hidden
         
-        #line 4768 "SchemaEntity202012.tt"
+        #line 4759 "SchemaEntity202012.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (o" +
                 "neOfResult");
         
         #line default
         #line hidden
         
-        #line 4770 "SchemaEntity202012.tt"
+        #line 4761 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4770 "SchemaEntity202012.tt"
+        #line 4761 "SchemaEntity202012.tt"
         this.Write(".IsValid)\r\n            {\r\n                result = result.MergeChildContext(oneOf" +
                 "Result");
         
         #line default
         #line hidden
         
-        #line 4772 "SchemaEntity202012.tt"
+        #line 4763 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4772 "SchemaEntity202012.tt"
+        #line 4763 "SchemaEntity202012.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n                oneOfCount += 1;\r\n        " +
                 "                    ");
         
         #line default
         #line hidden
         
-        #line 4774 "SchemaEntity202012.tt"
+        #line 4765 "SchemaEntity202012.tt"
 
             if (!HasUnevaluatedItems && !HasUnevaluatedProperties)
             {
@@ -14086,7 +14046,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4778 "SchemaEntity202012.tt"
+        #line 4769 "SchemaEntity202012.tt"
         this.Write("                if (oneOfCount > 1 && level == ValidationLevel.Flag)\r\n           " +
                 "     {\r\n                    result = result.WithResult(isValid: false);\r\n       " +
                 "             return result;\r\n                }\r\n            ");
@@ -14094,7 +14054,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4783 "SchemaEntity202012.tt"
+        #line 4774 "SchemaEntity202012.tt"
 
             }
             
@@ -14102,7 +14062,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4786 "SchemaEntity202012.tt"
+        #line 4777 "SchemaEntity202012.tt"
         this.Write("            }\r\n            else\r\n            {\r\n                if (level >= Vali" +
                 "dationLevel.Detailed)\r\n                {\r\n                    result = result.Me" +
                 "rgeResults(result.IsValid, level, oneOfResult");
@@ -14110,13 +14070,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4791 "SchemaEntity202012.tt"
+        #line 4782 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4791 "SchemaEntity202012.tt"
+        #line 4782 "SchemaEntity202012.tt"
         this.Write(");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)\r\n" +
                 "                {\r\n                    result = result.MergeResults(result.IsVal" +
                 "id, level, oneOfResult");
@@ -14124,32 +14084,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4795 "SchemaEntity202012.tt"
+        #line 4786 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4795 "SchemaEntity202012.tt"
+        #line 4786 "SchemaEntity202012.tt"
         this.Write(");\r\n                }\r\n                else\r\n                {\r\n                 " +
                 "   result = result.MergeResults(result.IsValid, level, oneOfResult");
         
         #line default
         #line hidden
         
-        #line 4799 "SchemaEntity202012.tt"
+        #line 4790 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4799 "SchemaEntity202012.tt"
+        #line 4790 "SchemaEntity202012.tt"
         this.Write(");\r\n                }\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4803 "SchemaEntity202012.tt"
+        #line 4794 "SchemaEntity202012.tt"
 
             oneOfIndex++;
         }
@@ -14158,7 +14118,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4807 "SchemaEntity202012.tt"
+        #line 4798 "SchemaEntity202012.tt"
         this.Write("\r\n            if (oneOfCount == 1)\r\n            {\r\n                if (level >= V" +
                 "alidationLevel.Detailed)\r\n                {\r\n                    result = result" +
                 ".WithResult(isValid: true, \"Validation 10.2.1.3. onef - validated against the on" +
@@ -14185,7 +14145,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4849 "SchemaEntity202012.tt"
+        #line 4840 "SchemaEntity202012.tt"
 
     }
     
@@ -14193,13 +14153,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4852 "SchemaEntity202012.tt"
+        #line 4843 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4854 "SchemaEntity202012.tt"
+        #line 4845 "SchemaEntity202012.tt"
 
     if (HasAnyOf)
     {
@@ -14208,7 +14168,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4858 "SchemaEntity202012.tt"
+        #line 4849 "SchemaEntity202012.tt"
         this.Write("        \r\n        private ValidationContext ValidateAnyOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n            bool foundValid = false;\r\n\r\n       " +
@@ -14217,7 +14177,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4865 "SchemaEntity202012.tt"
+        #line 4856 "SchemaEntity202012.tt"
 
         int anyOfIndex = 0;
         foreach (var anyOf in AnyOf)
@@ -14227,63 +14187,63 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4870 "SchemaEntity202012.tt"
+        #line 4861 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n            ValidationContext anyOfResult");
         
         #line default
         #line hidden
         
-        #line 4872 "SchemaEntity202012.tt"
+        #line 4863 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4872 "SchemaEntity202012.tt"
+        #line 4863 "SchemaEntity202012.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 4872 "SchemaEntity202012.tt"
+        #line 4863 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOf ));
         
         #line default
         #line hidden
         
-        #line 4872 "SchemaEntity202012.tt"
+        #line 4863 "SchemaEntity202012.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (a" +
                 "nyOfResult");
         
         #line default
         #line hidden
         
-        #line 4874 "SchemaEntity202012.tt"
+        #line 4865 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4874 "SchemaEntity202012.tt"
+        #line 4865 "SchemaEntity202012.tt"
         this.Write(".IsValid)\r\n            {\r\n                result = result.MergeChildContext(anyOf" +
                 "Result");
         
         #line default
         #line hidden
         
-        #line 4876 "SchemaEntity202012.tt"
+        #line 4867 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4876 "SchemaEntity202012.tt"
+        #line 4867 "SchemaEntity202012.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4877 "SchemaEntity202012.tt"
+        #line 4868 "SchemaEntity202012.tt"
 
             if (!HasUnevaluatedItems && !HasUnevaluatedProperties)
             {
@@ -14292,7 +14252,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4881 "SchemaEntity202012.tt"
+        #line 4872 "SchemaEntity202012.tt"
         this.Write("                if (level == ValidationLevel.Flag)\r\n                {\r\n          " +
                 "          return result;\r\n                }\r\n                else\r\n             " +
                 "   {\r\n                    foundValid = true;\r\n                }\r\n            ");
@@ -14300,7 +14260,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4889 "SchemaEntity202012.tt"
+        #line 4880 "SchemaEntity202012.tt"
 
             }
             else
@@ -14310,13 +14270,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4894 "SchemaEntity202012.tt"
+        #line 4885 "SchemaEntity202012.tt"
         this.Write("                    foundValid = true;\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4895 "SchemaEntity202012.tt"
+        #line 4886 "SchemaEntity202012.tt"
 
             }
             
@@ -14324,7 +14284,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4898 "SchemaEntity202012.tt"
+        #line 4889 "SchemaEntity202012.tt"
         this.Write("            }\r\n            else\r\n            {\r\n                if (level >= Vali" +
                 "dationLevel.Detailed)\r\n                {\r\n                    result = result.Me" +
                 "rgeResults(result.IsValid, level, anyOfResult");
@@ -14332,13 +14292,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4903 "SchemaEntity202012.tt"
+        #line 4894 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4903 "SchemaEntity202012.tt"
+        #line 4894 "SchemaEntity202012.tt"
         this.Write(");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)\r\n" +
                 "                {\r\n                    result = result.MergeResults(result.IsVal" +
                 "id, level, anyOfResult");
@@ -14346,19 +14306,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4907 "SchemaEntity202012.tt"
+        #line 4898 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4907 "SchemaEntity202012.tt"
+        #line 4898 "SchemaEntity202012.tt"
         this.Write(");\r\n                }\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4911 "SchemaEntity202012.tt"
+        #line 4902 "SchemaEntity202012.tt"
 
             anyOfIndex++;
         }
@@ -14367,7 +14327,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4915 "SchemaEntity202012.tt"
+        #line 4906 "SchemaEntity202012.tt"
         this.Write(@"
             if (foundValid)
             {
@@ -14400,7 +14360,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4942 "SchemaEntity202012.tt"
+        #line 4933 "SchemaEntity202012.tt"
 
     }
     
@@ -14408,13 +14368,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4945 "SchemaEntity202012.tt"
+        #line 4936 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4947 "SchemaEntity202012.tt"
+        #line 4938 "SchemaEntity202012.tt"
 
     if (HasAllOf)
     {
@@ -14423,7 +14383,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4951 "SchemaEntity202012.tt"
+        #line 4942 "SchemaEntity202012.tt"
         this.Write("        \r\n        private ValidationContext ValidateAllOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n        ");
@@ -14431,7 +14391,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4956 "SchemaEntity202012.tt"
+        #line 4947 "SchemaEntity202012.tt"
 
         int allOfIndex = 0;
         foreach (var allOf in AllOf)
@@ -14441,44 +14401,44 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4961 "SchemaEntity202012.tt"
+        #line 4952 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n            ValidationContext allOfResult");
         
         #line default
         #line hidden
         
-        #line 4963 "SchemaEntity202012.tt"
+        #line 4954 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4963 "SchemaEntity202012.tt"
+        #line 4954 "SchemaEntity202012.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 4963 "SchemaEntity202012.tt"
+        #line 4954 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOf ));
         
         #line default
         #line hidden
         
-        #line 4963 "SchemaEntity202012.tt"
+        #line 4954 "SchemaEntity202012.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (!" +
                 "allOfResult");
         
         #line default
         #line hidden
         
-        #line 4965 "SchemaEntity202012.tt"
+        #line 4956 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4965 "SchemaEntity202012.tt"
+        #line 4956 "SchemaEntity202012.tt"
         this.Write(".IsValid)\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r" +
                 "\n                {\r\n                    result = result.MergeChildContext(allOfR" +
                 "esult");
@@ -14486,13 +14446,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4969 "SchemaEntity202012.tt"
+        #line 4960 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4969 "SchemaEntity202012.tt"
+        #line 4960 "SchemaEntity202012.tt"
         this.Write(@", true).WithResult(isValid: false, ""Validation 10.2.1.1. allOf - failed to validate against the allOf schema."");
                 }
                 else if (level >= ValidationLevel.Basic)
@@ -14502,13 +14462,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4973 "SchemaEntity202012.tt"
+        #line 4964 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4973 "SchemaEntity202012.tt"
+        #line 4964 "SchemaEntity202012.tt"
         this.Write(", true).WithResult(isValid: false, \"Validation 10.2.1.1. allOf - failed to valida" +
                 "te against the allOf schema.\");\r\n                }\r\n                else\r\n      " +
                 "          {\r\n                    result = result.MergeChildContext(allOfResult");
@@ -14516,13 +14476,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4977 "SchemaEntity202012.tt"
+        #line 4968 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4977 "SchemaEntity202012.tt"
+        #line 4968 "SchemaEntity202012.tt"
         this.Write(", false).WithResult(isValid: false);\r\n                    return result;\r\n       " +
                 "         }\r\n            }\r\n            else\r\n            {\r\n                resu" +
                 "lt = result.MergeChildContext(allOfResult");
@@ -14530,19 +14490,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4983 "SchemaEntity202012.tt"
+        #line 4974 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4983 "SchemaEntity202012.tt"
+        #line 4974 "SchemaEntity202012.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4986 "SchemaEntity202012.tt"
+        #line 4977 "SchemaEntity202012.tt"
 
             allOfIndex++;
         }
@@ -14551,13 +14511,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4990 "SchemaEntity202012.tt"
+        #line 4981 "SchemaEntity202012.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4994 "SchemaEntity202012.tt"
+        #line 4985 "SchemaEntity202012.tt"
 
     }
     
@@ -14565,13 +14525,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4997 "SchemaEntity202012.tt"
+        #line 4988 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4999 "SchemaEntity202012.tt"
+        #line 4990 "SchemaEntity202012.tt"
 
     if (HasNot)
     {
@@ -14580,7 +14540,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5003 "SchemaEntity202012.tt"
+        #line 4994 "SchemaEntity202012.tt"
         this.Write("        \r\n        private ValidationContext ValidateNot(ValidationContext validat" +
                 "ionContext, ValidationLevel level)\r\n        {\r\n            ValidationContext res" +
                 "ult = validationContext;\r\n\r\n            ValidationContext notResult = this.As<");
@@ -14588,13 +14548,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5008 "SchemaEntity202012.tt"
+        #line 4999 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( NotDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5008 "SchemaEntity202012.tt"
+        #line 4999 "SchemaEntity202012.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
             if (notResult.IsValid)
             {
@@ -14624,7 +14584,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5032 "SchemaEntity202012.tt"
+        #line 5023 "SchemaEntity202012.tt"
 
     }
     
@@ -14632,13 +14592,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5035 "SchemaEntity202012.tt"
+        #line 5026 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5037 "SchemaEntity202012.tt"
+        #line 5028 "SchemaEntity202012.tt"
 
     if (HasIfThenElse)
     {
@@ -14647,7 +14607,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5041 "SchemaEntity202012.tt"
+        #line 5032 "SchemaEntity202012.tt"
         this.Write("        \r\n        private ValidationContext ValidateIfThenElse(in ValidationConte" +
                 "xt validationContext, ValidationLevel level)\r\n        {\r\n            ValidationC" +
                 "ontext result = validationContext;\r\n\r\n            ValidationContext ifResult = t" +
@@ -14656,13 +14616,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5046 "SchemaEntity202012.tt"
+        #line 5037 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( IfFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5046 "SchemaEntity202012.tt"
+        #line 5037 "SchemaEntity202012.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
             if (!ifResult.IsValid)
@@ -14692,7 +14652,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5070 "SchemaEntity202012.tt"
+        #line 5061 "SchemaEntity202012.tt"
 
         if (HasThen)
         {
@@ -14701,20 +14661,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5074 "SchemaEntity202012.tt"
+        #line 5065 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (ifResult.IsValid)\r\n            {\r\n                Valid" +
                 "ationContext thenResult = this.As<");
         
         #line default
         #line hidden
         
-        #line 5077 "SchemaEntity202012.tt"
+        #line 5068 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ThenFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5077 "SchemaEntity202012.tt"
+        #line 5068 "SchemaEntity202012.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
                 if (!thenResult.IsValid)
@@ -14748,7 +14708,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5105 "SchemaEntity202012.tt"
+        #line 5096 "SchemaEntity202012.tt"
 
         }
         
@@ -14756,13 +14716,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5108 "SchemaEntity202012.tt"
+        #line 5099 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5109 "SchemaEntity202012.tt"
+        #line 5100 "SchemaEntity202012.tt"
 
         if (HasElse)
         {
@@ -14771,20 +14731,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5113 "SchemaEntity202012.tt"
+        #line 5104 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (!ifResult.IsValid)\r\n            {\r\n                Vali" +
                 "dationContext elseResult = this.As<");
         
         #line default
         #line hidden
         
-        #line 5116 "SchemaEntity202012.tt"
+        #line 5107 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ElseFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5116 "SchemaEntity202012.tt"
+        #line 5107 "SchemaEntity202012.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
                 if (!elseResult.IsValid)
@@ -14818,7 +14778,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5144 "SchemaEntity202012.tt"
+        #line 5135 "SchemaEntity202012.tt"
 
         }
         
@@ -14826,13 +14786,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5147 "SchemaEntity202012.tt"
+        #line 5138 "SchemaEntity202012.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5151 "SchemaEntity202012.tt"
+        #line 5142 "SchemaEntity202012.tt"
 
     }
     
@@ -14840,13 +14800,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5154 "SchemaEntity202012.tt"
+        #line 5145 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5155 "SchemaEntity202012.tt"
+        #line 5146 "SchemaEntity202012.tt"
 
     if (HasMediaTypeOrEncoding)
     {
@@ -14855,14 +14815,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5159 "SchemaEntity202012.tt"
+        #line 5150 "SchemaEntity202012.tt"
         this.Write("        private ValidationContext ValidateMediaTypeAndEncoding(JsonValueKind valu" +
                 "eKind, ValidationContext result, ValidationLevel level)\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5161 "SchemaEntity202012.tt"
+        #line 5152 "SchemaEntity202012.tt"
 
         if (IsJsonBase64Content)
         {
@@ -14871,7 +14831,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5165 "SchemaEntity202012.tt"
+        #line 5156 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return this.As<JsonBase64Content>().Validate(result, level);\r\n      " +
                 "      }\r\n        ");
@@ -14879,7 +14839,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5170 "SchemaEntity202012.tt"
+        #line 5161 "SchemaEntity202012.tt"
 
         }
         
@@ -14887,13 +14847,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5173 "SchemaEntity202012.tt"
+        #line 5164 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5174 "SchemaEntity202012.tt"
+        #line 5165 "SchemaEntity202012.tt"
 
         if (IsJsonBase64String)
         {
@@ -14902,7 +14862,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5178 "SchemaEntity202012.tt"
+        #line 5169 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return this.As<JsonBase64String>().Validate(result, level);\r\n       " +
                 "     }\r\n\r\n        ");
@@ -14910,7 +14870,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5184 "SchemaEntity202012.tt"
+        #line 5175 "SchemaEntity202012.tt"
 
         }
         
@@ -14918,13 +14878,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5187 "SchemaEntity202012.tt"
+        #line 5178 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5188 "SchemaEntity202012.tt"
+        #line 5179 "SchemaEntity202012.tt"
 
         if (IsJsonContent)
         {
@@ -14933,7 +14893,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5192 "SchemaEntity202012.tt"
+        #line 5183 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return this.As<JsonContent>().Validate(result, level);\r\n            " +
                 "}\r\n        ");
@@ -14941,7 +14901,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5197 "SchemaEntity202012.tt"
+        #line 5188 "SchemaEntity202012.tt"
 
         }
         
@@ -14949,13 +14909,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5200 "SchemaEntity202012.tt"
+        #line 5191 "SchemaEntity202012.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5204 "SchemaEntity202012.tt"
+        #line 5195 "SchemaEntity202012.tt"
 
     }
     
@@ -14963,13 +14923,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5207 "SchemaEntity202012.tt"
+        #line 5198 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5208 "SchemaEntity202012.tt"
+        #line 5199 "SchemaEntity202012.tt"
 
     if (HasFormat)
     {
@@ -14978,14 +14938,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5212 "SchemaEntity202012.tt"
+        #line 5203 "SchemaEntity202012.tt"
         this.Write("        \r\n        private ValidationContext ValidateFormat(JsonValueKind valueKin" +
                 "d, ValidationContext result, ValidationLevel level)\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5215 "SchemaEntity202012.tt"
+        #line 5206 "SchemaEntity202012.tt"
 
         if (IsJsonRelativePointer)
         {
@@ -14994,7 +14954,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5219 "SchemaEntity202012.tt"
+        #line 5210 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
                 "vel);\r\n            }\r\n        ");
@@ -15002,7 +14962,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5224 "SchemaEntity202012.tt"
+        #line 5215 "SchemaEntity202012.tt"
 
         }
         
@@ -15010,13 +14970,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5227 "SchemaEntity202012.tt"
+        #line 5218 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5228 "SchemaEntity202012.tt"
+        #line 5219 "SchemaEntity202012.tt"
 
         if (IsJsonDate)
         {
@@ -15025,7 +14985,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5232 "SchemaEntity202012.tt"
+        #line 5223 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeDate(this, result, level);\r\n        " +
                 "    }\r\n\r\n        ");
@@ -15033,7 +14993,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5238 "SchemaEntity202012.tt"
+        #line 5229 "SchemaEntity202012.tt"
 
         }
         
@@ -15041,13 +15001,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5241 "SchemaEntity202012.tt"
+        #line 5232 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5242 "SchemaEntity202012.tt"
+        #line 5233 "SchemaEntity202012.tt"
 
         if (IsJsonDateTime)
         {
@@ -15056,7 +15016,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5246 "SchemaEntity202012.tt"
+        #line 5237 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeDateTime(this, result, level);\r\n    " +
                 "        }\r\n        ");
@@ -15064,7 +15024,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5251 "SchemaEntity202012.tt"
+        #line 5242 "SchemaEntity202012.tt"
 
         }
         
@@ -15072,13 +15032,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5254 "SchemaEntity202012.tt"
+        #line 5245 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5255 "SchemaEntity202012.tt"
+        #line 5246 "SchemaEntity202012.tt"
 
         if (IsJsonDuration)
         {
@@ -15087,7 +15047,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5259 "SchemaEntity202012.tt"
+        #line 5250 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeDuration(this, result, level);\r\n    " +
                 "        }\r\n        ");
@@ -15095,7 +15055,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5264 "SchemaEntity202012.tt"
+        #line 5255 "SchemaEntity202012.tt"
 
         }
         
@@ -15103,13 +15063,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5267 "SchemaEntity202012.tt"
+        #line 5258 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5268 "SchemaEntity202012.tt"
+        #line 5259 "SchemaEntity202012.tt"
 
         if (IsJsonTime)
         {
@@ -15118,7 +15078,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5272 "SchemaEntity202012.tt"
+        #line 5263 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeTime(this, result, level);\r\n        " +
                 "    }\r\n        ");
@@ -15126,7 +15086,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5277 "SchemaEntity202012.tt"
+        #line 5268 "SchemaEntity202012.tt"
 
         }
         
@@ -15134,13 +15094,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5280 "SchemaEntity202012.tt"
+        #line 5271 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5281 "SchemaEntity202012.tt"
+        #line 5272 "SchemaEntity202012.tt"
 
         if (IsJsonEmail)
         {
@@ -15149,7 +15109,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5285 "SchemaEntity202012.tt"
+        #line 5276 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeEmail(this, result, level);\r\n       " +
                 "     }\r\n        ");
@@ -15157,7 +15117,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5290 "SchemaEntity202012.tt"
+        #line 5281 "SchemaEntity202012.tt"
 
         }
         
@@ -15165,13 +15125,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5293 "SchemaEntity202012.tt"
+        #line 5284 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5294 "SchemaEntity202012.tt"
+        #line 5285 "SchemaEntity202012.tt"
 
         if (IsJsonHostname)
         {
@@ -15180,7 +15140,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5298 "SchemaEntity202012.tt"
+        #line 5289 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeHostname(this, result, level);\r\n    " +
                 "        }\r\n        ");
@@ -15188,7 +15148,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5303 "SchemaEntity202012.tt"
+        #line 5294 "SchemaEntity202012.tt"
 
         }
         
@@ -15196,13 +15156,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5306 "SchemaEntity202012.tt"
+        #line 5297 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5307 "SchemaEntity202012.tt"
+        #line 5298 "SchemaEntity202012.tt"
 
         if (IsJsonIdnEmail)
         {
@@ -15211,7 +15171,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5311 "SchemaEntity202012.tt"
+        #line 5302 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIdnEmail(this, result, level);\r\n    " +
                 "        }\r\n\r\n        ");
@@ -15219,7 +15179,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5317 "SchemaEntity202012.tt"
+        #line 5308 "SchemaEntity202012.tt"
 
         }
         
@@ -15227,13 +15187,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5320 "SchemaEntity202012.tt"
+        #line 5311 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5321 "SchemaEntity202012.tt"
+        #line 5312 "SchemaEntity202012.tt"
 
         if (IsJsonIdnHostname)
         {
@@ -15242,7 +15202,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5325 "SchemaEntity202012.tt"
+        #line 5316 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIdnHostname(this, result, level);\r\n " +
                 "           }\r\n        ");
@@ -15250,7 +15210,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5330 "SchemaEntity202012.tt"
+        #line 5321 "SchemaEntity202012.tt"
 
         }
         
@@ -15258,13 +15218,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5333 "SchemaEntity202012.tt"
+        #line 5324 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5334 "SchemaEntity202012.tt"
+        #line 5325 "SchemaEntity202012.tt"
 
         if (IsJsonInteger)
         {
@@ -15273,7 +15233,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5338 "SchemaEntity202012.tt"
+        #line 5329 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.Number)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeInteger(this, result, level);\r\n     " +
                 "       }\r\n        ");
@@ -15281,7 +15241,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5343 "SchemaEntity202012.tt"
+        #line 5334 "SchemaEntity202012.tt"
 
         }
         
@@ -15289,13 +15249,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5346 "SchemaEntity202012.tt"
+        #line 5337 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5347 "SchemaEntity202012.tt"
+        #line 5338 "SchemaEntity202012.tt"
 
         if (IsJsonIpV4)
         {
@@ -15304,7 +15264,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5351 "SchemaEntity202012.tt"
+        #line 5342 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIpV4(this, result, level);\r\n        " +
                 "    }\r\n\r\n        ");
@@ -15312,7 +15272,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5357 "SchemaEntity202012.tt"
+        #line 5348 "SchemaEntity202012.tt"
 
         }
         
@@ -15320,13 +15280,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5360 "SchemaEntity202012.tt"
+        #line 5351 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5361 "SchemaEntity202012.tt"
+        #line 5352 "SchemaEntity202012.tt"
 
         if (IsJsonIpV6)
         {
@@ -15335,7 +15295,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5365 "SchemaEntity202012.tt"
+        #line 5356 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIpV6(this, result, level);\r\n        " +
                 "    }\r\n\r\n        ");
@@ -15343,7 +15303,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5371 "SchemaEntity202012.tt"
+        #line 5362 "SchemaEntity202012.tt"
 
         }
         
@@ -15351,13 +15311,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5374 "SchemaEntity202012.tt"
+        #line 5365 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5375 "SchemaEntity202012.tt"
+        #line 5366 "SchemaEntity202012.tt"
 
         if (IsJsonIri)
         {
@@ -15366,7 +15326,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5379 "SchemaEntity202012.tt"
+        #line 5370 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIri(this, result, level);\r\n         " +
                 "   }\r\n        ");
@@ -15374,7 +15334,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5384 "SchemaEntity202012.tt"
+        #line 5375 "SchemaEntity202012.tt"
 
         }
         
@@ -15382,13 +15342,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5387 "SchemaEntity202012.tt"
+        #line 5378 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5388 "SchemaEntity202012.tt"
+        #line 5379 "SchemaEntity202012.tt"
 
         if (IsJsonIriReference)
         {
@@ -15397,7 +15357,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5392 "SchemaEntity202012.tt"
+        #line 5383 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeIriReference(this, result, level);\r\n" +
                 "            }\r\n        ");
@@ -15405,7 +15365,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5397 "SchemaEntity202012.tt"
+        #line 5388 "SchemaEntity202012.tt"
 
         }
         
@@ -15413,13 +15373,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5400 "SchemaEntity202012.tt"
+        #line 5391 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5401 "SchemaEntity202012.tt"
+        #line 5392 "SchemaEntity202012.tt"
 
         if (IsJsonPointer)
         {
@@ -15428,7 +15388,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5405 "SchemaEntity202012.tt"
+        #line 5396 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeJsonPointer(this, result, level);\r\n " +
                 "           }\r\n        ");
@@ -15436,7 +15396,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5410 "SchemaEntity202012.tt"
+        #line 5401 "SchemaEntity202012.tt"
 
         }
         
@@ -15444,13 +15404,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5413 "SchemaEntity202012.tt"
+        #line 5404 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5414 "SchemaEntity202012.tt"
+        #line 5405 "SchemaEntity202012.tt"
 
         if (IsJsonRegex)
         {
@@ -15459,7 +15419,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5418 "SchemaEntity202012.tt"
+        #line 5409 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeRegex(this, result, level);\r\n       " +
                 "     }\r\n        ");
@@ -15467,7 +15427,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5423 "SchemaEntity202012.tt"
+        #line 5414 "SchemaEntity202012.tt"
 
         }
         
@@ -15475,13 +15435,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5426 "SchemaEntity202012.tt"
+        #line 5417 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5427 "SchemaEntity202012.tt"
+        #line 5418 "SchemaEntity202012.tt"
 
         if (IsJsonRelativePointer)
         {
@@ -15490,7 +15450,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5431 "SchemaEntity202012.tt"
+        #line 5422 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
                 "vel);\r\n            }\r\n        ");
@@ -15498,7 +15458,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5436 "SchemaEntity202012.tt"
+        #line 5427 "SchemaEntity202012.tt"
 
         }
         
@@ -15506,13 +15466,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5439 "SchemaEntity202012.tt"
+        #line 5430 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5440 "SchemaEntity202012.tt"
+        #line 5431 "SchemaEntity202012.tt"
 
         if (IsJsonTime)
         {
@@ -15521,7 +15481,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5444 "SchemaEntity202012.tt"
+        #line 5435 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeTime(this, result, level);\r\n        " +
                 "    }\r\n\r\n        ");
@@ -15529,7 +15489,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5450 "SchemaEntity202012.tt"
+        #line 5441 "SchemaEntity202012.tt"
 
         }
         
@@ -15537,13 +15497,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5453 "SchemaEntity202012.tt"
+        #line 5444 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5454 "SchemaEntity202012.tt"
+        #line 5445 "SchemaEntity202012.tt"
 
         if (IsJsonUri)
         {
@@ -15552,7 +15512,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5458 "SchemaEntity202012.tt"
+        #line 5449 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeUri(this, result, level);\r\n         " +
                 "   }\r\n\r\n        ");
@@ -15560,7 +15520,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5464 "SchemaEntity202012.tt"
+        #line 5455 "SchemaEntity202012.tt"
 
         }
         
@@ -15568,13 +15528,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5467 "SchemaEntity202012.tt"
+        #line 5458 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5468 "SchemaEntity202012.tt"
+        #line 5459 "SchemaEntity202012.tt"
 
         if (IsJsonUriReference)
         {
@@ -15583,7 +15543,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5472 "SchemaEntity202012.tt"
+        #line 5463 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeUriReference(this, result, level);\r\n" +
                 "            }\r\n        ");
@@ -15591,7 +15551,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5477 "SchemaEntity202012.tt"
+        #line 5468 "SchemaEntity202012.tt"
 
         }
         
@@ -15599,13 +15559,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5480 "SchemaEntity202012.tt"
+        #line 5471 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5481 "SchemaEntity202012.tt"
+        #line 5472 "SchemaEntity202012.tt"
 
         if (IsJsonUriTemplate)
         {
@@ -15614,7 +15574,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5485 "SchemaEntity202012.tt"
+        #line 5476 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeUriTemplate(this, result, level);\r\n " +
                 "           }\r\n\r\n        ");
@@ -15622,7 +15582,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5491 "SchemaEntity202012.tt"
+        #line 5482 "SchemaEntity202012.tt"
 
         }
         
@@ -15630,13 +15590,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5494 "SchemaEntity202012.tt"
+        #line 5485 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5495 "SchemaEntity202012.tt"
+        #line 5486 "SchemaEntity202012.tt"
 
         if (IsJsonUuid)
         {
@@ -15645,7 +15605,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5499 "SchemaEntity202012.tt"
+        #line 5490 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeUuid(this, result, level);\r\n        " +
                 "    }\r\n\r\n        ");
@@ -15653,7 +15613,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5505 "SchemaEntity202012.tt"
+        #line 5496 "SchemaEntity202012.tt"
 
         }
         
@@ -15661,13 +15621,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5508 "SchemaEntity202012.tt"
+        #line 5499 "SchemaEntity202012.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5512 "SchemaEntity202012.tt"
+        #line 5503 "SchemaEntity202012.tt"
 
     }
     
@@ -15675,13 +15635,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5515 "SchemaEntity202012.tt"
+        #line 5506 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5516 "SchemaEntity202012.tt"
+        #line 5507 "SchemaEntity202012.tt"
 
     if (HasType)
     {
@@ -15690,7 +15650,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5520 "SchemaEntity202012.tt"
+        #line 5511 "SchemaEntity202012.tt"
         this.Write(@"        
         private ValidationContext ValidateType(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
@@ -15702,7 +15662,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5526 "SchemaEntity202012.tt"
+        #line 5517 "SchemaEntity202012.tt"
 
         if (HasStringType)
         {
@@ -15711,7 +15671,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5530 "SchemaEntity202012.tt"
+        #line 5521 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultString = Corvus.Json.Validate.TypeString(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultString.IsValid)
@@ -15729,7 +15689,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5542 "SchemaEntity202012.tt"
+        #line 5533 "SchemaEntity202012.tt"
 
         }
         
@@ -15737,13 +15697,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5545 "SchemaEntity202012.tt"
+        #line 5536 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5546 "SchemaEntity202012.tt"
+        #line 5537 "SchemaEntity202012.tt"
 
         if (HasObjectType)
         {
@@ -15752,7 +15712,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5550 "SchemaEntity202012.tt"
+        #line 5541 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultObject = Corvus.Json.Validate.TypeObject(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultObject.IsValid)
@@ -15770,7 +15730,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5562 "SchemaEntity202012.tt"
+        #line 5553 "SchemaEntity202012.tt"
 
         }
         
@@ -15778,13 +15738,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5565 "SchemaEntity202012.tt"
+        #line 5556 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5566 "SchemaEntity202012.tt"
+        #line 5557 "SchemaEntity202012.tt"
 
         if (HasArrayType)
         {
@@ -15793,7 +15753,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5570 "SchemaEntity202012.tt"
+        #line 5561 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultArray = Corvus.Json.Validate.TypeArray(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultArray.IsValid)
@@ -15811,7 +15771,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5582 "SchemaEntity202012.tt"
+        #line 5573 "SchemaEntity202012.tt"
 
         }
         
@@ -15819,13 +15779,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5585 "SchemaEntity202012.tt"
+        #line 5576 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5586 "SchemaEntity202012.tt"
+        #line 5577 "SchemaEntity202012.tt"
 
         if (HasNumberType)
         {
@@ -15834,7 +15794,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5590 "SchemaEntity202012.tt"
+        #line 5581 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultNumber = Corvus.Json.Validate.TypeNumber(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultNumber.IsValid)
@@ -15852,7 +15812,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5602 "SchemaEntity202012.tt"
+        #line 5593 "SchemaEntity202012.tt"
 
         }
         
@@ -15860,13 +15820,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5605 "SchemaEntity202012.tt"
+        #line 5596 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5606 "SchemaEntity202012.tt"
+        #line 5597 "SchemaEntity202012.tt"
 
         if (HasIntegerType)
         {
@@ -15875,7 +15835,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5610 "SchemaEntity202012.tt"
+        #line 5601 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultInteger = Corvus.Json.Validate.TypeInteger(this, result, level);
             if (level == ValidationLevel.Flag && localResultInteger.IsValid)
@@ -15893,7 +15853,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5622 "SchemaEntity202012.tt"
+        #line 5613 "SchemaEntity202012.tt"
 
         }
         
@@ -15901,13 +15861,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5625 "SchemaEntity202012.tt"
+        #line 5616 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5626 "SchemaEntity202012.tt"
+        #line 5617 "SchemaEntity202012.tt"
 
         if (HasBooleanType)
         {
@@ -15916,7 +15876,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5630 "SchemaEntity202012.tt"
+        #line 5621 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultBoolean = Corvus.Json.Validate.TypeBoolean(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultBoolean.IsValid)
@@ -15934,7 +15894,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5642 "SchemaEntity202012.tt"
+        #line 5633 "SchemaEntity202012.tt"
 
         }
         
@@ -15942,13 +15902,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5645 "SchemaEntity202012.tt"
+        #line 5636 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5646 "SchemaEntity202012.tt"
+        #line 5637 "SchemaEntity202012.tt"
 
         if (HasNullType)
         {
@@ -15957,7 +15917,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5650 "SchemaEntity202012.tt"
+        #line 5641 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultNull = Corvus.Json.Validate.TypeNull(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultNull.IsValid)
@@ -15975,7 +15935,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5662 "SchemaEntity202012.tt"
+        #line 5653 "SchemaEntity202012.tt"
 
         }
         
@@ -15983,14 +15943,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5665 "SchemaEntity202012.tt"
+        #line 5656 "SchemaEntity202012.tt"
         this.Write("\r\n            result = result.MergeResults(\r\n                isValid,\r\n          " +
                 "      level\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5669 "SchemaEntity202012.tt"
+        #line 5660 "SchemaEntity202012.tt"
 
         if (HasStringType)
         {
@@ -15999,13 +15959,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5673 "SchemaEntity202012.tt"
+        #line 5664 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultString\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5675 "SchemaEntity202012.tt"
+        #line 5666 "SchemaEntity202012.tt"
 
         }
         
@@ -16013,13 +15973,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5678 "SchemaEntity202012.tt"
+        #line 5669 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5679 "SchemaEntity202012.tt"
+        #line 5670 "SchemaEntity202012.tt"
 
         if (HasObjectType)
         {
@@ -16028,13 +15988,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5683 "SchemaEntity202012.tt"
+        #line 5674 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultObject\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5685 "SchemaEntity202012.tt"
+        #line 5676 "SchemaEntity202012.tt"
 
         }
         
@@ -16042,13 +16002,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5688 "SchemaEntity202012.tt"
+        #line 5679 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5689 "SchemaEntity202012.tt"
+        #line 5680 "SchemaEntity202012.tt"
 
         if (HasArrayType)
         {
@@ -16057,13 +16017,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5693 "SchemaEntity202012.tt"
+        #line 5684 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultArray\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5695 "SchemaEntity202012.tt"
+        #line 5686 "SchemaEntity202012.tt"
 
         }
         
@@ -16071,13 +16031,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5698 "SchemaEntity202012.tt"
+        #line 5689 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5699 "SchemaEntity202012.tt"
+        #line 5690 "SchemaEntity202012.tt"
 
         if (HasNumberType)
         {
@@ -16086,13 +16046,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5703 "SchemaEntity202012.tt"
+        #line 5694 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultNumber\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5705 "SchemaEntity202012.tt"
+        #line 5696 "SchemaEntity202012.tt"
 
         }
         
@@ -16100,13 +16060,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5708 "SchemaEntity202012.tt"
+        #line 5699 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5709 "SchemaEntity202012.tt"
+        #line 5700 "SchemaEntity202012.tt"
 
         if (HasIntegerType)
         {
@@ -16115,13 +16075,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5713 "SchemaEntity202012.tt"
+        #line 5704 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultInteger\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5715 "SchemaEntity202012.tt"
+        #line 5706 "SchemaEntity202012.tt"
 
         }
         
@@ -16129,13 +16089,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5718 "SchemaEntity202012.tt"
+        #line 5709 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5719 "SchemaEntity202012.tt"
+        #line 5710 "SchemaEntity202012.tt"
 
         if (HasBooleanType)
         {
@@ -16144,13 +16104,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5723 "SchemaEntity202012.tt"
+        #line 5714 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultBoolean\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5725 "SchemaEntity202012.tt"
+        #line 5716 "SchemaEntity202012.tt"
 
         }
         
@@ -16158,13 +16118,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5728 "SchemaEntity202012.tt"
+        #line 5719 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5729 "SchemaEntity202012.tt"
+        #line 5720 "SchemaEntity202012.tt"
 
         if (HasNullType)
         {
@@ -16173,13 +16133,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5733 "SchemaEntity202012.tt"
+        #line 5724 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultNull\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5735 "SchemaEntity202012.tt"
+        #line 5726 "SchemaEntity202012.tt"
 
         }
         
@@ -16187,13 +16147,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5738 "SchemaEntity202012.tt"
+        #line 5729 "SchemaEntity202012.tt"
         this.Write("                );\r\n\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5743 "SchemaEntity202012.tt"
+        #line 5734 "SchemaEntity202012.tt"
 
     }
     
@@ -16201,13 +16161,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5746 "SchemaEntity202012.tt"
+        #line 5737 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5747 "SchemaEntity202012.tt"
+        #line 5738 "SchemaEntity202012.tt"
 
     if (HasEnum)
     {
@@ -16216,14 +16176,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5751 "SchemaEntity202012.tt"
+        #line 5742 "SchemaEntity202012.tt"
         this.Write("        \r\n        /// <summary>\r\n        /// Permitted values.\r\n        /// </sum" +
                 "mary>\r\n        public static class EnumValues\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5757 "SchemaEntity202012.tt"
+        #line 5748 "SchemaEntity202012.tt"
 
         int enumItemIndex = 0;
         foreach (var enumValue in EnumValues)
@@ -16233,13 +16193,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5762 "SchemaEntity202012.tt"
+        #line 5753 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 5762 "SchemaEntity202012.tt"
+        #line 5753 "SchemaEntity202012.tt"
 
             if (enumValue.IsString)
             {
@@ -16248,7 +16208,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5766 "SchemaEntity202012.tt"
+        #line 5757 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// enumValue.AsPropertyName.\r\n           " +
                 " /// </summary>\r\n            /// <remarks>\r\n            /// {Description}.\r\n    " +
                 "        /// </remarks>\r\n            public static readonly ");
@@ -16256,43 +16216,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5772 "SchemaEntity202012.tt"
+        #line 5763 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5772 "SchemaEntity202012.tt"
+        #line 5763 "SchemaEntity202012.tt"
         this.Write(" ");
         
         #line default
         #line hidden
         
-        #line 5772 "SchemaEntity202012.tt"
+        #line 5763 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    enumValue.AsPropertyName));
         
         #line default
         #line hidden
         
-        #line 5772 "SchemaEntity202012.tt"
+        #line 5763 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5772 "SchemaEntity202012.tt"
+        #line 5763 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5772 "SchemaEntity202012.tt"
+        #line 5763 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5773 "SchemaEntity202012.tt"
+        #line 5764 "SchemaEntity202012.tt"
 
             }
             else if (enumValue.IsBoolean)
@@ -16302,19 +16262,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5778 "SchemaEntity202012.tt"
+        #line 5769 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5779 "SchemaEntity202012.tt"
+        #line 5770 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5779 "SchemaEntity202012.tt"
+        #line 5770 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16322,43 +16282,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5784 "SchemaEntity202012.tt"
+        #line 5775 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5784 "SchemaEntity202012.tt"
+        #line 5775 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5784 "SchemaEntity202012.tt"
+        #line 5775 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5784 "SchemaEntity202012.tt"
+        #line 5775 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5784 "SchemaEntity202012.tt"
+        #line 5775 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5784 "SchemaEntity202012.tt"
+        #line 5775 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5785 "SchemaEntity202012.tt"
+        #line 5776 "SchemaEntity202012.tt"
 
             }
             else if (enumValue.IsNumber)
@@ -16368,19 +16328,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5790 "SchemaEntity202012.tt"
+        #line 5781 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5791 "SchemaEntity202012.tt"
+        #line 5782 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5791 "SchemaEntity202012.tt"
+        #line 5782 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16388,43 +16348,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5796 "SchemaEntity202012.tt"
+        #line 5787 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5796 "SchemaEntity202012.tt"
+        #line 5787 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5796 "SchemaEntity202012.tt"
+        #line 5787 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5796 "SchemaEntity202012.tt"
+        #line 5787 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5796 "SchemaEntity202012.tt"
+        #line 5787 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5796 "SchemaEntity202012.tt"
+        #line 5787 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5797 "SchemaEntity202012.tt"
+        #line 5788 "SchemaEntity202012.tt"
 
             }
             else if (enumValue.IsObject)
@@ -16434,19 +16394,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5802 "SchemaEntity202012.tt"
+        #line 5793 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5803 "SchemaEntity202012.tt"
+        #line 5794 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5803 "SchemaEntity202012.tt"
+        #line 5794 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16454,43 +16414,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5808 "SchemaEntity202012.tt"
+        #line 5799 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5808 "SchemaEntity202012.tt"
+        #line 5799 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5808 "SchemaEntity202012.tt"
+        #line 5799 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5808 "SchemaEntity202012.tt"
+        #line 5799 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5808 "SchemaEntity202012.tt"
+        #line 5799 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5808 "SchemaEntity202012.tt"
+        #line 5799 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5809 "SchemaEntity202012.tt"
+        #line 5800 "SchemaEntity202012.tt"
 
             }
             else if (enumValue.IsArray)
@@ -16500,19 +16460,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5814 "SchemaEntity202012.tt"
+        #line 5805 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5815 "SchemaEntity202012.tt"
+        #line 5806 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5815 "SchemaEntity202012.tt"
+        #line 5806 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16520,43 +16480,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5820 "SchemaEntity202012.tt"
+        #line 5811 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5820 "SchemaEntity202012.tt"
+        #line 5811 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5820 "SchemaEntity202012.tt"
+        #line 5811 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5820 "SchemaEntity202012.tt"
+        #line 5811 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5820 "SchemaEntity202012.tt"
+        #line 5811 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5820 "SchemaEntity202012.tt"
+        #line 5811 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5821 "SchemaEntity202012.tt"
+        #line 5812 "SchemaEntity202012.tt"
 
             }
             else if (enumValue.IsNull)
@@ -16566,19 +16526,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5826 "SchemaEntity202012.tt"
+        #line 5817 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5827 "SchemaEntity202012.tt"
+        #line 5818 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5827 "SchemaEntity202012.tt"
+        #line 5818 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16586,31 +16546,31 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5832 "SchemaEntity202012.tt"
+        #line 5823 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5832 "SchemaEntity202012.tt"
+        #line 5823 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5832 "SchemaEntity202012.tt"
+        #line 5823 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5832 "SchemaEntity202012.tt"
+        #line 5823 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(\"null\");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5833 "SchemaEntity202012.tt"
+        #line 5824 "SchemaEntity202012.tt"
 
             }
             
@@ -16618,13 +16578,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5836 "SchemaEntity202012.tt"
+        #line 5827 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5837 "SchemaEntity202012.tt"
+        #line 5828 "SchemaEntity202012.tt"
 
             ++enumItemIndex;
         }
@@ -16633,13 +16593,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5841 "SchemaEntity202012.tt"
+        #line 5832 "SchemaEntity202012.tt"
         this.Write("\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5843 "SchemaEntity202012.tt"
+        #line 5834 "SchemaEntity202012.tt"
 
         enumItemIndex = 0;
         foreach (var enumValue in EnumValues)
@@ -16649,13 +16609,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5848 "SchemaEntity202012.tt"
+        #line 5839 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 5848 "SchemaEntity202012.tt"
+        #line 5839 "SchemaEntity202012.tt"
 
             if (enumValue.IsString)
             {
@@ -16664,19 +16624,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5852 "SchemaEntity202012.tt"
+        #line 5843 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5853 "SchemaEntity202012.tt"
+        #line 5844 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5853 "SchemaEntity202012.tt"
+        #line 5844 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            inte" +
                 "rnal static readonly ");
@@ -16684,43 +16644,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5858 "SchemaEntity202012.tt"
+        #line 5849 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5858 "SchemaEntity202012.tt"
+        #line 5849 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5858 "SchemaEntity202012.tt"
+        #line 5849 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5858 "SchemaEntity202012.tt"
+        #line 5849 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5858 "SchemaEntity202012.tt"
+        #line 5849 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5858 "SchemaEntity202012.tt"
+        #line 5849 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5859 "SchemaEntity202012.tt"
+        #line 5850 "SchemaEntity202012.tt"
 
             }
             enumItemIndex++;
@@ -16730,13 +16690,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5864 "SchemaEntity202012.tt"
+        #line 5855 "SchemaEntity202012.tt"
         this.Write("        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5865 "SchemaEntity202012.tt"
+        #line 5856 "SchemaEntity202012.tt"
 
     }
     
@@ -16744,13 +16704,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5868 "SchemaEntity202012.tt"
+        #line 5859 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5869 "SchemaEntity202012.tt"
+        #line 5860 "SchemaEntity202012.tt"
 
     foreach(var nestedType in NestedTypes)
     {
@@ -16759,25 +16719,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5873 "SchemaEntity202012.tt"
+        #line 5864 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5874 "SchemaEntity202012.tt"
+        #line 5865 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( WriteNestedType(nestedType) ));
         
         #line default
         #line hidden
         
-        #line 5874 "SchemaEntity202012.tt"
+        #line 5865 "SchemaEntity202012.tt"
         this.Write("\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5876 "SchemaEntity202012.tt"
+        #line 5867 "SchemaEntity202012.tt"
 
     }
     
@@ -16785,13 +16745,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5879 "SchemaEntity202012.tt"
+        #line 5870 "SchemaEntity202012.tt"
         this.Write("\r\n    }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5881 "SchemaEntity202012.tt"
+        #line 5872 "SchemaEntity202012.tt"
 
     if (!IsNested)
     {
@@ -16800,13 +16760,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5885 "SchemaEntity202012.tt"
+        #line 5876 "SchemaEntity202012.tt"
         this.Write("}\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5886 "SchemaEntity202012.tt"
+        #line 5877 "SchemaEntity202012.tt"
 
     }
     

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntity202012.cs
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntity202012.cs
@@ -12,7 +12,6 @@ using Corvus.Json;
 using System;
 using System.Collections.Generic;
 
-
 #pragma warning disable
 
 public partial class SchemaEntity202012 : SchemaEntity202012Base {
@@ -1049,39 +1048,52 @@ namespace ");
         #line hidden
         
         #line 254 "SchemaEntity202012.tt"
-        this.Write("\r\n        /// <summary>\r\n        /// Initializes a new instance of the <see cref=" +
-                "\"");
+        this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 256 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 256 "SchemaEntity202012.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">The backing " +
-                "<see cref=\"JsonElement\"/>.</param>\r\n        public ");
+        #line 255 "SchemaEntity202012.tt"
+
+    if (HasConst)
+    {
+    
         
         #line default
         #line hidden
         
         #line 259 "SchemaEntity202012.tt"
+        this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 260 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 259 "SchemaEntity202012.tt"
-        this.Write("(JsonElement value)\r\n        {\r\n            this.jsonElementBacking = value;\r\n   " +
-                " ");
+        #line 260 "SchemaEntity202012.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        public ");
         
         #line default
         #line hidden
         
         #line 262 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 262 "SchemaEntity202012.tt"
+        this.Write("()\r\n        {\r\n            this.jsonElementBacking = __CorvusConstValue.jsonEleme" +
+                "ntBacking;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 265 "SchemaEntity202012.tt"
 
     if(IsImplicitObject)
     {
@@ -1090,13 +1102,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 266 "SchemaEntity202012.tt"
-        this.Write("            this.objectBacking = default;\r\n    ");
+        #line 269 "SchemaEntity202012.tt"
+        this.Write("            this.objectBacking = __CorvusConstValue.objectBacking;\r\n    ");
         
         #line default
         #line hidden
         
-        #line 267 "SchemaEntity202012.tt"
+        #line 270 "SchemaEntity202012.tt"
 
     }
     
@@ -1104,13 +1116,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 270 "SchemaEntity202012.tt"
+        #line 273 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 270 "SchemaEntity202012.tt"
+        #line 273 "SchemaEntity202012.tt"
 
     if(IsImplicitArray)
     {
@@ -1119,13 +1131,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 274 "SchemaEntity202012.tt"
-        this.Write("            this.arrayBacking = default;\r\n    ");
+        #line 277 "SchemaEntity202012.tt"
+        this.Write("            this.arrayBacking = __CorvusConstValue.arrayBacking;\r\n    ");
         
         #line default
         #line hidden
         
-        #line 275 "SchemaEntity202012.tt"
+        #line 278 "SchemaEntity202012.tt"
 
     }
     
@@ -1133,13 +1145,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 278 "SchemaEntity202012.tt"
+        #line 281 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 278 "SchemaEntity202012.tt"
+        #line 281 "SchemaEntity202012.tt"
 
     if(IsImplicitNumber)
     {
@@ -1148,13 +1160,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 282 "SchemaEntity202012.tt"
-        this.Write("            this.numberBacking = default;\r\n    ");
+        #line 285 "SchemaEntity202012.tt"
+        this.Write("            this.numberBacking = __CorvusConstValue.numberBacking;\r\n    ");
         
         #line default
         #line hidden
         
-        #line 283 "SchemaEntity202012.tt"
+        #line 286 "SchemaEntity202012.tt"
 
     }
     
@@ -1162,13 +1174,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 286 "SchemaEntity202012.tt"
+        #line 289 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 286 "SchemaEntity202012.tt"
+        #line 289 "SchemaEntity202012.tt"
 
     if(IsImplicitString)
     {
@@ -1177,13 +1189,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 290 "SchemaEntity202012.tt"
-        this.Write("            this.stringBacking = default;\r\n    ");
+        #line 293 "SchemaEntity202012.tt"
+        this.Write("            this.stringBacking = __CorvusConstValue.stringBacking;\r\n    ");
         
         #line default
         #line hidden
         
-        #line 291 "SchemaEntity202012.tt"
+        #line 294 "SchemaEntity202012.tt"
 
     }
     
@@ -1191,13 +1203,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 294 "SchemaEntity202012.tt"
+        #line 297 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 294 "SchemaEntity202012.tt"
+        #line 297 "SchemaEntity202012.tt"
 
     if(IsImplicitBoolean)
     {
@@ -1206,13 +1218,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 298 "SchemaEntity202012.tt"
-        this.Write("            this.booleanBacking = default;\r\n    ");
+        #line 301 "SchemaEntity202012.tt"
+        this.Write("            this.booleanBacking = __CorvusConstValue.booleanBacking;\r\n    ");
         
         #line default
         #line hidden
         
-        #line 299 "SchemaEntity202012.tt"
+        #line 302 "SchemaEntity202012.tt"
 
     }
     
@@ -1220,13 +1232,54 @@ namespace ");
         #line default
         #line hidden
         
-        #line 302 "SchemaEntity202012.tt"
+        #line 305 "SchemaEntity202012.tt"
         this.Write("        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 304 "SchemaEntity202012.tt"
+        #line 307 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 310 "SchemaEntity202012.tt"
+        this.Write("\r\n        /// <summary>\r\n        /// Initializes a new instance of the <see cref=" +
+                "\"");
+        
+        #line default
+        #line hidden
+        
+        #line 312 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 312 "SchemaEntity202012.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">The backing " +
+                "<see cref=\"JsonElement\"/>.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 315 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 315 "SchemaEntity202012.tt"
+        this.Write("(JsonElement value)\r\n        {\r\n            this.jsonElementBacking = value;\r\n   " +
+                " ");
+        
+        #line default
+        #line hidden
+        
+        #line 318 "SchemaEntity202012.tt"
 
     if(IsImplicitObject)
     {
@@ -1235,39 +1288,184 @@ namespace ");
         #line default
         #line hidden
         
-        #line 308 "SchemaEntity202012.tt"
+        #line 322 "SchemaEntity202012.tt"
+        this.Write("            this.objectBacking = default;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 323 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 326 "SchemaEntity202012.tt"
+        this.Write("    ");
+        
+        #line default
+        #line hidden
+        
+        #line 326 "SchemaEntity202012.tt"
+
+    if(IsImplicitArray)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 330 "SchemaEntity202012.tt"
+        this.Write("            this.arrayBacking = default;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 331 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 334 "SchemaEntity202012.tt"
+        this.Write("    ");
+        
+        #line default
+        #line hidden
+        
+        #line 334 "SchemaEntity202012.tt"
+
+    if(IsImplicitNumber)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 338 "SchemaEntity202012.tt"
+        this.Write("            this.numberBacking = default;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 339 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 342 "SchemaEntity202012.tt"
+        this.Write("    ");
+        
+        #line default
+        #line hidden
+        
+        #line 342 "SchemaEntity202012.tt"
+
+    if(IsImplicitString)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 346 "SchemaEntity202012.tt"
+        this.Write("            this.stringBacking = default;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 347 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 350 "SchemaEntity202012.tt"
+        this.Write("    ");
+        
+        #line default
+        #line hidden
+        
+        #line 350 "SchemaEntity202012.tt"
+
+    if(IsImplicitBoolean)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 354 "SchemaEntity202012.tt"
+        this.Write("            this.booleanBacking = default;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 355 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 358 "SchemaEntity202012.tt"
+        this.Write("        }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 360 "SchemaEntity202012.tt"
+
+    if(IsImplicitObject)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 364 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 309 "SchemaEntity202012.tt"
+        #line 365 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 309 "SchemaEntity202012.tt"
+        #line 365 "SchemaEntity202012.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A property d" +
                 "ictionary.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 312 "SchemaEntity202012.tt"
+        #line 368 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 312 "SchemaEntity202012.tt"
+        #line 368 "SchemaEntity202012.tt"
         this.Write("(ImmutableDictionary<string, JsonAny> value)\r\n        {\r\n            this.jsonEle" +
                 "mentBacking = default;\r\n            this.objectBacking = value;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 316 "SchemaEntity202012.tt"
+        #line 372 "SchemaEntity202012.tt"
 
         if(IsImplicitArray)
         {
@@ -1276,13 +1474,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 320 "SchemaEntity202012.tt"
+        #line 376 "SchemaEntity202012.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 321 "SchemaEntity202012.tt"
+        #line 377 "SchemaEntity202012.tt"
 
         }
         
@@ -1290,13 +1488,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 324 "SchemaEntity202012.tt"
+        #line 380 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 324 "SchemaEntity202012.tt"
+        #line 380 "SchemaEntity202012.tt"
 
         if(IsImplicitNumber)
         {
@@ -1305,13 +1503,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 328 "SchemaEntity202012.tt"
+        #line 384 "SchemaEntity202012.tt"
         this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 329 "SchemaEntity202012.tt"
+        #line 385 "SchemaEntity202012.tt"
 
         }
         
@@ -1319,13 +1517,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 332 "SchemaEntity202012.tt"
+        #line 388 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 332 "SchemaEntity202012.tt"
+        #line 388 "SchemaEntity202012.tt"
 
         if(IsImplicitString)
         {
@@ -1334,13 +1532,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 336 "SchemaEntity202012.tt"
+        #line 392 "SchemaEntity202012.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 337 "SchemaEntity202012.tt"
+        #line 393 "SchemaEntity202012.tt"
 
         }
         
@@ -1348,13 +1546,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 340 "SchemaEntity202012.tt"
+        #line 396 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 340 "SchemaEntity202012.tt"
+        #line 396 "SchemaEntity202012.tt"
 
         if(IsImplicitBoolean)
         {
@@ -1363,13 +1561,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 344 "SchemaEntity202012.tt"
+        #line 400 "SchemaEntity202012.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 345 "SchemaEntity202012.tt"
+        #line 401 "SchemaEntity202012.tt"
 
         }
         
@@ -1377,20 +1575,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 348 "SchemaEntity202012.tt"
+        #line 404 "SchemaEntity202012.tt"
         this.Write("        }\r\n\r\n        /// <summary>\r\n        /// Initializes a new instance of the" +
                 " <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 351 "SchemaEntity202012.tt"
+        #line 407 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 351 "SchemaEntity202012.tt"
+        #line 407 "SchemaEntity202012.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"jsonObject\">The <se" +
                 "e cref=\"JsonObject\"/> from which to construct the value.</param>\r\n        public" +
                 " ");
@@ -1398,13 +1596,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 354 "SchemaEntity202012.tt"
+        #line 410 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 354 "SchemaEntity202012.tt"
+        #line 410 "SchemaEntity202012.tt"
         this.Write(@"(JsonObject jsonObject)
         {
             if (jsonObject.HasJsonElement)
@@ -1423,7 +1621,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 367 "SchemaEntity202012.tt"
+        #line 423 "SchemaEntity202012.tt"
 
         if(IsImplicitArray)
         {
@@ -1432,208 +1630,8 @@ namespace ");
         #line default
         #line hidden
         
-        #line 371 "SchemaEntity202012.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 372 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 375 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 375 "SchemaEntity202012.tt"
-
-        if(IsImplicitNumber)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 379 "SchemaEntity202012.tt"
-        this.Write("            this.numberBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 380 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 383 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 383 "SchemaEntity202012.tt"
-
-        if(IsImplicitString)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 387 "SchemaEntity202012.tt"
-        this.Write("            this.stringBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 388 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 391 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 391 "SchemaEntity202012.tt"
-
-        if(IsImplicitBoolean)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 395 "SchemaEntity202012.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 396 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 399 "SchemaEntity202012.tt"
-        this.Write("        }\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 400 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 403 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 404 "SchemaEntity202012.tt"
-
-    if(IsImplicitArray)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 408 "SchemaEntity202012.tt"
-        this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 409 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 409 "SchemaEntity202012.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">An array lis" +
-                "t.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 412 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 412 "SchemaEntity202012.tt"
-        this.Write("(ImmutableList<JsonAny> value)\r\n        {\r\n            this.jsonElementBacking = " +
-                "default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 415 "SchemaEntity202012.tt"
-
-        if(IsImplicitObject)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 419 "SchemaEntity202012.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 420 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 423 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 423 "SchemaEntity202012.tt"
-
-        if(IsImplicitNumber)
-        {
-        
-        
-        #line default
-        #line hidden
-        
         #line 427 "SchemaEntity202012.tt"
-        this.Write("            this.numberBacking = default;\r\n        ");
+        this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
@@ -1654,7 +1652,7 @@ namespace ");
         
         #line 431 "SchemaEntity202012.tt"
 
-        if(IsImplicitString)
+        if(IsImplicitNumber)
         {
         
         
@@ -1662,7 +1660,7 @@ namespace ");
         #line hidden
         
         #line 435 "SchemaEntity202012.tt"
-        this.Write("            this.stringBacking = default;\r\n        ");
+        this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
@@ -1683,7 +1681,7 @@ namespace ");
         
         #line 439 "SchemaEntity202012.tt"
 
-        if(IsImplicitBoolean)
+        if(IsImplicitString)
         {
         
         
@@ -1691,7 +1689,7 @@ namespace ");
         #line hidden
         
         #line 443 "SchemaEntity202012.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
+        this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
@@ -1705,32 +1703,232 @@ namespace ");
         #line hidden
         
         #line 447 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 447 "SchemaEntity202012.tt"
+
+        if(IsImplicitBoolean)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 451 "SchemaEntity202012.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 452 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 455 "SchemaEntity202012.tt"
+        this.Write("        }\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 456 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 459 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 460 "SchemaEntity202012.tt"
+
+    if(IsImplicitArray)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 464 "SchemaEntity202012.tt"
+        this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 465 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 465 "SchemaEntity202012.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">An array lis" +
+                "t.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 468 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 468 "SchemaEntity202012.tt"
+        this.Write("(ImmutableList<JsonAny> value)\r\n        {\r\n            this.jsonElementBacking = " +
+                "default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 471 "SchemaEntity202012.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 475 "SchemaEntity202012.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 476 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 479 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 479 "SchemaEntity202012.tt"
+
+        if(IsImplicitNumber)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 483 "SchemaEntity202012.tt"
+        this.Write("            this.numberBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 484 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 487 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 487 "SchemaEntity202012.tt"
+
+        if(IsImplicitString)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 491 "SchemaEntity202012.tt"
+        this.Write("            this.stringBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 492 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 495 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 495 "SchemaEntity202012.tt"
+
+        if(IsImplicitBoolean)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 499 "SchemaEntity202012.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 500 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 503 "SchemaEntity202012.tt"
         this.Write("            this.arrayBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n     " +
                 "   /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 451 "SchemaEntity202012.tt"
+        #line 507 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 451 "SchemaEntity202012.tt"
+        #line 507 "SchemaEntity202012.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"jsonArray\">The <see" +
                 " cref=\"JsonArray\"/> from which to construct the value.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 454 "SchemaEntity202012.tt"
+        #line 510 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 454 "SchemaEntity202012.tt"
+        #line 510 "SchemaEntity202012.tt"
         this.Write(@"(JsonArray jsonArray)
         {
             if (jsonArray.HasJsonElement)
@@ -1749,7 +1947,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 467 "SchemaEntity202012.tt"
+        #line 523 "SchemaEntity202012.tt"
 
         if(IsImplicitObject)
         {
@@ -1758,13 +1956,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 471 "SchemaEntity202012.tt"
+        #line 527 "SchemaEntity202012.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 472 "SchemaEntity202012.tt"
+        #line 528 "SchemaEntity202012.tt"
 
         }
         
@@ -1772,13 +1970,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 475 "SchemaEntity202012.tt"
+        #line 531 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 475 "SchemaEntity202012.tt"
+        #line 531 "SchemaEntity202012.tt"
 
         if(IsImplicitNumber)
         {
@@ -1787,13 +1985,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 479 "SchemaEntity202012.tt"
+        #line 535 "SchemaEntity202012.tt"
         this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 480 "SchemaEntity202012.tt"
+        #line 536 "SchemaEntity202012.tt"
 
         }
         
@@ -1801,13 +1999,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 483 "SchemaEntity202012.tt"
+        #line 539 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 483 "SchemaEntity202012.tt"
+        #line 539 "SchemaEntity202012.tt"
 
         if(IsImplicitString)
         {
@@ -1816,13 +2014,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 487 "SchemaEntity202012.tt"
+        #line 543 "SchemaEntity202012.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 488 "SchemaEntity202012.tt"
+        #line 544 "SchemaEntity202012.tt"
 
         }
         
@@ -1830,13 +2028,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 491 "SchemaEntity202012.tt"
+        #line 547 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 491 "SchemaEntity202012.tt"
+        #line 547 "SchemaEntity202012.tt"
 
         if(IsImplicitBoolean)
         {
@@ -1845,13 +2043,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 495 "SchemaEntity202012.tt"
+        #line 551 "SchemaEntity202012.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 496 "SchemaEntity202012.tt"
+        #line 552 "SchemaEntity202012.tt"
 
         }
         
@@ -1859,13 +2057,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 499 "SchemaEntity202012.tt"
+        #line 555 "SchemaEntity202012.tt"
         this.Write("        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 500 "SchemaEntity202012.tt"
+        #line 556 "SchemaEntity202012.tt"
 
     }
     
@@ -1873,13 +2071,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 503 "SchemaEntity202012.tt"
+        #line 559 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 504 "SchemaEntity202012.tt"
+        #line 560 "SchemaEntity202012.tt"
 
     if(IsImplicitNumber)
     {
@@ -1888,19 +2086,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 508 "SchemaEntity202012.tt"
+        #line 564 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 509 "SchemaEntity202012.tt"
+        #line 565 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 509 "SchemaEntity202012.tt"
+        #line 565 "SchemaEntity202012.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"jsonNumber\">The <se" +
                 "e cref=\"JsonNumber\"/> from which to construct the value.</param>\r\n        public" +
                 " ");
@@ -1908,13 +2106,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 512 "SchemaEntity202012.tt"
+        #line 568 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 512 "SchemaEntity202012.tt"
+        #line 568 "SchemaEntity202012.tt"
         this.Write(@"(JsonNumber jsonNumber)
         {
             if (jsonNumber.HasJsonElement)
@@ -1932,7 +2130,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 524 "SchemaEntity202012.tt"
+        #line 580 "SchemaEntity202012.tt"
 
         if(IsImplicitObject)
         {
@@ -1941,13 +2139,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 528 "SchemaEntity202012.tt"
+        #line 584 "SchemaEntity202012.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 529 "SchemaEntity202012.tt"
+        #line 585 "SchemaEntity202012.tt"
 
         }
         
@@ -1955,13 +2153,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 532 "SchemaEntity202012.tt"
+        #line 588 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 532 "SchemaEntity202012.tt"
+        #line 588 "SchemaEntity202012.tt"
 
         if(IsImplicitArray)
         {
@@ -1970,13 +2168,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 536 "SchemaEntity202012.tt"
+        #line 592 "SchemaEntity202012.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 537 "SchemaEntity202012.tt"
+        #line 593 "SchemaEntity202012.tt"
 
         }
         
@@ -1984,13 +2182,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 540 "SchemaEntity202012.tt"
+        #line 596 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 540 "SchemaEntity202012.tt"
+        #line 596 "SchemaEntity202012.tt"
 
         if(IsImplicitString)
         {
@@ -1999,13 +2197,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 544 "SchemaEntity202012.tt"
+        #line 600 "SchemaEntity202012.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 545 "SchemaEntity202012.tt"
+        #line 601 "SchemaEntity202012.tt"
 
         }
         
@@ -2013,13 +2211,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 548 "SchemaEntity202012.tt"
+        #line 604 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 548 "SchemaEntity202012.tt"
+        #line 604 "SchemaEntity202012.tt"
 
         if(IsImplicitBoolean)
         {
@@ -2028,13 +2226,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 552 "SchemaEntity202012.tt"
+        #line 608 "SchemaEntity202012.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 553 "SchemaEntity202012.tt"
+        #line 609 "SchemaEntity202012.tt"
 
         }
         
@@ -2042,40 +2240,40 @@ namespace ");
         #line default
         #line hidden
         
-        #line 556 "SchemaEntity202012.tt"
+        #line 612 "SchemaEntity202012.tt"
         this.Write("        }\r\n\r\n        /// <summary>\r\n        /// Initializes a new instance of the" +
                 " <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 559 "SchemaEntity202012.tt"
+        #line 615 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 559 "SchemaEntity202012.tt"
+        #line 615 "SchemaEntity202012.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
                 "ue.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 562 "SchemaEntity202012.tt"
+        #line 618 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 562 "SchemaEntity202012.tt"
+        #line 618 "SchemaEntity202012.tt"
         this.Write("(double value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n      " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 565 "SchemaEntity202012.tt"
+        #line 621 "SchemaEntity202012.tt"
 
         if(IsImplicitObject)
         {
@@ -2084,13 +2282,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 569 "SchemaEntity202012.tt"
+        #line 625 "SchemaEntity202012.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 570 "SchemaEntity202012.tt"
+        #line 626 "SchemaEntity202012.tt"
 
         }
         
@@ -2098,13 +2296,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 573 "SchemaEntity202012.tt"
+        #line 629 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 573 "SchemaEntity202012.tt"
+        #line 629 "SchemaEntity202012.tt"
 
         if(IsImplicitArray)
         {
@@ -2113,13 +2311,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 577 "SchemaEntity202012.tt"
+        #line 633 "SchemaEntity202012.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 578 "SchemaEntity202012.tt"
+        #line 634 "SchemaEntity202012.tt"
 
         }
         
@@ -2127,13 +2325,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 581 "SchemaEntity202012.tt"
+        #line 637 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 581 "SchemaEntity202012.tt"
+        #line 637 "SchemaEntity202012.tt"
 
         if(IsImplicitString)
         {
@@ -2142,13 +2340,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 585 "SchemaEntity202012.tt"
+        #line 641 "SchemaEntity202012.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 586 "SchemaEntity202012.tt"
+        #line 642 "SchemaEntity202012.tt"
 
         }
         
@@ -2156,354 +2354,68 @@ namespace ");
         #line default
         #line hidden
         
-        #line 589 "SchemaEntity202012.tt"
+        #line 645 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 589 "SchemaEntity202012.tt"
+        #line 645 "SchemaEntity202012.tt"
 
         if(IsImplicitBoolean)
         {
         
-        
-        #line default
-        #line hidden
-        
-        #line 593 "SchemaEntity202012.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 594 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 597 "SchemaEntity202012.tt"
-        this.Write("            this.numberBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
-                "    /// Initializes a new instance of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 601 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 601 "SchemaEntity202012.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
-                "ue.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 604 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 604 "SchemaEntity202012.tt"
-        this.Write("(int value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 607 "SchemaEntity202012.tt"
-
-        if(IsImplicitObject)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 611 "SchemaEntity202012.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 612 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 615 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 615 "SchemaEntity202012.tt"
-
-        if(IsImplicitArray)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 619 "SchemaEntity202012.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 620 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 623 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 623 "SchemaEntity202012.tt"
-
-        if(IsImplicitString)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 627 "SchemaEntity202012.tt"
-        this.Write("            this.stringBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 628 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 631 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 631 "SchemaEntity202012.tt"
-
-        if(IsImplicitBoolean)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 635 "SchemaEntity202012.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 636 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 639 "SchemaEntity202012.tt"
-        this.Write("            this.numberBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
-                "    /// Initializes a new instance of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 643 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 643 "SchemaEntity202012.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
-                "ue.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 646 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 646 "SchemaEntity202012.tt"
-        this.Write("(float value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n       " +
-                " ");
         
         #line default
         #line hidden
         
         #line 649 "SchemaEntity202012.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 650 "SchemaEntity202012.tt"
 
-        if(IsImplicitObject)
-        {
+        }
         
         
         #line default
         #line hidden
         
         #line 653 "SchemaEntity202012.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 654 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 657 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 657 "SchemaEntity202012.tt"
-
-        if(IsImplicitArray)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 661 "SchemaEntity202012.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 662 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 665 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 665 "SchemaEntity202012.tt"
-
-        if(IsImplicitString)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 669 "SchemaEntity202012.tt"
-        this.Write("            this.stringBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 670 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 673 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 673 "SchemaEntity202012.tt"
-
-        if(IsImplicitBoolean)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 677 "SchemaEntity202012.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 678 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 681 "SchemaEntity202012.tt"
         this.Write("            this.numberBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
                 "    /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 685 "SchemaEntity202012.tt"
+        #line 657 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 685 "SchemaEntity202012.tt"
+        #line 657 "SchemaEntity202012.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
                 "ue.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 688 "SchemaEntity202012.tt"
+        #line 660 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 688 "SchemaEntity202012.tt"
-        this.Write("(long value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n        " +
-                "");
+        #line 660 "SchemaEntity202012.tt"
+        this.Write("(int value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 691 "SchemaEntity202012.tt"
+        #line 663 "SchemaEntity202012.tt"
 
         if(IsImplicitObject)
         {
@@ -2512,13 +2424,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 695 "SchemaEntity202012.tt"
+        #line 667 "SchemaEntity202012.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 696 "SchemaEntity202012.tt"
+        #line 668 "SchemaEntity202012.tt"
 
         }
         
@@ -2526,13 +2438,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 699 "SchemaEntity202012.tt"
+        #line 671 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 699 "SchemaEntity202012.tt"
+        #line 671 "SchemaEntity202012.tt"
 
         if(IsImplicitArray)
         {
@@ -2541,13 +2453,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 703 "SchemaEntity202012.tt"
+        #line 675 "SchemaEntity202012.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 704 "SchemaEntity202012.tt"
+        #line 676 "SchemaEntity202012.tt"
 
         }
         
@@ -2555,13 +2467,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 707 "SchemaEntity202012.tt"
+        #line 679 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 707 "SchemaEntity202012.tt"
+        #line 679 "SchemaEntity202012.tt"
 
         if(IsImplicitString)
         {
@@ -2570,13 +2482,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 711 "SchemaEntity202012.tt"
+        #line 683 "SchemaEntity202012.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 712 "SchemaEntity202012.tt"
+        #line 684 "SchemaEntity202012.tt"
 
         }
         
@@ -2584,13 +2496,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 715 "SchemaEntity202012.tt"
+        #line 687 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 715 "SchemaEntity202012.tt"
+        #line 687 "SchemaEntity202012.tt"
 
         if(IsImplicitBoolean)
         {
@@ -2599,13 +2511,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 719 "SchemaEntity202012.tt"
+        #line 691 "SchemaEntity202012.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 720 "SchemaEntity202012.tt"
+        #line 692 "SchemaEntity202012.tt"
 
         }
         
@@ -2613,13 +2525,299 @@ namespace ");
         #line default
         #line hidden
         
-        #line 723 "SchemaEntity202012.tt"
-        this.Write("            this.numberBacking = value;\r\n        }\r\n    ");
+        #line 695 "SchemaEntity202012.tt"
+        this.Write("            this.numberBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
+                "    /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 699 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 699 "SchemaEntity202012.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
+                "ue.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 702 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 702 "SchemaEntity202012.tt"
+        this.Write("(float value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n       " +
+                " ");
+        
+        #line default
+        #line hidden
+        
+        #line 705 "SchemaEntity202012.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 709 "SchemaEntity202012.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 710 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 713 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 713 "SchemaEntity202012.tt"
+
+        if(IsImplicitArray)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 717 "SchemaEntity202012.tt"
+        this.Write("            this.arrayBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 718 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 721 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 721 "SchemaEntity202012.tt"
+
+        if(IsImplicitString)
+        {
+        
         
         #line default
         #line hidden
         
         #line 725 "SchemaEntity202012.tt"
+        this.Write("            this.stringBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 726 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 729 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 729 "SchemaEntity202012.tt"
+
+        if(IsImplicitBoolean)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 733 "SchemaEntity202012.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 734 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 737 "SchemaEntity202012.tt"
+        this.Write("            this.numberBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
+                "    /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 741 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 741 "SchemaEntity202012.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A number val" +
+                "ue.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 744 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 744 "SchemaEntity202012.tt"
+        this.Write("(long value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n        " +
+                "");
+        
+        #line default
+        #line hidden
+        
+        #line 747 "SchemaEntity202012.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 751 "SchemaEntity202012.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 752 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 755 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 755 "SchemaEntity202012.tt"
+
+        if(IsImplicitArray)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 759 "SchemaEntity202012.tt"
+        this.Write("            this.arrayBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 760 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 763 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 763 "SchemaEntity202012.tt"
+
+        if(IsImplicitString)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 767 "SchemaEntity202012.tt"
+        this.Write("            this.stringBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 768 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 771 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 771 "SchemaEntity202012.tt"
+
+        if(IsImplicitBoolean)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 775 "SchemaEntity202012.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 776 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 779 "SchemaEntity202012.tt"
+        this.Write("            this.numberBacking = value;\r\n        }\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 781 "SchemaEntity202012.tt"
 
     }
     
@@ -2627,13 +2825,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 728 "SchemaEntity202012.tt"
+        #line 784 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 729 "SchemaEntity202012.tt"
+        #line 785 "SchemaEntity202012.tt"
 
     if(IsImplicitString)
     {
@@ -2642,39 +2840,39 @@ namespace ");
         #line default
         #line hidden
         
-        #line 733 "SchemaEntity202012.tt"
+        #line 789 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 734 "SchemaEntity202012.tt"
+        #line 790 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 734 "SchemaEntity202012.tt"
+        #line 790 "SchemaEntity202012.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A string val" +
                 "ue.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 737 "SchemaEntity202012.tt"
+        #line 793 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 737 "SchemaEntity202012.tt"
+        #line 793 "SchemaEntity202012.tt"
         this.Write("(string value)\r\n        {\r\n            this.jsonElementBacking = default;\r\n      " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 740 "SchemaEntity202012.tt"
+        #line 796 "SchemaEntity202012.tt"
 
         if(IsImplicitObject)
         {
@@ -2683,13 +2881,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 744 "SchemaEntity202012.tt"
+        #line 800 "SchemaEntity202012.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 745 "SchemaEntity202012.tt"
+        #line 801 "SchemaEntity202012.tt"
 
         }
         
@@ -2697,13 +2895,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 748 "SchemaEntity202012.tt"
+        #line 804 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 748 "SchemaEntity202012.tt"
+        #line 804 "SchemaEntity202012.tt"
 
         if(IsImplicitArray)
         {
@@ -2712,13 +2910,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 752 "SchemaEntity202012.tt"
+        #line 808 "SchemaEntity202012.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 753 "SchemaEntity202012.tt"
+        #line 809 "SchemaEntity202012.tt"
 
         }
         
@@ -2726,13 +2924,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 756 "SchemaEntity202012.tt"
+        #line 812 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 756 "SchemaEntity202012.tt"
+        #line 812 "SchemaEntity202012.tt"
 
         if(IsImplicitNumber)
         {
@@ -2741,13 +2939,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 760 "SchemaEntity202012.tt"
+        #line 816 "SchemaEntity202012.tt"
         this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 761 "SchemaEntity202012.tt"
+        #line 817 "SchemaEntity202012.tt"
 
         }
         
@@ -2755,227 +2953,84 @@ namespace ");
         #line default
         #line hidden
         
-        #line 764 "SchemaEntity202012.tt"
+        #line 820 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 764 "SchemaEntity202012.tt"
+        #line 820 "SchemaEntity202012.tt"
 
         if(IsImplicitBoolean)
         {
         
-        
-        #line default
-        #line hidden
-        
-        #line 768 "SchemaEntity202012.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 769 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 772 "SchemaEntity202012.tt"
-        this.Write("            this.stringBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
-                "    /// Initializes a new instance of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 776 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 776 "SchemaEntity202012.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A string val" +
-                "ue.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 779 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 779 "SchemaEntity202012.tt"
-        this.Write("(ReadOnlySpan<char> value)\r\n        {\r\n            this.jsonElementBacking = defa" +
-                "ult;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 782 "SchemaEntity202012.tt"
-
-        if(IsImplicitObject)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 786 "SchemaEntity202012.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 787 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 790 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 790 "SchemaEntity202012.tt"
-
-        if(IsImplicitArray)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 794 "SchemaEntity202012.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 795 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 798 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 798 "SchemaEntity202012.tt"
-
-        if(IsImplicitNumber)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 802 "SchemaEntity202012.tt"
-        this.Write("            this.numberBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 803 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 806 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 806 "SchemaEntity202012.tt"
-
-        if(IsImplicitBoolean)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 810 "SchemaEntity202012.tt"
-        this.Write("            this.booleanBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 811 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 814 "SchemaEntity202012.tt"
-        this.Write("            this.stringBacking = value.ToString();\r\n        }\r\n\r\n        /// <sum" +
-                "mary>\r\n        /// Initializes a new instance of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 818 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 818 "SchemaEntity202012.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A string val" +
-                "ue.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 821 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 821 "SchemaEntity202012.tt"
-        this.Write("(ReadOnlySpan<byte> value)\r\n        {\r\n            this.jsonElementBacking = defa" +
-                "ult;\r\n        ");
         
         #line default
         #line hidden
         
         #line 824 "SchemaEntity202012.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 825 "SchemaEntity202012.tt"
 
-        if(IsImplicitObject)
-        {
+        }
         
         
         #line default
         #line hidden
         
         #line 828 "SchemaEntity202012.tt"
+        this.Write("            this.stringBacking = value;\r\n        }\r\n\r\n        /// <summary>\r\n    " +
+                "    /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 832 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 832 "SchemaEntity202012.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A string val" +
+                "ue.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 835 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 835 "SchemaEntity202012.tt"
+        this.Write("(ReadOnlySpan<char> value)\r\n        {\r\n            this.jsonElementBacking = defa" +
+                "ult;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 838 "SchemaEntity202012.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 842 "SchemaEntity202012.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 829 "SchemaEntity202012.tt"
+        #line 843 "SchemaEntity202012.tt"
 
         }
         
@@ -2983,13 +3038,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 832 "SchemaEntity202012.tt"
+        #line 846 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 832 "SchemaEntity202012.tt"
+        #line 846 "SchemaEntity202012.tt"
 
         if(IsImplicitArray)
         {
@@ -2998,13 +3053,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 836 "SchemaEntity202012.tt"
+        #line 850 "SchemaEntity202012.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 837 "SchemaEntity202012.tt"
+        #line 851 "SchemaEntity202012.tt"
 
         }
         
@@ -3012,13 +3067,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 840 "SchemaEntity202012.tt"
+        #line 854 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 840 "SchemaEntity202012.tt"
+        #line 854 "SchemaEntity202012.tt"
 
         if(IsImplicitNumber)
         {
@@ -3027,13 +3082,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 844 "SchemaEntity202012.tt"
+        #line 858 "SchemaEntity202012.tt"
         this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 845 "SchemaEntity202012.tt"
+        #line 859 "SchemaEntity202012.tt"
 
         }
         
@@ -3041,13 +3096,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 848 "SchemaEntity202012.tt"
+        #line 862 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 848 "SchemaEntity202012.tt"
+        #line 862 "SchemaEntity202012.tt"
 
         if(IsImplicitBoolean)
         {
@@ -3056,13 +3111,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 852 "SchemaEntity202012.tt"
+        #line 866 "SchemaEntity202012.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 853 "SchemaEntity202012.tt"
+        #line 867 "SchemaEntity202012.tt"
 
         }
         
@@ -3070,7 +3125,150 @@ namespace ");
         #line default
         #line hidden
         
-        #line 856 "SchemaEntity202012.tt"
+        #line 870 "SchemaEntity202012.tt"
+        this.Write("            this.stringBacking = value.ToString();\r\n        }\r\n\r\n        /// <sum" +
+                "mary>\r\n        /// Initializes a new instance of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 874 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 874 "SchemaEntity202012.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"value\">A string val" +
+                "ue.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 877 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 877 "SchemaEntity202012.tt"
+        this.Write("(ReadOnlySpan<byte> value)\r\n        {\r\n            this.jsonElementBacking = defa" +
+                "ult;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 880 "SchemaEntity202012.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 884 "SchemaEntity202012.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 885 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 888 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 888 "SchemaEntity202012.tt"
+
+        if(IsImplicitArray)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 892 "SchemaEntity202012.tt"
+        this.Write("            this.arrayBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 893 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 896 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 896 "SchemaEntity202012.tt"
+
+        if(IsImplicitNumber)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 900 "SchemaEntity202012.tt"
+        this.Write("            this.numberBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 901 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 904 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 904 "SchemaEntity202012.tt"
+
+        if(IsImplicitBoolean)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 908 "SchemaEntity202012.tt"
+        this.Write("            this.booleanBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 909 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 912 "SchemaEntity202012.tt"
         this.Write("            this.stringBacking = System.Text.Encoding.UTF8.GetString(value);\r\n   " +
                 "     }\r\n\r\n        /// <summary>\r\n        /// Initializes a new instance of the <" +
                 "see cref=\"");
@@ -3078,13 +3276,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 860 "SchemaEntity202012.tt"
+        #line 916 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 860 "SchemaEntity202012.tt"
+        #line 916 "SchemaEntity202012.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"jsonString\">The <se" +
                 "e cref=\"JsonString\"/> from which to construct the value.</param>\r\n        public" +
                 " ");
@@ -3092,13 +3290,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 863 "SchemaEntity202012.tt"
+        #line 919 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 863 "SchemaEntity202012.tt"
+        #line 919 "SchemaEntity202012.tt"
         this.Write(@"(JsonString jsonString)
         {
             if (jsonString.HasJsonElement)
@@ -3117,7 +3315,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 876 "SchemaEntity202012.tt"
+        #line 932 "SchemaEntity202012.tt"
 
         if(IsImplicitObject)
         {
@@ -3126,13 +3324,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 880 "SchemaEntity202012.tt"
+        #line 936 "SchemaEntity202012.tt"
         this.Write("            this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 881 "SchemaEntity202012.tt"
+        #line 937 "SchemaEntity202012.tt"
 
         }
         
@@ -3140,13 +3338,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 884 "SchemaEntity202012.tt"
+        #line 940 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 884 "SchemaEntity202012.tt"
+        #line 940 "SchemaEntity202012.tt"
 
         if(IsImplicitArray)
         {
@@ -3155,13 +3353,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 888 "SchemaEntity202012.tt"
+        #line 944 "SchemaEntity202012.tt"
         this.Write("            this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 889 "SchemaEntity202012.tt"
+        #line 945 "SchemaEntity202012.tt"
 
         }
         
@@ -3169,13 +3367,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 892 "SchemaEntity202012.tt"
+        #line 948 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 892 "SchemaEntity202012.tt"
+        #line 948 "SchemaEntity202012.tt"
 
         if(IsImplicitNumber)
         {
@@ -3184,13 +3382,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 896 "SchemaEntity202012.tt"
+        #line 952 "SchemaEntity202012.tt"
         this.Write("            this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 897 "SchemaEntity202012.tt"
+        #line 953 "SchemaEntity202012.tt"
 
         }
         
@@ -3198,13 +3396,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 900 "SchemaEntity202012.tt"
+        #line 956 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 900 "SchemaEntity202012.tt"
+        #line 956 "SchemaEntity202012.tt"
 
         if(IsImplicitBoolean)
         {
@@ -3213,13 +3411,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 904 "SchemaEntity202012.tt"
+        #line 960 "SchemaEntity202012.tt"
         this.Write("            this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 905 "SchemaEntity202012.tt"
+        #line 961 "SchemaEntity202012.tt"
 
         }
         
@@ -3227,13 +3425,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 908 "SchemaEntity202012.tt"
+        #line 964 "SchemaEntity202012.tt"
         this.Write("        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 909 "SchemaEntity202012.tt"
+        #line 965 "SchemaEntity202012.tt"
 
     }
     
@@ -3241,13 +3439,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 912 "SchemaEntity202012.tt"
+        #line 968 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 913 "SchemaEntity202012.tt"
+        #line 969 "SchemaEntity202012.tt"
 
     if(IsImplicitBoolean)
     {
@@ -3256,19 +3454,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 917 "SchemaEntity202012.tt"
+        #line 973 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 918 "SchemaEntity202012.tt"
+        #line 974 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 918 "SchemaEntity202012.tt"
+        #line 974 "SchemaEntity202012.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"jsonBoolean\">The <s" +
                 "ee cref=\"JsonBoolean\"/> from which to construct the value.</param>\r\n        publ" +
                 "ic ");
@@ -3276,13 +3474,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 921 "SchemaEntity202012.tt"
+        #line 977 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 921 "SchemaEntity202012.tt"
+        #line 977 "SchemaEntity202012.tt"
         this.Write(@"(JsonBoolean jsonBoolean)
         {
             if (jsonBoolean.HasJsonElement)
@@ -3301,237 +3499,94 @@ namespace ");
         #line default
         #line hidden
         
-        #line 934 "SchemaEntity202012.tt"
-
-        if(IsImplicitObject)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 938 "SchemaEntity202012.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 939 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 942 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 942 "SchemaEntity202012.tt"
-
-        if(IsImplicitArray)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 946 "SchemaEntity202012.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 947 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 950 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 950 "SchemaEntity202012.tt"
-
-        if(IsImplicitNumber)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 954 "SchemaEntity202012.tt"
-        this.Write("            this.numberBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 955 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 958 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 958 "SchemaEntity202012.tt"
-
-        if(IsImplicitString)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 962 "SchemaEntity202012.tt"
-        this.Write("            this.stringBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 963 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 966 "SchemaEntity202012.tt"
-        this.Write("        }\r\n\r\n                /// <summary>\r\n        /// Initializes a new instanc" +
-                "e of the <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 969 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 969 "SchemaEntity202012.tt"
-        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"boolean\">The <see c" +
-                "ref=\"bool\"/> from which to construct the value.</param>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 972 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 972 "SchemaEntity202012.tt"
-        this.Write("(bool boolean)\r\n        {\r\n            this.jsonElementBacking = default;\r\n      " +
-                "      this.booleanBacking = boolean;\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 977 "SchemaEntity202012.tt"
-
-        if(IsImplicitObject)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 981 "SchemaEntity202012.tt"
-        this.Write("            this.objectBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 982 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 985 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 985 "SchemaEntity202012.tt"
-
-        if(IsImplicitArray)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 989 "SchemaEntity202012.tt"
-        this.Write("            this.arrayBacking = default;\r\n        ");
-        
-        #line default
-        #line hidden
-        
         #line 990 "SchemaEntity202012.tt"
 
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 993 "SchemaEntity202012.tt"
-        this.Write("        ");
-        
-        #line default
-        #line hidden
-        
-        #line 993 "SchemaEntity202012.tt"
-
-        if(IsImplicitNumber)
+        if(IsImplicitObject)
         {
         
         
         #line default
         #line hidden
         
-        #line 997 "SchemaEntity202012.tt"
-        this.Write("            this.numberBacking = default;\r\n        ");
+        #line 994 "SchemaEntity202012.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 995 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 998 "SchemaEntity202012.tt"
+        this.Write("        ");
         
         #line default
         #line hidden
         
         #line 998 "SchemaEntity202012.tt"
 
+        if(IsImplicitArray)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1002 "SchemaEntity202012.tt"
+        this.Write("            this.arrayBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1003 "SchemaEntity202012.tt"
+
         }
         
         
         #line default
         #line hidden
         
-        #line 1001 "SchemaEntity202012.tt"
+        #line 1006 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1001 "SchemaEntity202012.tt"
+        #line 1006 "SchemaEntity202012.tt"
+
+        if(IsImplicitNumber)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1010 "SchemaEntity202012.tt"
+        this.Write("            this.numberBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1011 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1014 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1014 "SchemaEntity202012.tt"
 
         if(IsImplicitString)
         {
@@ -3540,13 +3595,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1005 "SchemaEntity202012.tt"
+        #line 1018 "SchemaEntity202012.tt"
         this.Write("            this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1006 "SchemaEntity202012.tt"
+        #line 1019 "SchemaEntity202012.tt"
 
         }
         
@@ -3554,13 +3609,156 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1009 "SchemaEntity202012.tt"
+        #line 1022 "SchemaEntity202012.tt"
+        this.Write("        }\r\n\r\n                /// <summary>\r\n        /// Initializes a new instanc" +
+                "e of the <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 1025 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 1025 "SchemaEntity202012.tt"
+        this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"boolean\">The <see c" +
+                "ref=\"bool\"/> from which to construct the value.</param>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 1028 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 1028 "SchemaEntity202012.tt"
+        this.Write("(bool boolean)\r\n        {\r\n            this.jsonElementBacking = default;\r\n      " +
+                "      this.booleanBacking = boolean;\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1033 "SchemaEntity202012.tt"
+
+        if(IsImplicitObject)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1037 "SchemaEntity202012.tt"
+        this.Write("            this.objectBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1038 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1041 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1041 "SchemaEntity202012.tt"
+
+        if(IsImplicitArray)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1045 "SchemaEntity202012.tt"
+        this.Write("            this.arrayBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1046 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1049 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1049 "SchemaEntity202012.tt"
+
+        if(IsImplicitNumber)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1053 "SchemaEntity202012.tt"
+        this.Write("            this.numberBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1054 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1057 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1057 "SchemaEntity202012.tt"
+
+        if(IsImplicitString)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1061 "SchemaEntity202012.tt"
+        this.Write("            this.stringBacking = default;\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 1062 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 1065 "SchemaEntity202012.tt"
         this.Write("        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1011 "SchemaEntity202012.tt"
+        #line 1067 "SchemaEntity202012.tt"
 
     }
     
@@ -3568,25 +3766,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1014 "SchemaEntity202012.tt"
+        #line 1070 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1015 "SchemaEntity202012.tt"
+        #line 1071 "SchemaEntity202012.tt"
  /* Implicit Constructors */ 
         
         #line default
         #line hidden
         
-        #line 1016 "SchemaEntity202012.tt"
+        #line 1072 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1017 "SchemaEntity202012.tt"
+        #line 1073 "SchemaEntity202012.tt"
 
     foreach (Conversion conversion in ConversionsViaConstructor)
     {
@@ -3599,56 +3797,56 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1025 "SchemaEntity202012.tt"
+        #line 1081 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Initializes a new instance of the <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 1026 "SchemaEntity202012.tt"
+        #line 1082 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1026 "SchemaEntity202012.tt"
+        #line 1082 "SchemaEntity202012.tt"
         this.Write("\"/> struct.\r\n        /// </summary>\r\n        /// <param name=\"conversion\">The <se" +
                 "e cref=\"");
         
         #line default
         #line hidden
         
-        #line 1028 "SchemaEntity202012.tt"
+        #line 1084 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1028 "SchemaEntity202012.tt"
+        #line 1084 "SchemaEntity202012.tt"
         this.Write("\"/> from which to construct the value.</param>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 1029 "SchemaEntity202012.tt"
+        #line 1085 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1029 "SchemaEntity202012.tt"
+        #line 1085 "SchemaEntity202012.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 1029 "SchemaEntity202012.tt"
+        #line 1085 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1029 "SchemaEntity202012.tt"
+        #line 1085 "SchemaEntity202012.tt"
         this.Write(" conversion)\r\n        {\r\n            if (conversion.HasJsonElement)\r\n            " +
                 "{\r\n                this.jsonElementBacking = conversion.AsJsonElement;\r\n        " +
                 "");
@@ -3656,7 +3854,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1034 "SchemaEntity202012.tt"
+        #line 1090 "SchemaEntity202012.tt"
 
         if(IsImplicitObject)
         {
@@ -3665,13 +3863,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1038 "SchemaEntity202012.tt"
+        #line 1094 "SchemaEntity202012.tt"
         this.Write("                this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1039 "SchemaEntity202012.tt"
+        #line 1095 "SchemaEntity202012.tt"
 
         }
         
@@ -3679,13 +3877,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1042 "SchemaEntity202012.tt"
+        #line 1098 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1042 "SchemaEntity202012.tt"
+        #line 1098 "SchemaEntity202012.tt"
 
         if(IsImplicitBoolean)
         {
@@ -3694,13 +3892,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1046 "SchemaEntity202012.tt"
+        #line 1102 "SchemaEntity202012.tt"
         this.Write("                this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1047 "SchemaEntity202012.tt"
+        #line 1103 "SchemaEntity202012.tt"
 
         }
         
@@ -3708,13 +3906,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1050 "SchemaEntity202012.tt"
+        #line 1106 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1051 "SchemaEntity202012.tt"
+        #line 1107 "SchemaEntity202012.tt"
 
         if(IsImplicitArray)
         {
@@ -3723,13 +3921,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1055 "SchemaEntity202012.tt"
+        #line 1111 "SchemaEntity202012.tt"
         this.Write("                this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1056 "SchemaEntity202012.tt"
+        #line 1112 "SchemaEntity202012.tt"
 
         }
         
@@ -3737,13 +3935,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1059 "SchemaEntity202012.tt"
+        #line 1115 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1059 "SchemaEntity202012.tt"
+        #line 1115 "SchemaEntity202012.tt"
 
         if(IsImplicitNumber)
         {
@@ -3752,13 +3950,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1063 "SchemaEntity202012.tt"
+        #line 1119 "SchemaEntity202012.tt"
         this.Write("                this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1064 "SchemaEntity202012.tt"
+        #line 1120 "SchemaEntity202012.tt"
 
         }
         
@@ -3766,13 +3964,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1067 "SchemaEntity202012.tt"
+        #line 1123 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1067 "SchemaEntity202012.tt"
+        #line 1123 "SchemaEntity202012.tt"
 
         if(IsImplicitString)
         {
@@ -3781,13 +3979,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1071 "SchemaEntity202012.tt"
+        #line 1127 "SchemaEntity202012.tt"
         this.Write("                this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1072 "SchemaEntity202012.tt"
+        #line 1128 "SchemaEntity202012.tt"
 
         }
         
@@ -3795,14 +3993,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1075 "SchemaEntity202012.tt"
+        #line 1131 "SchemaEntity202012.tt"
         this.Write("            }\r\n            else\r\n            {\r\n                this.jsonElementB" +
                 "acking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1079 "SchemaEntity202012.tt"
+        #line 1135 "SchemaEntity202012.tt"
 
         if(conversion.IsObject)
         {
@@ -3811,7 +4009,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1083 "SchemaEntity202012.tt"
+        #line 1139 "SchemaEntity202012.tt"
         this.Write(@"                if (conversion.ValueKind == JsonValueKind.Object)
                 {
                     this.objectBacking = conversion;
@@ -3825,7 +4023,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1091 "SchemaEntity202012.tt"
+        #line 1147 "SchemaEntity202012.tt"
 
         }
         else if (IsImplicitObject)
@@ -3835,13 +4033,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1096 "SchemaEntity202012.tt"
+        #line 1152 "SchemaEntity202012.tt"
         this.Write("                this.objectBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1097 "SchemaEntity202012.tt"
+        #line 1153 "SchemaEntity202012.tt"
 
         }
         
@@ -3849,13 +4047,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1100 "SchemaEntity202012.tt"
+        #line 1156 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1100 "SchemaEntity202012.tt"
+        #line 1156 "SchemaEntity202012.tt"
 
         if(conversion.IsBoolean)
         {
@@ -3864,7 +4062,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1104 "SchemaEntity202012.tt"
+        #line 1160 "SchemaEntity202012.tt"
         this.Write(@"                if (conversion.ValueKind == JsonValueKind.True || conversion.ValueKind == JsonValueKind.False)
                 {
                     this.booleanBacking = conversion;
@@ -3878,7 +4076,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1112 "SchemaEntity202012.tt"
+        #line 1168 "SchemaEntity202012.tt"
 
         }
         else if (IsImplicitBoolean)
@@ -3888,13 +4086,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1117 "SchemaEntity202012.tt"
+        #line 1173 "SchemaEntity202012.tt"
         this.Write("                this.booleanBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1118 "SchemaEntity202012.tt"
+        #line 1174 "SchemaEntity202012.tt"
 
         }
         
@@ -3902,13 +4100,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1121 "SchemaEntity202012.tt"
+        #line 1177 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1122 "SchemaEntity202012.tt"
+        #line 1178 "SchemaEntity202012.tt"
 
         if(conversion.IsArray)
         {
@@ -3917,7 +4115,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1126 "SchemaEntity202012.tt"
+        #line 1182 "SchemaEntity202012.tt"
         this.Write(@"                if (conversion.ValueKind == JsonValueKind.Array)
                 {
                     this.arrayBacking = conversion;
@@ -3931,7 +4129,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1134 "SchemaEntity202012.tt"
+        #line 1190 "SchemaEntity202012.tt"
 
         }
         else if (IsImplicitArray)
@@ -3941,13 +4139,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1139 "SchemaEntity202012.tt"
+        #line 1195 "SchemaEntity202012.tt"
         this.Write("                this.arrayBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1140 "SchemaEntity202012.tt"
+        #line 1196 "SchemaEntity202012.tt"
 
         }
         
@@ -3955,13 +4153,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1143 "SchemaEntity202012.tt"
+        #line 1199 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1143 "SchemaEntity202012.tt"
+        #line 1199 "SchemaEntity202012.tt"
 
         if(conversion.IsNumber)
         {
@@ -3970,7 +4168,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1147 "SchemaEntity202012.tt"
+        #line 1203 "SchemaEntity202012.tt"
         this.Write(@"                if (conversion.ValueKind == JsonValueKind.Number)
                 {
                     this.numberBacking = conversion;
@@ -3984,7 +4182,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1155 "SchemaEntity202012.tt"
+        #line 1211 "SchemaEntity202012.tt"
 
         }
         else if (IsImplicitNumber)
@@ -3994,13 +4192,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1160 "SchemaEntity202012.tt"
+        #line 1216 "SchemaEntity202012.tt"
         this.Write("                this.numberBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1161 "SchemaEntity202012.tt"
+        #line 1217 "SchemaEntity202012.tt"
 
         }
         
@@ -4008,13 +4206,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1164 "SchemaEntity202012.tt"
+        #line 1220 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1164 "SchemaEntity202012.tt"
+        #line 1220 "SchemaEntity202012.tt"
 
         if(conversion.IsString)
         {
@@ -4023,7 +4221,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1168 "SchemaEntity202012.tt"
+        #line 1224 "SchemaEntity202012.tt"
         this.Write(@"                if (conversion.ValueKind == JsonValueKind.String)
                 {
                     this.stringBacking = conversion;
@@ -4037,7 +4235,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1176 "SchemaEntity202012.tt"
+        #line 1232 "SchemaEntity202012.tt"
 
         }
         else if (IsImplicitString)
@@ -4047,13 +4245,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1181 "SchemaEntity202012.tt"
+        #line 1237 "SchemaEntity202012.tt"
         this.Write("                this.stringBacking = default;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1182 "SchemaEntity202012.tt"
+        #line 1238 "SchemaEntity202012.tt"
 
         }
         
@@ -4061,13 +4259,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1185 "SchemaEntity202012.tt"
+        #line 1241 "SchemaEntity202012.tt"
         this.Write("            }\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1187 "SchemaEntity202012.tt"
+        #line 1243 "SchemaEntity202012.tt"
 
     }
     
@@ -4075,13 +4273,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1190 "SchemaEntity202012.tt"
+        #line 1246 "SchemaEntity202012.tt"
         this.Write("\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1192 "SchemaEntity202012.tt"
+        #line 1248 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -4090,7 +4288,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1196 "SchemaEntity202012.tt"
+        #line 1252 "SchemaEntity202012.tt"
         this.Write(@"        /// <inheritdoc/>
         public int Length
         {
@@ -4109,7 +4307,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1209 "SchemaEntity202012.tt"
+        #line 1265 "SchemaEntity202012.tt"
 
     }
     
@@ -4117,13 +4315,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1212 "SchemaEntity202012.tt"
+        #line 1268 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1213 "SchemaEntity202012.tt"
+        #line 1269 "SchemaEntity202012.tt"
 
     foreach (Conversion conversion in ConversionsViaConstructor)
     {
@@ -4136,43 +4334,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1221 "SchemaEntity202012.tt"
+        #line 1277 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Gets the value as a <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 1222 "SchemaEntity202012.tt"
+        #line 1278 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1222 "SchemaEntity202012.tt"
+        #line 1278 "SchemaEntity202012.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 1224 "SchemaEntity202012.tt"
+        #line 1280 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1224 "SchemaEntity202012.tt"
+        #line 1280 "SchemaEntity202012.tt"
         this.Write(" As");
         
         #line default
         #line hidden
         
-        #line 1224 "SchemaEntity202012.tt"
+        #line 1280 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1224 "SchemaEntity202012.tt"
+        #line 1280 "SchemaEntity202012.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return this;\r\n      " +
                 "      }\r\n        }\r\n\r\n        /// <summary>\r\n        /// Gets a value indicating" +
                 " whether this is a valid <see cref=\"");
@@ -4180,43 +4378,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1233 "SchemaEntity202012.tt"
+        #line 1289 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1233 "SchemaEntity202012.tt"
+        #line 1289 "SchemaEntity202012.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public bool Is");
         
         #line default
         #line hidden
         
-        #line 1235 "SchemaEntity202012.tt"
+        #line 1291 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1235 "SchemaEntity202012.tt"
+        #line 1291 "SchemaEntity202012.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return ((");
         
         #line default
         #line hidden
         
-        #line 1239 "SchemaEntity202012.tt"
+        #line 1295 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1239 "SchemaEntity202012.tt"
+        #line 1295 "SchemaEntity202012.tt"
         this.Write(")this).Validate().IsValid;\r\n            }\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1243 "SchemaEntity202012.tt"
+        #line 1299 "SchemaEntity202012.tt"
 
     }
     
@@ -4224,13 +4422,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1246 "SchemaEntity202012.tt"
+        #line 1302 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1247 "SchemaEntity202012.tt"
+        #line 1303 "SchemaEntity202012.tt"
 
     if (HasIfThenElse)
     {
@@ -4239,13 +4437,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1251 "SchemaEntity202012.tt"
+        #line 1307 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1251 "SchemaEntity202012.tt"
+        #line 1307 "SchemaEntity202012.tt"
 
         if (HasThen)
         {
@@ -4254,32 +4452,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1255 "SchemaEntity202012.tt"
+        #line 1311 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Gets a value indicating whether this matches t" +
                 "he If/Then type.\r\n        /// </summary>\r\n        public bool IsIfMatch");
         
         #line default
         #line hidden
         
-        #line 1258 "SchemaEntity202012.tt"
+        #line 1314 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                ThenDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1258 "SchemaEntity202012.tt"
+        #line 1314 "SchemaEntity202012.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return this.As<");
         
         #line default
         #line hidden
         
-        #line 1262 "SchemaEntity202012.tt"
+        #line 1318 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                IfFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1262 "SchemaEntity202012.tt"
+        #line 1318 "SchemaEntity202012.tt"
         this.Write(">().IsValid(); \r\n            }\r\n        }\r\n\r\n        /// <summary>\r\n        /// G" +
                 "ets this as the matching type for the If/Then clause.\r\n        /// </summary>\r\n " +
                 "       public ");
@@ -4287,43 +4485,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1269 "SchemaEntity202012.tt"
+        #line 1325 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ThenFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1269 "SchemaEntity202012.tt"
+        #line 1325 "SchemaEntity202012.tt"
         this.Write(" AsIfMatch");
         
         #line default
         #line hidden
         
-        #line 1269 "SchemaEntity202012.tt"
+        #line 1325 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ThenDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1269 "SchemaEntity202012.tt"
+        #line 1325 "SchemaEntity202012.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return this.As<");
         
         #line default
         #line hidden
         
-        #line 1273 "SchemaEntity202012.tt"
+        #line 1329 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ThenFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1273 "SchemaEntity202012.tt"
+        #line 1329 "SchemaEntity202012.tt"
         this.Write(">(); \r\n            }\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1277 "SchemaEntity202012.tt"
+        #line 1333 "SchemaEntity202012.tt"
 
         }
         
@@ -4331,13 +4529,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1280 "SchemaEntity202012.tt"
+        #line 1336 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1281 "SchemaEntity202012.tt"
+        #line 1337 "SchemaEntity202012.tt"
 
         if (HasElse)
         {
@@ -4346,32 +4544,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1285 "SchemaEntity202012.tt"
+        #line 1341 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Gets a value indicating whether this matches t" +
                 "he If/Else type.\r\n        /// </summary>\r\n        public bool IsElseMatch");
         
         #line default
         #line hidden
         
-        #line 1288 "SchemaEntity202012.tt"
+        #line 1344 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ElseDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1288 "SchemaEntity202012.tt"
+        #line 1344 "SchemaEntity202012.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return !this.As<");
         
         #line default
         #line hidden
         
-        #line 1292 "SchemaEntity202012.tt"
+        #line 1348 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(IfFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1292 "SchemaEntity202012.tt"
+        #line 1348 "SchemaEntity202012.tt"
         this.Write(">().IsValid(); \r\n            }\r\n        }\r\n\r\n        /// <summary>\r\n        /// G" +
                 "ets this as the matching type for the If/Else clause.\r\n        /// </summary>\r\n " +
                 "       public ");
@@ -4379,43 +4577,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1299 "SchemaEntity202012.tt"
+        #line 1355 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ElseFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1299 "SchemaEntity202012.tt"
+        #line 1355 "SchemaEntity202012.tt"
         this.Write(" AsElseMatch");
         
         #line default
         #line hidden
         
-        #line 1299 "SchemaEntity202012.tt"
+        #line 1355 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ElseDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1299 "SchemaEntity202012.tt"
+        #line 1355 "SchemaEntity202012.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                return this.As<");
         
         #line default
         #line hidden
         
-        #line 1303 "SchemaEntity202012.tt"
+        #line 1359 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(ElseFullyQualifiedDotnetTypeName));
         
         #line default
         #line hidden
         
-        #line 1303 "SchemaEntity202012.tt"
+        #line 1359 "SchemaEntity202012.tt"
         this.Write(">(); \r\n            }\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1306 "SchemaEntity202012.tt"
+        #line 1362 "SchemaEntity202012.tt"
 
         }
         
@@ -4423,13 +4621,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1309 "SchemaEntity202012.tt"
+        #line 1365 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 1309 "SchemaEntity202012.tt"
+        #line 1365 "SchemaEntity202012.tt"
 
     }
     
@@ -4437,13 +4635,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1312 "SchemaEntity202012.tt"
+        #line 1368 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1313 "SchemaEntity202012.tt"
+        #line 1369 "SchemaEntity202012.tt"
 
     if(HasProperties)
     {
@@ -4452,13 +4650,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1317 "SchemaEntity202012.tt"
+        #line 1373 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1317 "SchemaEntity202012.tt"
+        #line 1373 "SchemaEntity202012.tt"
 
         foreach(var property in Properties)
         {
@@ -4467,19 +4665,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1321 "SchemaEntity202012.tt"
+        #line 1377 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Gets ");
         
         #line default
         #line hidden
         
-        #line 1323 "SchemaEntity202012.tt"
+        #line 1379 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 1323 "SchemaEntity202012.tt"
+        #line 1379 "SchemaEntity202012.tt"
         this.Write(".\r\n        /// </summary>\r\n        /// <remarks>\r\n        /// {Property title}.\r\n" +
                 "        /// {Property description}.\r\n        /// </remarks>\r\n        /// <exampl" +
                 "e>\r\n        /// {Property examples}.\r\n        /// </example>\r\n        public ");
@@ -4487,25 +4685,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1332 "SchemaEntity202012.tt"
+        #line 1388 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1332 "SchemaEntity202012.tt"
+        #line 1388 "SchemaEntity202012.tt"
         this.Write(" ");
         
         #line default
         #line hidden
         
-        #line 1332 "SchemaEntity202012.tt"
+        #line 1388 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 1332 "SchemaEntity202012.tt"
+        #line 1388 "SchemaEntity202012.tt"
         this.Write("\r\n        {\r\n            get\r\n            {\r\n                if (this.objectBacki" +
                 "ng is ImmutableDictionary<string, JsonAny> properties)\r\n                {\r\n     " +
                 "               if(properties.TryGetValue(");
@@ -4513,13 +4711,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1338 "SchemaEntity202012.tt"
+        #line 1394 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 1338 "SchemaEntity202012.tt"
+        #line 1394 "SchemaEntity202012.tt"
         this.Write(@"JsonPropertyName, out JsonAny result))
                     {
                         return result;
@@ -4533,33 +4731,33 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1346 "SchemaEntity202012.tt"
+        #line 1402 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 1346 "SchemaEntity202012.tt"
+        #line 1402 "SchemaEntity202012.tt"
         this.Write("Utf8JsonPropertyName.Span, out JsonElement result))\r\n                    {\r\n     " +
                 "                   return new  ");
         
         #line default
         #line hidden
         
-        #line 1348 "SchemaEntity202012.tt"
+        #line 1404 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1348 "SchemaEntity202012.tt"
+        #line 1404 "SchemaEntity202012.tt"
         this.Write("(result);\r\n                    }\r\n                }\r\n\r\n                return def" +
                 "ault;\r\n            }\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1356 "SchemaEntity202012.tt"
+        #line 1412 "SchemaEntity202012.tt"
 
         }
         
@@ -4567,13 +4765,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1359 "SchemaEntity202012.tt"
+        #line 1415 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 1359 "SchemaEntity202012.tt"
+        #line 1415 "SchemaEntity202012.tt"
 
     }
     
@@ -4581,7 +4779,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1362 "SchemaEntity202012.tt"
+        #line 1418 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Gets a value indicating whether this is backed" +
                 " by a JSON element.\r\n        /// </summary>\r\n        public bool HasJsonElement " +
                 "=>\r\n    ");
@@ -4589,7 +4787,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1366 "SchemaEntity202012.tt"
+        #line 1422 "SchemaEntity202012.tt"
 
     bool isFirstProperty = true;
     
@@ -4597,13 +4795,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1369 "SchemaEntity202012.tt"
+        #line 1425 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1370 "SchemaEntity202012.tt"
+        #line 1426 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -4612,13 +4810,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1374 "SchemaEntity202012.tt"
+        #line 1430 "SchemaEntity202012.tt"
         this.Write("            this.objectBacking is null\r\n            \r\n    ");
         
         #line default
         #line hidden
         
-        #line 1376 "SchemaEntity202012.tt"
+        #line 1432 "SchemaEntity202012.tt"
 
         isFirstProperty = false;
     }
@@ -4627,13 +4825,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1380 "SchemaEntity202012.tt"
+        #line 1436 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1381 "SchemaEntity202012.tt"
+        #line 1437 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -4642,13 +4840,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1385 "SchemaEntity202012.tt"
+        #line 1441 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1385 "SchemaEntity202012.tt"
+        #line 1441 "SchemaEntity202012.tt"
 
         if (isFirstProperty)
         {
@@ -4661,13 +4859,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1393 "SchemaEntity202012.tt"
+        #line 1449 "SchemaEntity202012.tt"
         this.Write("            &&\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1394 "SchemaEntity202012.tt"
+        #line 1450 "SchemaEntity202012.tt"
 
         }
         
@@ -4675,13 +4873,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1397 "SchemaEntity202012.tt"
+        #line 1453 "SchemaEntity202012.tt"
         this.Write("            this.arrayBacking is null\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1398 "SchemaEntity202012.tt"
+        #line 1454 "SchemaEntity202012.tt"
 
     }
     
@@ -4689,13 +4887,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1401 "SchemaEntity202012.tt"
+        #line 1457 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 1401 "SchemaEntity202012.tt"
+        #line 1457 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -4704,13 +4902,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1405 "SchemaEntity202012.tt"
+        #line 1461 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1405 "SchemaEntity202012.tt"
+        #line 1461 "SchemaEntity202012.tt"
 
         if (isFirstProperty)
         {
@@ -4723,13 +4921,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1413 "SchemaEntity202012.tt"
+        #line 1469 "SchemaEntity202012.tt"
         this.Write("            &&\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1414 "SchemaEntity202012.tt"
+        #line 1470 "SchemaEntity202012.tt"
 
         }
         
@@ -4737,13 +4935,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1417 "SchemaEntity202012.tt"
+        #line 1473 "SchemaEntity202012.tt"
         this.Write("            this.numberBacking is null\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1418 "SchemaEntity202012.tt"
+        #line 1474 "SchemaEntity202012.tt"
 
     }
     
@@ -4751,13 +4949,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1421 "SchemaEntity202012.tt"
+        #line 1477 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 1421 "SchemaEntity202012.tt"
+        #line 1477 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -4766,13 +4964,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1425 "SchemaEntity202012.tt"
+        #line 1481 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1425 "SchemaEntity202012.tt"
+        #line 1481 "SchemaEntity202012.tt"
 
         if (isFirstProperty)
         {
@@ -4785,13 +4983,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1433 "SchemaEntity202012.tt"
+        #line 1489 "SchemaEntity202012.tt"
         this.Write("            &&\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1434 "SchemaEntity202012.tt"
+        #line 1490 "SchemaEntity202012.tt"
 
         }
         
@@ -4799,13 +4997,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1437 "SchemaEntity202012.tt"
+        #line 1493 "SchemaEntity202012.tt"
         this.Write("            this.stringBacking is null\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1438 "SchemaEntity202012.tt"
+        #line 1494 "SchemaEntity202012.tt"
 
     }
     
@@ -4813,13 +5011,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1441 "SchemaEntity202012.tt"
+        #line 1497 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 1441 "SchemaEntity202012.tt"
+        #line 1497 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -4828,13 +5026,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1445 "SchemaEntity202012.tt"
+        #line 1501 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1445 "SchemaEntity202012.tt"
+        #line 1501 "SchemaEntity202012.tt"
 
         if (isFirstProperty)
         {
@@ -4847,13 +5045,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1453 "SchemaEntity202012.tt"
+        #line 1509 "SchemaEntity202012.tt"
         this.Write("            &&\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1454 "SchemaEntity202012.tt"
+        #line 1510 "SchemaEntity202012.tt"
 
         }
         
@@ -4861,132 +5059,8 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1457 "SchemaEntity202012.tt"
+        #line 1513 "SchemaEntity202012.tt"
         this.Write("            this.booleanBacking is null\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1458 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1461 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1462 "SchemaEntity202012.tt"
-
-    if (!IsImplicitObject && !IsImplicitArray && !IsImplicitNumber && !IsImplicitBoolean && !IsImplicitString)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1466 "SchemaEntity202012.tt"
-        this.Write("    true\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1467 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1470 "SchemaEntity202012.tt"
-        this.Write("            ;\r\n\r\n        /// <summary>\r\n        /// Gets the value as a JsonEleme" +
-                "nt.\r\n        /// </summary>\r\n        public JsonElement AsJsonElement\r\n        {" +
-                "\r\n            get\r\n            {\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1479 "SchemaEntity202012.tt"
-
-    if (IsImplicitObject)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1483 "SchemaEntity202012.tt"
-        this.Write("          \r\n                if (this.objectBacking is ImmutableDictionary<string," +
-                " JsonAny> objectBacking)\r\n                {\r\n                    return JsonObje" +
-                "ct.PropertiesToJsonElement(objectBacking);\r\n                }\r\n\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1489 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1492 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1493 "SchemaEntity202012.tt"
-
-    if (IsImplicitArray)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1497 "SchemaEntity202012.tt"
-        this.Write("                if (this.arrayBacking is ImmutableList<JsonAny> arrayBacking)\r\n  " +
-                "              {\r\n                    return JsonArray.ItemsToJsonElement(arrayBa" +
-                "cking);\r\n                }\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1501 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1504 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 1505 "SchemaEntity202012.tt"
-
-    if (IsImplicitNumber)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 1509 "SchemaEntity202012.tt"
-        this.Write("                if (this.numberBacking is double numberBacking)\r\n                " +
-                "{\r\n                    return JsonNumber.NumberToJsonElement(numberBacking);\r\n  " +
-                "              }\r\n\r\n    ");
         
         #line default
         #line hidden
@@ -5007,7 +5081,7 @@ namespace ");
         
         #line 1518 "SchemaEntity202012.tt"
 
-    if (IsImplicitString)
+    if (!IsImplicitObject && !IsImplicitArray && !IsImplicitNumber && !IsImplicitBoolean && !IsImplicitString)
     {
     
         
@@ -5015,6 +5089,130 @@ namespace ");
         #line hidden
         
         #line 1522 "SchemaEntity202012.tt"
+        this.Write("    true\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1523 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1526 "SchemaEntity202012.tt"
+        this.Write("            ;\r\n\r\n        /// <summary>\r\n        /// Gets the value as a JsonEleme" +
+                "nt.\r\n        /// </summary>\r\n        public JsonElement AsJsonElement\r\n        {" +
+                "\r\n            get\r\n            {\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1535 "SchemaEntity202012.tt"
+
+    if (IsImplicitObject)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1539 "SchemaEntity202012.tt"
+        this.Write("          \r\n                if (this.objectBacking is ImmutableDictionary<string," +
+                " JsonAny> objectBacking)\r\n                {\r\n                    return JsonObje" +
+                "ct.PropertiesToJsonElement(objectBacking);\r\n                }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1545 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1548 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1549 "SchemaEntity202012.tt"
+
+    if (IsImplicitArray)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1553 "SchemaEntity202012.tt"
+        this.Write("                if (this.arrayBacking is ImmutableList<JsonAny> arrayBacking)\r\n  " +
+                "              {\r\n                    return JsonArray.ItemsToJsonElement(arrayBa" +
+                "cking);\r\n                }\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1557 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1560 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1561 "SchemaEntity202012.tt"
+
+    if (IsImplicitNumber)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1565 "SchemaEntity202012.tt"
+        this.Write("                if (this.numberBacking is double numberBacking)\r\n                " +
+                "{\r\n                    return JsonNumber.NumberToJsonElement(numberBacking);\r\n  " +
+                "              }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1570 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1573 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 1574 "SchemaEntity202012.tt"
+
+    if (IsImplicitString)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 1578 "SchemaEntity202012.tt"
         this.Write("                if (this.stringBacking is string stringBacking)\r\n                " +
                 "{\r\n                    return JsonString.StringToJsonElement(stringBacking);\r\n  " +
                 "              }\r\n\r\n    ");
@@ -5022,7 +5220,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1527 "SchemaEntity202012.tt"
+        #line 1583 "SchemaEntity202012.tt"
 
     }
     
@@ -5030,13 +5228,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1530 "SchemaEntity202012.tt"
+        #line 1586 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1531 "SchemaEntity202012.tt"
+        #line 1587 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -5045,7 +5243,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1535 "SchemaEntity202012.tt"
+        #line 1591 "SchemaEntity202012.tt"
         this.Write("                if (this.booleanBacking is bool booleanBacking)\r\n                " +
                 "{\r\n                    return JsonBoolean.BoolToJsonElement(booleanBacking);\r\n  " +
                 "              }\r\n\r\n    ");
@@ -5053,7 +5251,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1540 "SchemaEntity202012.tt"
+        #line 1596 "SchemaEntity202012.tt"
 
     }
     
@@ -5061,7 +5259,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1543 "SchemaEntity202012.tt"
+        #line 1599 "SchemaEntity202012.tt"
         this.Write("\r\n                return this.jsonElementBacking;\r\n            }\r\n        }\r\n\r\n  " +
                 "      /// <inheritdoc/>\r\n        public JsonValueKind ValueKind\r\n        {\r\n    " +
                 "        get\r\n            {\r\n    ");
@@ -5069,7 +5267,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1553 "SchemaEntity202012.tt"
+        #line 1609 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -5078,7 +5276,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1557 "SchemaEntity202012.tt"
+        #line 1613 "SchemaEntity202012.tt"
         this.Write("                if (this.objectBacking is ImmutableDictionary<string, JsonAny>)\r\n" +
                 "                {\r\n                    return JsonValueKind.Object;\r\n           " +
                 "     }\r\n\r\n    ");
@@ -5086,7 +5284,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1562 "SchemaEntity202012.tt"
+        #line 1618 "SchemaEntity202012.tt"
 
     }
     
@@ -5094,13 +5292,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1565 "SchemaEntity202012.tt"
+        #line 1621 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1566 "SchemaEntity202012.tt"
+        #line 1622 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -5109,14 +5307,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1570 "SchemaEntity202012.tt"
+        #line 1626 "SchemaEntity202012.tt"
         this.Write("                if (this.arrayBacking is ImmutableList<JsonAny>)\r\n               " +
                 " {\r\n                    return JsonValueKind.Array;\r\n                }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1575 "SchemaEntity202012.tt"
+        #line 1631 "SchemaEntity202012.tt"
 
     }
     
@@ -5124,13 +5322,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1578 "SchemaEntity202012.tt"
+        #line 1634 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1579 "SchemaEntity202012.tt"
+        #line 1635 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -5139,14 +5337,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1583 "SchemaEntity202012.tt"
+        #line 1639 "SchemaEntity202012.tt"
         this.Write("                if (this.numberBacking is double)\r\n                {\r\n           " +
                 "         return JsonValueKind.Number;\r\n                }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1588 "SchemaEntity202012.tt"
+        #line 1644 "SchemaEntity202012.tt"
 
     }
     
@@ -5154,13 +5352,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1591 "SchemaEntity202012.tt"
+        #line 1647 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1592 "SchemaEntity202012.tt"
+        #line 1648 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -5169,14 +5367,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1596 "SchemaEntity202012.tt"
+        #line 1652 "SchemaEntity202012.tt"
         this.Write("                if (this.stringBacking is string)\r\n                {\r\n           " +
                 "         return JsonValueKind.String;\r\n                }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1601 "SchemaEntity202012.tt"
+        #line 1657 "SchemaEntity202012.tt"
 
     }
     
@@ -5184,13 +5382,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1604 "SchemaEntity202012.tt"
+        #line 1660 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1605 "SchemaEntity202012.tt"
+        #line 1661 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -5199,7 +5397,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1609 "SchemaEntity202012.tt"
+        #line 1665 "SchemaEntity202012.tt"
         this.Write("                if (this.booleanBacking is bool booleanBacking)\r\n                " +
                 "{\r\n                    return booleanBacking ? JsonValueKind.True : JsonValueKin" +
                 "d.False;\r\n                }\r\n\r\n    ");
@@ -5207,7 +5405,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1614 "SchemaEntity202012.tt"
+        #line 1670 "SchemaEntity202012.tt"
 
     }
     
@@ -5215,7 +5413,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1617 "SchemaEntity202012.tt"
+        #line 1673 "SchemaEntity202012.tt"
         this.Write("\r\n                return this.jsonElementBacking.ValueKind;\r\n            }\r\n     " +
                 "   }\r\n\r\n        /// <inheritdoc/>\r\n        public JsonAny AsAny\r\n        {\r\n    " +
                 "        get\r\n            {\r\n    ");
@@ -5223,7 +5421,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1627 "SchemaEntity202012.tt"
+        #line 1683 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -5232,7 +5430,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1631 "SchemaEntity202012.tt"
+        #line 1687 "SchemaEntity202012.tt"
         this.Write("                if (this.objectBacking is ImmutableDictionary<string, JsonAny> ob" +
                 "jectBacking)\r\n                {\r\n                    return new JsonAny(objectBa" +
                 "cking);\r\n                }\r\n\r\n    ");
@@ -5240,7 +5438,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1636 "SchemaEntity202012.tt"
+        #line 1692 "SchemaEntity202012.tt"
 
     }
     
@@ -5248,13 +5446,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1639 "SchemaEntity202012.tt"
+        #line 1695 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1640 "SchemaEntity202012.tt"
+        #line 1696 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -5263,7 +5461,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1644 "SchemaEntity202012.tt"
+        #line 1700 "SchemaEntity202012.tt"
         this.Write("                if (this.arrayBacking is ImmutableList<JsonAny> arrayBacking)\r\n  " +
                 "              {\r\n                    return new JsonAny(arrayBacking);\r\n        " +
                 "        }\r\n\r\n    ");
@@ -5271,7 +5469,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1649 "SchemaEntity202012.tt"
+        #line 1705 "SchemaEntity202012.tt"
 
     }
     
@@ -5279,13 +5477,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1652 "SchemaEntity202012.tt"
+        #line 1708 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1653 "SchemaEntity202012.tt"
+        #line 1709 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -5294,7 +5492,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1657 "SchemaEntity202012.tt"
+        #line 1713 "SchemaEntity202012.tt"
         this.Write("                if (this.numberBacking is double numberBacking)\r\n                " +
                 "{\r\n                    return new JsonAny(numberBacking);\r\n                }\r\n\r\n" +
                 "    ");
@@ -5302,7 +5500,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1662 "SchemaEntity202012.tt"
+        #line 1718 "SchemaEntity202012.tt"
 
     }
     
@@ -5310,13 +5508,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1665 "SchemaEntity202012.tt"
+        #line 1721 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1666 "SchemaEntity202012.tt"
+        #line 1722 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -5325,7 +5523,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1670 "SchemaEntity202012.tt"
+        #line 1726 "SchemaEntity202012.tt"
         this.Write("                if (this.stringBacking is string stringBacking)\r\n                " +
                 "{\r\n                    return new JsonAny(stringBacking);\r\n                }\r\n\r\n" +
                 "    ");
@@ -5333,7 +5531,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1675 "SchemaEntity202012.tt"
+        #line 1731 "SchemaEntity202012.tt"
 
     }
     
@@ -5341,13 +5539,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1678 "SchemaEntity202012.tt"
+        #line 1734 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1679 "SchemaEntity202012.tt"
+        #line 1735 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -5356,7 +5554,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1683 "SchemaEntity202012.tt"
+        #line 1739 "SchemaEntity202012.tt"
         this.Write("                if (this.booleanBacking is bool booleanBacking)\r\n                " +
                 "{\r\n                    return new JsonAny(booleanBacking);\r\n                }\r\n\r" +
                 "\n    ");
@@ -5364,7 +5562,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1688 "SchemaEntity202012.tt"
+        #line 1744 "SchemaEntity202012.tt"
 
     }
     
@@ -5372,14 +5570,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1691 "SchemaEntity202012.tt"
+        #line 1747 "SchemaEntity202012.tt"
         this.Write("\r\n                return new JsonAny(this.jsonElementBacking);\r\n            }\r\n  " +
                 "      }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1696 "SchemaEntity202012.tt"
+        #line 1752 "SchemaEntity202012.tt"
 
     foreach(Conversion conversion in ConversionsViaConstructor)
     {
@@ -5392,100 +5590,100 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1704 "SchemaEntity202012.tt"
+        #line 1760 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Conversion from <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 1705 "SchemaEntity202012.tt"
+        #line 1761 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1705 "SchemaEntity202012.tt"
+        #line 1761 "SchemaEntity202012.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        /// <param name=\"value\">The value from whi" +
                 "ch to convert.</param>\r\n        public static implicit operator ");
         
         #line default
         #line hidden
         
-        #line 1708 "SchemaEntity202012.tt"
+        #line 1764 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1708 "SchemaEntity202012.tt"
+        #line 1764 "SchemaEntity202012.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 1708 "SchemaEntity202012.tt"
+        #line 1764 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1708 "SchemaEntity202012.tt"
+        #line 1764 "SchemaEntity202012.tt"
         this.Write(" value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1710 "SchemaEntity202012.tt"
+        #line 1766 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1710 "SchemaEntity202012.tt"
+        #line 1766 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to <see cref" +
                 "=\"");
         
         #line default
         #line hidden
         
-        #line 1714 "SchemaEntity202012.tt"
+        #line 1770 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1714 "SchemaEntity202012.tt"
+        #line 1770 "SchemaEntity202012.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        /// <param name=\"value\">The value from whi" +
                 "ch to convert.</param>\r\n        public static implicit operator ");
         
         #line default
         #line hidden
         
-        #line 1717 "SchemaEntity202012.tt"
+        #line 1773 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1717 "SchemaEntity202012.tt"
+        #line 1773 "SchemaEntity202012.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 1717 "SchemaEntity202012.tt"
+        #line 1773 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1717 "SchemaEntity202012.tt"
+        #line 1773 "SchemaEntity202012.tt"
         this.Write(" value)\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1719 "SchemaEntity202012.tt"
+        #line 1775 "SchemaEntity202012.tt"
 
         if(conversion.IsObject)
         {
@@ -5494,26 +5692,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1723 "SchemaEntity202012.tt"
+        #line 1779 "SchemaEntity202012.tt"
         this.Write("            if (value.ValueKind == JsonValueKind.Object)\r\n            {\r\n        " +
                 "        return new ");
         
         #line default
         #line hidden
         
-        #line 1725 "SchemaEntity202012.tt"
+        #line 1781 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1725 "SchemaEntity202012.tt"
+        #line 1781 "SchemaEntity202012.tt"
         this.Write("(value.AsObject);\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1727 "SchemaEntity202012.tt"
+        #line 1783 "SchemaEntity202012.tt"
 
         }
         
@@ -5521,13 +5719,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1730 "SchemaEntity202012.tt"
+        #line 1786 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1730 "SchemaEntity202012.tt"
+        #line 1786 "SchemaEntity202012.tt"
 
         if(conversion.IsArray)
         {
@@ -5536,26 +5734,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1734 "SchemaEntity202012.tt"
+        #line 1790 "SchemaEntity202012.tt"
         this.Write("            if (value.ValueKind == JsonValueKind.Array)\r\n            {\r\n         " +
                 "       return new ");
         
         #line default
         #line hidden
         
-        #line 1736 "SchemaEntity202012.tt"
+        #line 1792 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1736 "SchemaEntity202012.tt"
+        #line 1792 "SchemaEntity202012.tt"
         this.Write("(value.AsArray);\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1738 "SchemaEntity202012.tt"
+        #line 1794 "SchemaEntity202012.tt"
 
         }
         
@@ -5563,13 +5761,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1741 "SchemaEntity202012.tt"
+        #line 1797 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1741 "SchemaEntity202012.tt"
+        #line 1797 "SchemaEntity202012.tt"
 
         if(conversion.IsString)
         {
@@ -5578,26 +5776,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1745 "SchemaEntity202012.tt"
+        #line 1801 "SchemaEntity202012.tt"
         this.Write("            if (value.ValueKind == JsonValueKind.String)\r\n            {\r\n        " +
                 "        return new ");
         
         #line default
         #line hidden
         
-        #line 1747 "SchemaEntity202012.tt"
+        #line 1803 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1747 "SchemaEntity202012.tt"
+        #line 1803 "SchemaEntity202012.tt"
         this.Write("(value.AsString);\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1749 "SchemaEntity202012.tt"
+        #line 1805 "SchemaEntity202012.tt"
 
         }
         
@@ -5605,13 +5803,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1752 "SchemaEntity202012.tt"
+        #line 1808 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1752 "SchemaEntity202012.tt"
+        #line 1808 "SchemaEntity202012.tt"
 
         if(conversion.IsBoolean)
         {
@@ -5620,26 +5818,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1756 "SchemaEntity202012.tt"
+        #line 1812 "SchemaEntity202012.tt"
         this.Write("            if (value.ValueKind == JsonValueKind.True || value.ValueKind == JsonV" +
                 "alueKind.False)\r\n            {\r\n                return new ");
         
         #line default
         #line hidden
         
-        #line 1758 "SchemaEntity202012.tt"
+        #line 1814 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1758 "SchemaEntity202012.tt"
+        #line 1814 "SchemaEntity202012.tt"
         this.Write("(value.AsBoolean);\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1760 "SchemaEntity202012.tt"
+        #line 1816 "SchemaEntity202012.tt"
 
         }
         
@@ -5647,13 +5845,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1763 "SchemaEntity202012.tt"
+        #line 1819 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 1763 "SchemaEntity202012.tt"
+        #line 1819 "SchemaEntity202012.tt"
 
         if(conversion.IsNumber)
         {
@@ -5662,26 +5860,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1767 "SchemaEntity202012.tt"
+        #line 1823 "SchemaEntity202012.tt"
         this.Write("            if (value.ValueKind == JsonValueKind.Number)\r\n            {\r\n        " +
                 "        return new ");
         
         #line default
         #line hidden
         
-        #line 1769 "SchemaEntity202012.tt"
+        #line 1825 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1769 "SchemaEntity202012.tt"
+        #line 1825 "SchemaEntity202012.tt"
         this.Write("(value.AsNumber);\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1771 "SchemaEntity202012.tt"
+        #line 1827 "SchemaEntity202012.tt"
 
         }
         
@@ -5689,13 +5887,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1774 "SchemaEntity202012.tt"
+        #line 1830 "SchemaEntity202012.tt"
         this.Write("            return default;\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1776 "SchemaEntity202012.tt"
+        #line 1832 "SchemaEntity202012.tt"
 
     }
     
@@ -5703,13 +5901,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1779 "SchemaEntity202012.tt"
+        #line 1835 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 1780 "SchemaEntity202012.tt"
+        #line 1836 "SchemaEntity202012.tt"
 
     foreach(Conversion conversion in ConversionsViaCast)
     {
@@ -5718,112 +5916,112 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1784 "SchemaEntity202012.tt"
+        #line 1840 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Conversion from <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 1785 "SchemaEntity202012.tt"
+        #line 1841 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1785 "SchemaEntity202012.tt"
+        #line 1841 "SchemaEntity202012.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        /// <param name=\"value\">The value from whi" +
                 "ch to convert.</param>\r\n        public static implicit operator ");
         
         #line default
         #line hidden
         
-        #line 1788 "SchemaEntity202012.tt"
+        #line 1844 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1788 "SchemaEntity202012.tt"
+        #line 1844 "SchemaEntity202012.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 1788 "SchemaEntity202012.tt"
+        #line 1844 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1788 "SchemaEntity202012.tt"
+        #line 1844 "SchemaEntity202012.tt"
         this.Write(" value)\r\n        {\r\n            return (");
         
         #line default
         #line hidden
         
-        #line 1790 "SchemaEntity202012.tt"
+        #line 1846 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.ConvertViaDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1790 "SchemaEntity202012.tt"
+        #line 1846 "SchemaEntity202012.tt"
         this.Write(")value;\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to <see cref=" +
                 "\"");
         
         #line default
         #line hidden
         
-        #line 1794 "SchemaEntity202012.tt"
+        #line 1850 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1794 "SchemaEntity202012.tt"
+        #line 1850 "SchemaEntity202012.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        /// <param name=\"value\">The value from whi" +
                 "ch to convert.</param>\r\n        public static implicit operator ");
         
         #line default
         #line hidden
         
-        #line 1797 "SchemaEntity202012.tt"
+        #line 1853 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1797 "SchemaEntity202012.tt"
+        #line 1853 "SchemaEntity202012.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 1797 "SchemaEntity202012.tt"
+        #line 1853 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1797 "SchemaEntity202012.tt"
+        #line 1853 "SchemaEntity202012.tt"
         this.Write(" value)\r\n        {\r\n            return (");
         
         #line default
         #line hidden
         
-        #line 1799 "SchemaEntity202012.tt"
+        #line 1855 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( conversion.ConvertViaDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1799 "SchemaEntity202012.tt"
+        #line 1855 "SchemaEntity202012.tt"
         this.Write(")value;\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1801 "SchemaEntity202012.tt"
+        #line 1857 "SchemaEntity202012.tt"
 
     }
     
@@ -5831,7 +6029,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1804 "SchemaEntity202012.tt"
+        #line 1860 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from any.\r\n        /// </summary>" +
                 "\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n    " +
                 "    public static implicit operator ");
@@ -5839,38 +6037,38 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1809 "SchemaEntity202012.tt"
+        #line 1865 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1809 "SchemaEntity202012.tt"
+        #line 1865 "SchemaEntity202012.tt"
         this.Write("(JsonAny value)\r\n        {\r\n            if (value.HasJsonElement)\r\n            {\r" +
                 "\n                return new ");
         
         #line default
         #line hidden
         
-        #line 1813 "SchemaEntity202012.tt"
+        #line 1869 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1813 "SchemaEntity202012.tt"
+        #line 1869 "SchemaEntity202012.tt"
         this.Write("(value.AsJsonElement);\r\n            }\r\n\r\n            return value.As<");
         
         #line default
         #line hidden
         
-        #line 1816 "SchemaEntity202012.tt"
+        #line 1872 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1816 "SchemaEntity202012.tt"
+        #line 1872 "SchemaEntity202012.tt"
         this.Write(">();\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to any.\r\n       " +
                 " /// </summary>\r\n        /// <param name=\"value\">The value from which to convert" +
                 ".</param>\r\n        public static implicit operator JsonAny(");
@@ -5878,19 +6076,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1823 "SchemaEntity202012.tt"
+        #line 1879 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1823 "SchemaEntity202012.tt"
+        #line 1879 "SchemaEntity202012.tt"
         this.Write(" value)\r\n        {\r\n            return value.AsAny;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1828 "SchemaEntity202012.tt"
+        #line 1884 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -5899,7 +6097,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1832 "SchemaEntity202012.tt"
+        #line 1888 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from array.\r\n        /// </summar" +
                 "y>\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n  " +
                 "      public static implicit operator ");
@@ -5907,25 +6105,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1837 "SchemaEntity202012.tt"
+        #line 1893 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1837 "SchemaEntity202012.tt"
+        #line 1893 "SchemaEntity202012.tt"
         this.Write("(JsonArray value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1839 "SchemaEntity202012.tt"
+        #line 1895 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1839 "SchemaEntity202012.tt"
+        #line 1895 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to array.\r\n " +
                 "       /// </summary>\r\n        /// <param name=\"value\">The value from which to c" +
                 "onvert.</param>\r\n        public static implicit operator JsonArray(");
@@ -5933,13 +6131,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1846 "SchemaEntity202012.tt"
+        #line 1902 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1846 "SchemaEntity202012.tt"
+        #line 1902 "SchemaEntity202012.tt"
         this.Write(@" value)
         {
             return value.AsArray;
@@ -5954,13 +6152,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1855 "SchemaEntity202012.tt"
+        #line 1911 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1855 "SchemaEntity202012.tt"
+        #line 1911 "SchemaEntity202012.tt"
         this.Write(@" value)
         {
             return value.AsArray.AsItemsList;
@@ -5975,31 +6173,31 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1864 "SchemaEntity202012.tt"
+        #line 1920 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1864 "SchemaEntity202012.tt"
+        #line 1920 "SchemaEntity202012.tt"
         this.Write("(ImmutableList<JsonAny> value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1866 "SchemaEntity202012.tt"
+        #line 1922 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1866 "SchemaEntity202012.tt"
+        #line 1922 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1868 "SchemaEntity202012.tt"
+        #line 1924 "SchemaEntity202012.tt"
 
     }
     
@@ -6007,13 +6205,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1871 "SchemaEntity202012.tt"
+        #line 1927 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1872 "SchemaEntity202012.tt"
+        #line 1928 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -6022,7 +6220,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1876 "SchemaEntity202012.tt"
+        #line 1932 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from object.\r\n        /// </summa" +
                 "ry>\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n " +
                 "       public static implicit operator ");
@@ -6030,25 +6228,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1881 "SchemaEntity202012.tt"
+        #line 1937 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1881 "SchemaEntity202012.tt"
+        #line 1937 "SchemaEntity202012.tt"
         this.Write("(JsonObject value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1883 "SchemaEntity202012.tt"
+        #line 1939 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1883 "SchemaEntity202012.tt"
+        #line 1939 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to object.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"value\">The value from which to " +
                 "convert.</param>\r\n        public static implicit operator JsonObject(");
@@ -6056,13 +6254,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1890 "SchemaEntity202012.tt"
+        #line 1946 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1890 "SchemaEntity202012.tt"
+        #line 1946 "SchemaEntity202012.tt"
         this.Write(@" value)
         {
             return value.AsObject;
@@ -6077,13 +6275,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1899 "SchemaEntity202012.tt"
+        #line 1955 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1899 "SchemaEntity202012.tt"
+        #line 1955 "SchemaEntity202012.tt"
         this.Write(@"  value)
         {
             return value.AsObject.AsPropertyDictionary;
@@ -6098,32 +6296,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1908 "SchemaEntity202012.tt"
+        #line 1964 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1908 "SchemaEntity202012.tt"
+        #line 1964 "SchemaEntity202012.tt"
         this.Write(" (ImmutableDictionary<string, JsonAny> value)\r\n        {\r\n            return new " +
                 "");
         
         #line default
         #line hidden
         
-        #line 1910 "SchemaEntity202012.tt"
+        #line 1966 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1910 "SchemaEntity202012.tt"
+        #line 1966 "SchemaEntity202012.tt"
         this.Write(" (value);\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1913 "SchemaEntity202012.tt"
+        #line 1969 "SchemaEntity202012.tt"
 
     }
     
@@ -6131,13 +6329,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1916 "SchemaEntity202012.tt"
+        #line 1972 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1917 "SchemaEntity202012.tt"
+        #line 1973 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -6146,7 +6344,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1921 "SchemaEntity202012.tt"
+        #line 1977 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from string.\r\n        /// </summa" +
                 "ry>\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n " +
                 "       public static implicit operator ");
@@ -6154,25 +6352,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1926 "SchemaEntity202012.tt"
+        #line 1982 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1926 "SchemaEntity202012.tt"
+        #line 1982 "SchemaEntity202012.tt"
         this.Write("(string value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1928 "SchemaEntity202012.tt"
+        #line 1984 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1928 "SchemaEntity202012.tt"
+        #line 1984 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to string.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"value\">The number from which to" +
                 " convert.</param>\r\n        public static implicit operator string(");
@@ -6180,13 +6378,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1935 "SchemaEntity202012.tt"
+        #line 1991 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1935 "SchemaEntity202012.tt"
+        #line 1991 "SchemaEntity202012.tt"
         this.Write(@" value)
         {
             return value.AsString;
@@ -6201,25 +6399,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1944 "SchemaEntity202012.tt"
+        #line 2000 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1944 "SchemaEntity202012.tt"
+        #line 2000 "SchemaEntity202012.tt"
         this.Write("(ReadOnlySpan<char> value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1946 "SchemaEntity202012.tt"
+        #line 2002 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1946 "SchemaEntity202012.tt"
+        #line 2002 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to string.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"value\">The number from which to" +
                 " convert.</param>\r\n        public static implicit operator ReadOnlySpan<char>(");
@@ -6227,13 +6425,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1953 "SchemaEntity202012.tt"
+        #line 2009 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1953 "SchemaEntity202012.tt"
+        #line 2009 "SchemaEntity202012.tt"
         this.Write(@" value)
         {
             return value.AsString;
@@ -6248,25 +6446,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1962 "SchemaEntity202012.tt"
+        #line 2018 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1962 "SchemaEntity202012.tt"
+        #line 2018 "SchemaEntity202012.tt"
         this.Write("(ReadOnlySpan<byte> value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1964 "SchemaEntity202012.tt"
+        #line 2020 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1964 "SchemaEntity202012.tt"
+        #line 2020 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to utf8 byte" +
                 "s.\r\n        /// </summary>\r\n        /// <param name=\"value\">The number from whic" +
                 "h to convert.</param>\r\n        public static implicit operator ReadOnlySpan<byte" +
@@ -6275,13 +6473,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1971 "SchemaEntity202012.tt"
+        #line 2027 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1971 "SchemaEntity202012.tt"
+        #line 2027 "SchemaEntity202012.tt"
         this.Write(@" value)
         {
             return value.AsString;
@@ -6296,25 +6494,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1980 "SchemaEntity202012.tt"
+        #line 2036 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1980 "SchemaEntity202012.tt"
+        #line 2036 "SchemaEntity202012.tt"
         this.Write("(JsonString value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 1982 "SchemaEntity202012.tt"
+        #line 2038 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1982 "SchemaEntity202012.tt"
+        #line 2038 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to string.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"value\">The value from which to " +
                 "convert.</param>\r\n        public static implicit operator JsonString(");
@@ -6322,19 +6520,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1989 "SchemaEntity202012.tt"
+        #line 2045 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 1989 "SchemaEntity202012.tt"
+        #line 2045 "SchemaEntity202012.tt"
         this.Write(" value)\r\n        {\r\n            return value.AsString;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1994 "SchemaEntity202012.tt"
+        #line 2050 "SchemaEntity202012.tt"
 
     }
     
@@ -6342,13 +6540,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 1997 "SchemaEntity202012.tt"
+        #line 2053 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 1998 "SchemaEntity202012.tt"
+        #line 2054 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -6357,7 +6555,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2002 "SchemaEntity202012.tt"
+        #line 2058 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from double.\r\n        /// </summa" +
                 "ry>\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n " +
                 "       public static implicit operator ");
@@ -6365,25 +6563,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2007 "SchemaEntity202012.tt"
+        #line 2063 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2007 "SchemaEntity202012.tt"
+        #line 2063 "SchemaEntity202012.tt"
         this.Write("(double value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2009 "SchemaEntity202012.tt"
+        #line 2065 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2009 "SchemaEntity202012.tt"
+        #line 2065 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to double.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"number\">The number from which t" +
                 "o convert.</param>\r\n        public static implicit operator double(");
@@ -6391,13 +6589,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2016 "SchemaEntity202012.tt"
+        #line 2072 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2016 "SchemaEntity202012.tt"
+        #line 2072 "SchemaEntity202012.tt"
         this.Write(@" number)
         {
             return number.AsNumber.GetDouble();
@@ -6412,25 +6610,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2025 "SchemaEntity202012.tt"
+        #line 2081 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2025 "SchemaEntity202012.tt"
+        #line 2081 "SchemaEntity202012.tt"
         this.Write("(float value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2027 "SchemaEntity202012.tt"
+        #line 2083 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2027 "SchemaEntity202012.tt"
+        #line 2083 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to float.\r\n " +
                 "       /// </summary>\r\n        /// <param name=\"number\">The number from which to" +
                 " convert.</param>\r\n        public static implicit operator float(");
@@ -6438,13 +6636,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2034 "SchemaEntity202012.tt"
+        #line 2090 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2034 "SchemaEntity202012.tt"
+        #line 2090 "SchemaEntity202012.tt"
         this.Write(@" number)
         {
             return number.AsNumber.GetSingle();
@@ -6459,25 +6657,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2043 "SchemaEntity202012.tt"
+        #line 2099 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2043 "SchemaEntity202012.tt"
+        #line 2099 "SchemaEntity202012.tt"
         this.Write("(long value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2045 "SchemaEntity202012.tt"
+        #line 2101 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2045 "SchemaEntity202012.tt"
+        #line 2101 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to long.\r\n  " +
                 "      /// </summary>\r\n        /// <param name=\"number\">The number from which to " +
                 "convert.</param>\r\n        public static implicit operator long(");
@@ -6485,13 +6683,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2052 "SchemaEntity202012.tt"
+        #line 2108 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2052 "SchemaEntity202012.tt"
+        #line 2108 "SchemaEntity202012.tt"
         this.Write(@" number)
         {
             return number.AsNumber.GetInt64();
@@ -6506,25 +6704,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2061 "SchemaEntity202012.tt"
+        #line 2117 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2061 "SchemaEntity202012.tt"
+        #line 2117 "SchemaEntity202012.tt"
         this.Write("(int value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2063 "SchemaEntity202012.tt"
+        #line 2119 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2063 "SchemaEntity202012.tt"
+        #line 2119 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to int.\r\n   " +
                 "     /// </summary>\r\n        /// <param name=\"number\">The number from which to c" +
                 "onvert.</param>\r\n        public static implicit operator int(");
@@ -6532,13 +6730,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2070 "SchemaEntity202012.tt"
+        #line 2126 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2070 "SchemaEntity202012.tt"
+        #line 2126 "SchemaEntity202012.tt"
         this.Write(@" number)
         {
             return number.AsNumber.GetInt32();
@@ -6553,25 +6751,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2079 "SchemaEntity202012.tt"
+        #line 2135 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2079 "SchemaEntity202012.tt"
+        #line 2135 "SchemaEntity202012.tt"
         this.Write("(JsonNumber value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2081 "SchemaEntity202012.tt"
+        #line 2137 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2081 "SchemaEntity202012.tt"
+        #line 2137 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to number.\r\n" +
                 "        /// </summary>\r\n        /// <param name=\"number\">The value from which to" +
                 " convert.</param>\r\n        public static implicit operator JsonNumber(");
@@ -6579,19 +6777,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2088 "SchemaEntity202012.tt"
+        #line 2144 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2088 "SchemaEntity202012.tt"
+        #line 2144 "SchemaEntity202012.tt"
         this.Write(" number)\r\n        {\r\n            return number.AsNumber;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2093 "SchemaEntity202012.tt"
+        #line 2149 "SchemaEntity202012.tt"
 
     }
     
@@ -6599,13 +6797,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2096 "SchemaEntity202012.tt"
+        #line 2152 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2097 "SchemaEntity202012.tt"
+        #line 2153 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -6614,7 +6812,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2101 "SchemaEntity202012.tt"
+        #line 2157 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Conversion from bool.\r\n        /// </summary" +
                 ">\r\n        /// <param name=\"value\">The value from which to convert.</param>\r\n   " +
                 "     public static implicit operator ");
@@ -6622,25 +6820,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2106 "SchemaEntity202012.tt"
+        #line 2162 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2106 "SchemaEntity202012.tt"
+        #line 2162 "SchemaEntity202012.tt"
         this.Write("(bool value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2108 "SchemaEntity202012.tt"
+        #line 2164 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2108 "SchemaEntity202012.tt"
+        #line 2164 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to bool.\r\n  " +
                 "      /// </summary>\r\n        /// <param name=\"boolean\">The value from which to " +
                 "convert.</param>\r\n        public static implicit operator bool(");
@@ -6648,13 +6846,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2115 "SchemaEntity202012.tt"
+        #line 2171 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2115 "SchemaEntity202012.tt"
+        #line 2171 "SchemaEntity202012.tt"
         this.Write(@" boolean)
         {
             return boolean.AsBoolean.GetBoolean();
@@ -6669,25 +6867,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2124 "SchemaEntity202012.tt"
+        #line 2180 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2124 "SchemaEntity202012.tt"
+        #line 2180 "SchemaEntity202012.tt"
         this.Write("(JsonBoolean value)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2126 "SchemaEntity202012.tt"
+        #line 2182 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2126 "SchemaEntity202012.tt"
+        #line 2182 "SchemaEntity202012.tt"
         this.Write("(value);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Conversion to bool.\r\n  " +
                 "      /// </summary>\r\n        /// <param name=\"boolean\">The value from which to " +
                 "convert.</param>\r\n        public static implicit operator JsonBoolean(");
@@ -6695,19 +6893,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2133 "SchemaEntity202012.tt"
+        #line 2189 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2133 "SchemaEntity202012.tt"
+        #line 2189 "SchemaEntity202012.tt"
         this.Write(" boolean)\r\n        {\r\n            return boolean.AsBoolean;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2138 "SchemaEntity202012.tt"
+        #line 2194 "SchemaEntity202012.tt"
 
     }
     
@@ -6715,7 +6913,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2141 "SchemaEntity202012.tt"
+        #line 2197 "SchemaEntity202012.tt"
         this.Write(@"
         /// <summary>
         /// Standard equality operator.
@@ -6728,25 +6926,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2148 "SchemaEntity202012.tt"
+        #line 2204 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2148 "SchemaEntity202012.tt"
+        #line 2204 "SchemaEntity202012.tt"
         this.Write(" lhs, ");
         
         #line default
         #line hidden
         
-        #line 2148 "SchemaEntity202012.tt"
+        #line 2204 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2148 "SchemaEntity202012.tt"
+        #line 2204 "SchemaEntity202012.tt"
         this.Write(@" rhs)
         {
             return lhs.Equals(rhs);
@@ -6763,31 +6961,31 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2159 "SchemaEntity202012.tt"
+        #line 2215 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2159 "SchemaEntity202012.tt"
+        #line 2215 "SchemaEntity202012.tt"
         this.Write(" lhs, ");
         
         #line default
         #line hidden
         
-        #line 2159 "SchemaEntity202012.tt"
+        #line 2215 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2159 "SchemaEntity202012.tt"
+        #line 2215 "SchemaEntity202012.tt"
         this.Write(" rhs)\r\n        {\r\n            return !lhs.Equals(rhs);\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2164 "SchemaEntity202012.tt"
+        #line 2220 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -6796,13 +6994,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2168 "SchemaEntity202012.tt"
+        #line 2224 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 2168 "SchemaEntity202012.tt"
+        #line 2224 "SchemaEntity202012.tt"
 
         if (CanEnumerateAsSpecificType)
         {
@@ -6811,7 +7009,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2172 "SchemaEntity202012.tt"
+        #line 2228 "SchemaEntity202012.tt"
         this.Write(@"        /// <summary>
         /// Create an array from the given items.
         /// </summary>
@@ -6822,25 +7020,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2177 "SchemaEntity202012.tt"
+        #line 2233 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2177 "SchemaEntity202012.tt"
+        #line 2233 "SchemaEntity202012.tt"
         this.Write(" From(params ");
         
         #line default
         #line hidden
         
-        #line 2177 "SchemaEntity202012.tt"
+        #line 2233 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2177 "SchemaEntity202012.tt"
+        #line 2233 "SchemaEntity202012.tt"
         this.Write("[] items)\r\n        {\r\n            var builder = ImmutableList.CreateBuilder<JsonA" +
                 "ny>();\r\n            foreach (var item in items)\r\n            {\r\n                " +
                 "builder.Add(item);\r\n            }\r\n\r\n            return new ");
@@ -6848,13 +7046,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2185 "SchemaEntity202012.tt"
+        #line 2241 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2185 "SchemaEntity202012.tt"
+        #line 2241 "SchemaEntity202012.tt"
         this.Write(@"(builder.ToImmutable());
         }
 
@@ -6868,37 +7066,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2193 "SchemaEntity202012.tt"
+        #line 2249 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2193 "SchemaEntity202012.tt"
+        #line 2249 "SchemaEntity202012.tt"
         this.Write(" From(");
         
         #line default
         #line hidden
         
-        #line 2193 "SchemaEntity202012.tt"
+        #line 2249 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2193 "SchemaEntity202012.tt"
+        #line 2249 "SchemaEntity202012.tt"
         this.Write(" item1)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2195 "SchemaEntity202012.tt"
+        #line 2251 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2195 "SchemaEntity202012.tt"
+        #line 2251 "SchemaEntity202012.tt"
         this.Write(@"(ImmutableList.Create((JsonAny)item1));
         }
 
@@ -6913,49 +7111,49 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2204 "SchemaEntity202012.tt"
+        #line 2260 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2204 "SchemaEntity202012.tt"
+        #line 2260 "SchemaEntity202012.tt"
         this.Write(" From(");
         
         #line default
         #line hidden
         
-        #line 2204 "SchemaEntity202012.tt"
+        #line 2260 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2204 "SchemaEntity202012.tt"
+        #line 2260 "SchemaEntity202012.tt"
         this.Write(" item1, ");
         
         #line default
         #line hidden
         
-        #line 2204 "SchemaEntity202012.tt"
+        #line 2260 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2204 "SchemaEntity202012.tt"
+        #line 2260 "SchemaEntity202012.tt"
         this.Write(" item2)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2206 "SchemaEntity202012.tt"
+        #line 2262 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2206 "SchemaEntity202012.tt"
+        #line 2262 "SchemaEntity202012.tt"
         this.Write(@"(ImmutableList.Create((JsonAny)item1, (JsonAny)item2));
         }
 
@@ -6971,61 +7169,61 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2216 "SchemaEntity202012.tt"
+        #line 2272 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2216 "SchemaEntity202012.tt"
+        #line 2272 "SchemaEntity202012.tt"
         this.Write(" From(");
         
         #line default
         #line hidden
         
-        #line 2216 "SchemaEntity202012.tt"
+        #line 2272 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2216 "SchemaEntity202012.tt"
+        #line 2272 "SchemaEntity202012.tt"
         this.Write(" item1, ");
         
         #line default
         #line hidden
         
-        #line 2216 "SchemaEntity202012.tt"
+        #line 2272 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2216 "SchemaEntity202012.tt"
+        #line 2272 "SchemaEntity202012.tt"
         this.Write(" item2, ");
         
         #line default
         #line hidden
         
-        #line 2216 "SchemaEntity202012.tt"
+        #line 2272 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2216 "SchemaEntity202012.tt"
+        #line 2272 "SchemaEntity202012.tt"
         this.Write(" item3)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2218 "SchemaEntity202012.tt"
+        #line 2274 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2218 "SchemaEntity202012.tt"
+        #line 2274 "SchemaEntity202012.tt"
         this.Write(@"(ImmutableList.Create((JsonAny)item1, (JsonAny)item2, (JsonAny)item3));
         }
 
@@ -7042,80 +7240,80 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2229 "SchemaEntity202012.tt"
+        #line 2285 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2229 "SchemaEntity202012.tt"
+        #line 2285 "SchemaEntity202012.tt"
         this.Write(" From(");
         
         #line default
         #line hidden
         
-        #line 2229 "SchemaEntity202012.tt"
+        #line 2285 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2229 "SchemaEntity202012.tt"
+        #line 2285 "SchemaEntity202012.tt"
         this.Write(" item1, ");
         
         #line default
         #line hidden
         
-        #line 2229 "SchemaEntity202012.tt"
+        #line 2285 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2229 "SchemaEntity202012.tt"
+        #line 2285 "SchemaEntity202012.tt"
         this.Write(" item2, ");
         
         #line default
         #line hidden
         
-        #line 2229 "SchemaEntity202012.tt"
+        #line 2285 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2229 "SchemaEntity202012.tt"
+        #line 2285 "SchemaEntity202012.tt"
         this.Write(" item3, ");
         
         #line default
         #line hidden
         
-        #line 2229 "SchemaEntity202012.tt"
+        #line 2285 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2229 "SchemaEntity202012.tt"
+        #line 2285 "SchemaEntity202012.tt"
         this.Write(" item4)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2231 "SchemaEntity202012.tt"
+        #line 2287 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2231 "SchemaEntity202012.tt"
+        #line 2287 "SchemaEntity202012.tt"
         this.Write("(ImmutableList.Create((JsonAny)item1, (JsonAny)item2, (JsonAny)item3, (JsonAny)it" +
                 "em4));\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2233 "SchemaEntity202012.tt"
+        #line 2289 "SchemaEntity202012.tt"
 
         }
         else
@@ -7125,7 +7323,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2238 "SchemaEntity202012.tt"
+        #line 2294 "SchemaEntity202012.tt"
         this.Write(@"                /// <summary>
         /// Create an array from the given items.
         /// </summary>
@@ -7136,25 +7334,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2243 "SchemaEntity202012.tt"
+        #line 2299 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2243 "SchemaEntity202012.tt"
+        #line 2299 "SchemaEntity202012.tt"
         this.Write(" From(params JsonAny[] items)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2245 "SchemaEntity202012.tt"
+        #line 2301 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2245 "SchemaEntity202012.tt"
+        #line 2301 "SchemaEntity202012.tt"
         this.Write(@"(items.ToImmutableList());
         }
 
@@ -7168,25 +7366,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2253 "SchemaEntity202012.tt"
+        #line 2309 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2253 "SchemaEntity202012.tt"
+        #line 2309 "SchemaEntity202012.tt"
         this.Write(" From(JsonAny item1)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2255 "SchemaEntity202012.tt"
+        #line 2311 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2255 "SchemaEntity202012.tt"
+        #line 2311 "SchemaEntity202012.tt"
         this.Write(@"(ImmutableList.Create(item1));
         }
 
@@ -7201,25 +7399,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2264 "SchemaEntity202012.tt"
+        #line 2320 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2264 "SchemaEntity202012.tt"
+        #line 2320 "SchemaEntity202012.tt"
         this.Write(" From(JsonAny item1, JsonAny item2)\r\n        {\r\n            return new ");
         
         #line default
         #line hidden
         
-        #line 2266 "SchemaEntity202012.tt"
+        #line 2322 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2266 "SchemaEntity202012.tt"
+        #line 2322 "SchemaEntity202012.tt"
         this.Write(@"(ImmutableList.Create(item1, item2));
         }
 
@@ -7235,26 +7433,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2276 "SchemaEntity202012.tt"
+        #line 2332 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2276 "SchemaEntity202012.tt"
+        #line 2332 "SchemaEntity202012.tt"
         this.Write(" From(JsonAny item1, JsonAny item2, JsonAny item3)\r\n        {\r\n            return" +
                 " new ");
         
         #line default
         #line hidden
         
-        #line 2278 "SchemaEntity202012.tt"
+        #line 2334 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2278 "SchemaEntity202012.tt"
+        #line 2334 "SchemaEntity202012.tt"
         this.Write(@"(ImmutableList.Create(item1, item2, item3));
         }
 
@@ -7271,32 +7469,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2289 "SchemaEntity202012.tt"
+        #line 2345 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2289 "SchemaEntity202012.tt"
+        #line 2345 "SchemaEntity202012.tt"
         this.Write(" From(JsonAny item1, JsonAny item2, JsonAny item3, JsonAny item4)\r\n        {\r\n   " +
                 "         return new ");
         
         #line default
         #line hidden
         
-        #line 2291 "SchemaEntity202012.tt"
+        #line 2347 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2291 "SchemaEntity202012.tt"
+        #line 2347 "SchemaEntity202012.tt"
         this.Write("(ImmutableList.Create(item1, item2, item3, item4));\r\n        }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2293 "SchemaEntity202012.tt"
+        #line 2349 "SchemaEntity202012.tt"
 
         }
         
@@ -7304,13 +7502,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2296 "SchemaEntity202012.tt"
+        #line 2352 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2297 "SchemaEntity202012.tt"
+        #line 2353 "SchemaEntity202012.tt"
 
     }
     
@@ -7318,13 +7516,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2300 "SchemaEntity202012.tt"
+        #line 2356 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2301 "SchemaEntity202012.tt"
+        #line 2357 "SchemaEntity202012.tt"
 
     if (HasProperties)
     {
@@ -7333,111 +7531,114 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2305 "SchemaEntity202012.tt"
+        #line 2361 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Creates an instance of a <see cref=\"");
         
         #line default
         #line hidden
         
-        #line 2306 "SchemaEntity202012.tt"
+        #line 2362 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2306 "SchemaEntity202012.tt"
+        #line 2362 "SchemaEntity202012.tt"
         this.Write("\"/>.\r\n        /// </summary>\r\n        public static ");
         
         #line default
         #line hidden
         
-        #line 2308 "SchemaEntity202012.tt"
+        #line 2364 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2308 "SchemaEntity202012.tt"
+        #line 2364 "SchemaEntity202012.tt"
         this.Write(" Create(\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2309 "SchemaEntity202012.tt"
+        #line 2365 "SchemaEntity202012.tt"
 
         bool isFirstCreateParameter = true;
         foreach(var property in RequiredAllOfAndRefProperties)
         {
-            if (isFirstCreateParameter)
-            {
-                isFirstCreateParameter = false;
-            }
-            else
-            {
+            if (!IsConst(property.Type))
+            {           
+                if (isFirstCreateParameter)
+                {
+                    isFirstCreateParameter = false;
+                }
+                else
+                {
         
         
         #line default
         #line hidden
         
-        #line 2320 "SchemaEntity202012.tt"
+        #line 2378 "SchemaEntity202012.tt"
         this.Write(", ");
         
         #line default
         #line hidden
         
-        #line 2320 "SchemaEntity202012.tt"
+        #line 2378 "SchemaEntity202012.tt"
 
-            }
+                }
         
         
         #line default
         #line hidden
         
-        #line 2323 "SchemaEntity202012.tt"
+        #line 2381 "SchemaEntity202012.tt"
         this.Write("           ");
         
         #line default
         #line hidden
         
-        #line 2323 "SchemaEntity202012.tt"
+        #line 2381 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2323 "SchemaEntity202012.tt"
+        #line 2381 "SchemaEntity202012.tt"
         this.Write(" ");
         
         #line default
         #line hidden
         
-        #line 2323 "SchemaEntity202012.tt"
+        #line 2381 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2323 "SchemaEntity202012.tt"
+        #line 2381 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2324 "SchemaEntity202012.tt"
+        #line 2382 "SchemaEntity202012.tt"
 
+            }
         }
         
         
         #line default
         #line hidden
         
-        #line 2327 "SchemaEntity202012.tt"
+        #line 2386 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 2327 "SchemaEntity202012.tt"
+        #line 2386 "SchemaEntity202012.tt"
 
         foreach(var property in OptionalAllOfAndRefProperties)
         {
@@ -7452,13 +7653,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2337 "SchemaEntity202012.tt"
+        #line 2396 "SchemaEntity202012.tt"
         this.Write(", ");
         
         #line default
         #line hidden
         
-        #line 2337 "SchemaEntity202012.tt"
+        #line 2396 "SchemaEntity202012.tt"
 
             }
         
@@ -7466,37 +7667,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2340 "SchemaEntity202012.tt"
+        #line 2399 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 2340 "SchemaEntity202012.tt"
+        #line 2399 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2340 "SchemaEntity202012.tt"
+        #line 2399 "SchemaEntity202012.tt"
         this.Write("? ");
         
         #line default
         #line hidden
         
-        #line 2340 "SchemaEntity202012.tt"
+        #line 2399 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2340 "SchemaEntity202012.tt"
+        #line 2399 "SchemaEntity202012.tt"
         this.Write(" = null\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2341 "SchemaEntity202012.tt"
+        #line 2400 "SchemaEntity202012.tt"
 
         }
         
@@ -7504,67 +7705,110 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2344 "SchemaEntity202012.tt"
+        #line 2403 "SchemaEntity202012.tt"
         this.Write("\r\n        )\r\n        {\r\n            var builder = ImmutableDictionary.CreateBuild" +
                 "er<string, JsonAny>();\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2348 "SchemaEntity202012.tt"
+        #line 2407 "SchemaEntity202012.tt"
 
         foreach(var property in RequiredAllOfAndRefProperties)
         {
+            if (IsConst(property.Type))
+            {
         
         
         #line default
         #line hidden
         
-        #line 2352 "SchemaEntity202012.tt"
+        #line 2413 "SchemaEntity202012.tt"
         this.Write("            builder.Add(");
         
         #line default
         #line hidden
         
-        #line 2352 "SchemaEntity202012.tt"
+        #line 2413 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName));
         
         #line default
         #line hidden
         
-        #line 2352 "SchemaEntity202012.tt"
+        #line 2413 "SchemaEntity202012.tt"
+        this.Write("JsonPropertyName, new ");
+        
+        #line default
+        #line hidden
+        
+        #line 2413 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 2413 "SchemaEntity202012.tt"
+        this.Write("());\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 2414 "SchemaEntity202012.tt"
+
+            }
+            else
+            {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 2419 "SchemaEntity202012.tt"
+        this.Write("            builder.Add(");
+        
+        #line default
+        #line hidden
+        
+        #line 2419 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName));
+        
+        #line default
+        #line hidden
+        
+        #line 2419 "SchemaEntity202012.tt"
         this.Write("JsonPropertyName, ");
         
         #line default
         #line hidden
         
-        #line 2352 "SchemaEntity202012.tt"
+        #line 2419 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2352 "SchemaEntity202012.tt"
+        #line 2419 "SchemaEntity202012.tt"
         this.Write(");\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2353 "SchemaEntity202012.tt"
+        #line 2420 "SchemaEntity202012.tt"
 
+            }
         }
         
         
         #line default
         #line hidden
         
-        #line 2356 "SchemaEntity202012.tt"
+        #line 2424 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 2356 "SchemaEntity202012.tt"
+        #line 2424 "SchemaEntity202012.tt"
 
         foreach(var property in OptionalAllOfAndRefProperties)
         {
@@ -7573,108 +7817,152 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2360 "SchemaEntity202012.tt"
+        #line 2428 "SchemaEntity202012.tt"
         this.Write("            if (");
         
         #line default
         #line hidden
         
-        #line 2360 "SchemaEntity202012.tt"
+        #line 2428 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2360 "SchemaEntity202012.tt"
+        #line 2428 "SchemaEntity202012.tt"
         this.Write(" is ");
         
         #line default
         #line hidden
         
-        #line 2360 "SchemaEntity202012.tt"
+        #line 2428 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2360 "SchemaEntity202012.tt"
+        #line 2428 "SchemaEntity202012.tt"
         this.Write(" ");
         
         #line default
         #line hidden
         
-        #line 2360 "SchemaEntity202012.tt"
+        #line 2428 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2360 "SchemaEntity202012.tt"
+        #line 2428 "SchemaEntity202012.tt"
         this.Write("__)\r\n            {\r\n                builder.Add(");
         
         #line default
         #line hidden
         
-        #line 2362 "SchemaEntity202012.tt"
+        #line 2430 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName));
         
         #line default
         #line hidden
         
-        #line 2362 "SchemaEntity202012.tt"
+        #line 2430 "SchemaEntity202012.tt"
         this.Write("JsonPropertyName, ");
         
         #line default
         #line hidden
         
-        #line 2362 "SchemaEntity202012.tt"
+        #line 2430 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetParameterName ));
         
         #line default
         #line hidden
         
-        #line 2362 "SchemaEntity202012.tt"
-        this.Write("__);\r\n            }\r\n        ");
+        #line 2430 "SchemaEntity202012.tt"
+        this.Write("__);\r\n            }            \r\n        ");
         
         #line default
         #line hidden
         
-        #line 2364 "SchemaEntity202012.tt"
+        #line 2432 "SchemaEntity202012.tt"
 
+            if (IsConst(property.Type))
+            {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 2436 "SchemaEntity202012.tt"
+        this.Write("            else\r\n            {\r\n                builder.Add(");
+        
+        #line default
+        #line hidden
+        
+        #line 2438 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName));
+        
+        #line default
+        #line hidden
+        
+        #line 2438 "SchemaEntity202012.tt"
+        this.Write("JsonPropertyName, new ");
+        
+        #line default
+        #line hidden
+        
+        #line 2438 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 2438 "SchemaEntity202012.tt"
+        this.Write("());\r\n            }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 2440 "SchemaEntity202012.tt"
+
+            }
         }
         
         
         #line default
         #line hidden
         
-        #line 2367 "SchemaEntity202012.tt"
+        #line 2444 "SchemaEntity202012.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2370 "SchemaEntity202012.tt"
+        #line 2447 "SchemaEntity202012.tt"
 
         foreach(var property in Properties)
         {
+            if (IsConst(property.Type))
+            {
+                continue;
+            }
         
         
         #line default
         #line hidden
         
-        #line 2374 "SchemaEntity202012.tt"
+        #line 2455 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <summary>\r\n        /// Sets ");
         
         #line default
         #line hidden
         
-        #line 2376 "SchemaEntity202012.tt"
+        #line 2457 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(property.JsonPropertyName, true).Trim('"') ));
         
         #line default
         #line hidden
         
-        #line 2376 "SchemaEntity202012.tt"
+        #line 2457 "SchemaEntity202012.tt"
         this.Write(".\r\n        /// </summary>\r\n        /// <param name=\"value\">The value to set.</par" +
                 "am>\r\n        /// <returns>The entity with the updated property.</returns>\r\n     " +
                 "   public ");
@@ -7682,55 +7970,55 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2380 "SchemaEntity202012.tt"
+        #line 2461 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2380 "SchemaEntity202012.tt"
+        #line 2461 "SchemaEntity202012.tt"
         this.Write(" With");
         
         #line default
         #line hidden
         
-        #line 2380 "SchemaEntity202012.tt"
+        #line 2461 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 2380 "SchemaEntity202012.tt"
+        #line 2461 "SchemaEntity202012.tt"
         this.Write("(");
         
         #line default
         #line hidden
         
-        #line 2380 "SchemaEntity202012.tt"
+        #line 2461 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2380 "SchemaEntity202012.tt"
+        #line 2461 "SchemaEntity202012.tt"
         this.Write(" value)\r\n        {\r\n            return this.SetProperty(");
         
         #line default
         #line hidden
         
-        #line 2382 "SchemaEntity202012.tt"
+        #line 2463 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 2382 "SchemaEntity202012.tt"
+        #line 2463 "SchemaEntity202012.tt"
         this.Write("JsonPropertyName, value);\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2385 "SchemaEntity202012.tt"
+        #line 2466 "SchemaEntity202012.tt"
 
         }
         
@@ -7738,13 +8026,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2388 "SchemaEntity202012.tt"
+        #line 2469 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2389 "SchemaEntity202012.tt"
+        #line 2470 "SchemaEntity202012.tt"
 
     }
     
@@ -7752,7 +8040,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2392 "SchemaEntity202012.tt"
+        #line 2473 "SchemaEntity202012.tt"
         this.Write(@"
         /// <inheritdoc/>
         public override string ToString()
@@ -7783,7 +8071,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2417 "SchemaEntity202012.tt"
+        #line 2498 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -7792,13 +8080,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2421 "SchemaEntity202012.tt"
+        #line 2502 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2422 "SchemaEntity202012.tt"
+        #line 2503 "SchemaEntity202012.tt"
 
     }
     else
@@ -7808,13 +8096,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2427 "SchemaEntity202012.tt"
+        #line 2508 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2428 "SchemaEntity202012.tt"
+        #line 2509 "SchemaEntity202012.tt"
 
     }
     
@@ -7822,13 +8110,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2431 "SchemaEntity202012.tt"
+        #line 2512 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2431 "SchemaEntity202012.tt"
+        #line 2512 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -7837,13 +8125,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2435 "SchemaEntity202012.tt"
+        #line 2516 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2436 "SchemaEntity202012.tt"
+        #line 2517 "SchemaEntity202012.tt"
 
     }
     else
@@ -7853,13 +8141,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2441 "SchemaEntity202012.tt"
+        #line 2522 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2442 "SchemaEntity202012.tt"
+        #line 2523 "SchemaEntity202012.tt"
 
     }
     
@@ -7867,13 +8155,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2445 "SchemaEntity202012.tt"
+        #line 2526 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2445 "SchemaEntity202012.tt"
+        #line 2526 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -7882,13 +8170,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2449 "SchemaEntity202012.tt"
+        #line 2530 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2450 "SchemaEntity202012.tt"
+        #line 2531 "SchemaEntity202012.tt"
 
     }
     else
@@ -7898,13 +8186,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2455 "SchemaEntity202012.tt"
+        #line 2536 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2456 "SchemaEntity202012.tt"
+        #line 2537 "SchemaEntity202012.tt"
 
     }
     
@@ -7912,13 +8200,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2459 "SchemaEntity202012.tt"
+        #line 2540 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2459 "SchemaEntity202012.tt"
+        #line 2540 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -7927,13 +8215,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2463 "SchemaEntity202012.tt"
+        #line 2544 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString.GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2464 "SchemaEntity202012.tt"
+        #line 2545 "SchemaEntity202012.tt"
 
     }
     else
@@ -7943,13 +8231,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2469 "SchemaEntity202012.tt"
+        #line 2550 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString().GetHashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2470 "SchemaEntity202012.tt"
+        #line 2551 "SchemaEntity202012.tt"
 
     }
     
@@ -7957,13 +8245,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2473 "SchemaEntity202012.tt"
+        #line 2554 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2473 "SchemaEntity202012.tt"
+        #line 2554 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -7972,14 +8260,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2477 "SchemaEntity202012.tt"
+        #line 2558 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.GetHa" +
                 "shCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2478 "SchemaEntity202012.tt"
+        #line 2559 "SchemaEntity202012.tt"
 
     }
     else
@@ -7989,14 +8277,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2483 "SchemaEntity202012.tt"
+        #line 2564 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Get" +
                 "HashCode(),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2484 "SchemaEntity202012.tt"
+        #line 2565 "SchemaEntity202012.tt"
 
     }
     
@@ -8004,7 +8292,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2487 "SchemaEntity202012.tt"
+        #line 2568 "SchemaEntity202012.tt"
         this.Write(@"                JsonValueKind.Null => JsonNull.NullHashCode,
                 _ => JsonAny.UndefinedHashCode,
             };
@@ -8021,7 +8309,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2498 "SchemaEntity202012.tt"
+        #line 2579 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -8030,7 +8318,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2502 "SchemaEntity202012.tt"
+        #line 2583 "SchemaEntity202012.tt"
         this.Write("            if (this.objectBacking is ImmutableDictionary<string, JsonAny> object" +
                 "Backing)\r\n            {\r\n                JsonObject.WriteProperties(objectBackin" +
                 "g, writer);\r\n                return;\r\n            }\r\n\r\n    ");
@@ -8038,7 +8326,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2508 "SchemaEntity202012.tt"
+        #line 2589 "SchemaEntity202012.tt"
 
     }
     
@@ -8046,13 +8334,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2511 "SchemaEntity202012.tt"
+        #line 2592 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2512 "SchemaEntity202012.tt"
+        #line 2593 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -8061,7 +8349,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2516 "SchemaEntity202012.tt"
+        #line 2597 "SchemaEntity202012.tt"
         this.Write("            if (this.arrayBacking is ImmutableList<JsonAny> arrayBacking)\r\n      " +
                 "      {\r\n                JsonArray.WriteItems(arrayBacking, writer);\r\n          " +
                 "      return;\r\n            }\r\n\r\n    ");
@@ -8069,7 +8357,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2522 "SchemaEntity202012.tt"
+        #line 2603 "SchemaEntity202012.tt"
 
     }
     
@@ -8077,13 +8365,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2525 "SchemaEntity202012.tt"
+        #line 2606 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2526 "SchemaEntity202012.tt"
+        #line 2607 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -8092,7 +8380,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2530 "SchemaEntity202012.tt"
+        #line 2611 "SchemaEntity202012.tt"
         this.Write("            if (this.numberBacking is double numberBacking)\r\n            {\r\n     " +
                 "           writer.WriteNumberValue(numberBacking);\r\n                return;\r\n   " +
                 "         }\r\n\r\n    ");
@@ -8100,7 +8388,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2536 "SchemaEntity202012.tt"
+        #line 2617 "SchemaEntity202012.tt"
 
     }
     
@@ -8108,13 +8396,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2539 "SchemaEntity202012.tt"
+        #line 2620 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2540 "SchemaEntity202012.tt"
+        #line 2621 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -8123,7 +8411,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2544 "SchemaEntity202012.tt"
+        #line 2625 "SchemaEntity202012.tt"
         this.Write("            if (this.stringBacking is string stringBacking)\r\n            {\r\n     " +
                 "           writer.WriteStringValue(stringBacking);\r\n                return;\r\n   " +
                 "         }\r\n\r\n    ");
@@ -8131,7 +8419,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2550 "SchemaEntity202012.tt"
+        #line 2631 "SchemaEntity202012.tt"
 
     }
     
@@ -8139,13 +8427,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2553 "SchemaEntity202012.tt"
+        #line 2634 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2554 "SchemaEntity202012.tt"
+        #line 2635 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -8154,7 +8442,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2558 "SchemaEntity202012.tt"
+        #line 2639 "SchemaEntity202012.tt"
         this.Write("            if (this.booleanBacking is bool booleanBacking)\r\n            {\r\n     " +
                 "           writer.WriteBooleanValue(booleanBacking);\r\n                return;\r\n " +
                 "           }\r\n    ");
@@ -8162,7 +8450,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2563 "SchemaEntity202012.tt"
+        #line 2644 "SchemaEntity202012.tt"
 
     }
     
@@ -8170,7 +8458,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2566 "SchemaEntity202012.tt"
+        #line 2647 "SchemaEntity202012.tt"
         this.Write("\r\n            if (this.jsonElementBacking.ValueKind != JsonValueKind.Undefined)\r\n" +
                 "            {\r\n                this.jsonElementBacking.WriteTo(writer);\r\n       " +
                 "         return;\r\n            }\r\n\r\n            writer.WriteNullValue();\r\n       " +
@@ -8179,7 +8467,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2576 "SchemaEntity202012.tt"
+        #line 2657 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -8188,13 +8476,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2580 "SchemaEntity202012.tt"
+        #line 2661 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2581 "SchemaEntity202012.tt"
+        #line 2662 "SchemaEntity202012.tt"
 
         if (HasAdditionalPropertiesObject && !HasUnevaluatedPropertiesObject)
         {
@@ -8203,20 +8491,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2585 "SchemaEntity202012.tt"
+        #line 2666 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the object as the given item type\r\n " +
                 "       /// </summary>\r\n        public JsonObjectEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2588 "SchemaEntity202012.tt"
+        #line 2669 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2588 "SchemaEntity202012.tt"
+        #line 2669 "SchemaEntity202012.tt"
         this.Write("> EnumerateProperties()\r\n        {\r\n            if (this.objectBacking is Immutab" +
                 "leDictionary<string, JsonAny> properties)\r\n            {\r\n                return" +
                 " new JsonObjectEnumerator<");
@@ -8224,13 +8512,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2592 "SchemaEntity202012.tt"
+        #line 2673 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2592 "SchemaEntity202012.tt"
+        #line 2673 "SchemaEntity202012.tt"
         this.Write(">(properties);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKin" +
                 "d == JsonValueKind.Object)\r\n            {\r\n                return new JsonObject" +
                 "Enumerator<");
@@ -8238,20 +8526,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2597 "SchemaEntity202012.tt"
+        #line 2678 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2597 "SchemaEntity202012.tt"
+        #line 2678 "SchemaEntity202012.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n\r\n    " +
                 "    }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2603 "SchemaEntity202012.tt"
+        #line 2684 "SchemaEntity202012.tt"
 
         }
         
@@ -8259,13 +8547,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2606 "SchemaEntity202012.tt"
+        #line 2687 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2607 "SchemaEntity202012.tt"
+        #line 2688 "SchemaEntity202012.tt"
 
         if (!HasAdditionalPropertiesObject && HasUnevaluatedPropertiesObject)
         {
@@ -8274,20 +8562,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2611 "SchemaEntity202012.tt"
+        #line 2692 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the object as the given item type\r\n " +
                 "       /// </summary>\r\n        public JsonObjectEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2614 "SchemaEntity202012.tt"
+        #line 2695 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2614 "SchemaEntity202012.tt"
+        #line 2695 "SchemaEntity202012.tt"
         this.Write("> EnumerateProperties()\r\n        {\r\n            if (this.objectBacking is Immutab" +
                 "leDictionary<string, JsonAny> properties)\r\n            {\r\n                return" +
                 " new JsonObjectEnumerator<");
@@ -8295,13 +8583,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2618 "SchemaEntity202012.tt"
+        #line 2699 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2618 "SchemaEntity202012.tt"
+        #line 2699 "SchemaEntity202012.tt"
         this.Write(">(properties);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKin" +
                 "d == JsonValueKind.Object)\r\n            {\r\n                return new JsonObject" +
                 "Enumerator<");
@@ -8309,20 +8597,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2623 "SchemaEntity202012.tt"
+        #line 2704 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2623 "SchemaEntity202012.tt"
+        #line 2704 "SchemaEntity202012.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n\r\n    " +
                 "    }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2629 "SchemaEntity202012.tt"
+        #line 2710 "SchemaEntity202012.tt"
 
         }
         
@@ -8330,7 +8618,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2632 "SchemaEntity202012.tt"
+        #line 2713 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public JsonObjectEnumerator EnumerateObject(" +
                 ")\r\n        {\r\n            return this.AsObject.EnumerateObject();\r\n        }\r\n\r\n" +
                 "    ");
@@ -8338,7 +8626,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2639 "SchemaEntity202012.tt"
+        #line 2720 "SchemaEntity202012.tt"
 
     }
     
@@ -8346,13 +8634,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2642 "SchemaEntity202012.tt"
+        #line 2723 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2643 "SchemaEntity202012.tt"
+        #line 2724 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -8361,13 +8649,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2647 "SchemaEntity202012.tt"
+        #line 2728 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2648 "SchemaEntity202012.tt"
+        #line 2729 "SchemaEntity202012.tt"
 
         if (CanEnumerateAsSpecificType)
         {
@@ -8376,32 +8664,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2652 "SchemaEntity202012.tt"
+        #line 2733 "SchemaEntity202012.tt"
         this.Write("        /// <summary>\r\n        /// Enumerate the items in the array as a <see cre" +
                 "f=\"");
         
         #line default
         #line hidden
         
-        #line 2653 "SchemaEntity202012.tt"
+        #line 2734 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2653 "SchemaEntity202012.tt"
+        #line 2734 "SchemaEntity202012.tt"
         this.Write("\" />.\r\n        /// </summary>\r\n        public JsonArrayEnumerator<");
         
         #line default
         #line hidden
         
-        #line 2655 "SchemaEntity202012.tt"
+        #line 2736 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2655 "SchemaEntity202012.tt"
+        #line 2736 "SchemaEntity202012.tt"
         this.Write("> EnumerateItems()\r\n        {\r\n            if (this.arrayBacking is ImmutableList" +
                 "<JsonAny> items)\r\n            {\r\n                return new JsonArrayEnumerator<" +
                 "");
@@ -8409,13 +8697,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2659 "SchemaEntity202012.tt"
+        #line 2740 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2659 "SchemaEntity202012.tt"
+        #line 2740 "SchemaEntity202012.tt"
         this.Write(">(items);\r\n            }\r\n\r\n            if (this.jsonElementBacking.ValueKind == " +
                 "JsonValueKind.Array)\r\n            {\r\n                return new JsonArrayEnumera" +
                 "tor<");
@@ -8423,20 +8711,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2664 "SchemaEntity202012.tt"
+        #line 2745 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2664 "SchemaEntity202012.tt"
+        #line 2745 "SchemaEntity202012.tt"
         this.Write(">(this.jsonElementBacking);\r\n            }\r\n\r\n            return default;\r\n      " +
                 "  }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 2669 "SchemaEntity202012.tt"
+        #line 2750 "SchemaEntity202012.tt"
 
         }
         
@@ -8444,14 +8732,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2672 "SchemaEntity202012.tt"
+        #line 2753 "SchemaEntity202012.tt"
         this.Write("        /// <inheritdoc/>\r\n        public JsonArrayEnumerator EnumerateArray()\r\n " +
                 "       {\r\n            return this.AsArray.EnumerateArray();\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2677 "SchemaEntity202012.tt"
+        #line 2758 "SchemaEntity202012.tt"
 
     }
     
@@ -8459,13 +8747,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2680 "SchemaEntity202012.tt"
+        #line 2761 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2681 "SchemaEntity202012.tt"
+        #line 2762 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -8474,7 +8762,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2685 "SchemaEntity202012.tt"
+        #line 2766 "SchemaEntity202012.tt"
         this.Write(@"
         /// <inheritdoc/>
         public bool TryGetProperty(string name, out JsonAny value)
@@ -8499,7 +8787,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2704 "SchemaEntity202012.tt"
+        #line 2785 "SchemaEntity202012.tt"
 
         if (HasDefaults)
         {
@@ -8508,7 +8796,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2708 "SchemaEntity202012.tt"
+        #line 2789 "SchemaEntity202012.tt"
         this.Write(@"        /// <inheritdoc/>
         public bool TryGetDefault(string name, out JsonAny value)
         {
@@ -8550,7 +8838,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2744 "SchemaEntity202012.tt"
+        #line 2825 "SchemaEntity202012.tt"
 
         }
         
@@ -8558,13 +8846,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2747 "SchemaEntity202012.tt"
+        #line 2828 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2748 "SchemaEntity202012.tt"
+        #line 2829 "SchemaEntity202012.tt"
 
     }
     
@@ -8572,7 +8860,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2751 "SchemaEntity202012.tt"
+        #line 2832 "SchemaEntity202012.tt"
         this.Write(@"
         /// <inheritdoc/>
         public bool Equals<T>(T other)
@@ -8592,7 +8880,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2765 "SchemaEntity202012.tt"
+        #line 2846 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -8601,14 +8889,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2769 "SchemaEntity202012.tt"
+        #line 2850 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.Equals(other.AsObject()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2770 "SchemaEntity202012.tt"
+        #line 2851 "SchemaEntity202012.tt"
 
     }
     else
@@ -8618,14 +8906,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2775 "SchemaEntity202012.tt"
+        #line 2856 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().Equals(other.AsObject())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2776 "SchemaEntity202012.tt"
+        #line 2857 "SchemaEntity202012.tt"
 
     }
     
@@ -8633,13 +8921,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2779 "SchemaEntity202012.tt"
+        #line 2860 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2779 "SchemaEntity202012.tt"
+        #line 2860 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -8648,14 +8936,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2783 "SchemaEntity202012.tt"
+        #line 2864 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.Equals(other.AsArray()),\r\n   " +
                 " ");
         
         #line default
         #line hidden
         
-        #line 2784 "SchemaEntity202012.tt"
+        #line 2865 "SchemaEntity202012.tt"
 
     }
     else
@@ -8665,14 +8953,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2789 "SchemaEntity202012.tt"
+        #line 2870 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().Equals(other.AsArray()),\r\n " +
                 "   ");
         
         #line default
         #line hidden
         
-        #line 2790 "SchemaEntity202012.tt"
+        #line 2871 "SchemaEntity202012.tt"
 
     }
     
@@ -8680,13 +8968,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2793 "SchemaEntity202012.tt"
+        #line 2874 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2793 "SchemaEntity202012.tt"
+        #line 2874 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -8695,14 +8983,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2797 "SchemaEntity202012.tt"
+        #line 2878 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.Equals(other.AsNumber()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2798 "SchemaEntity202012.tt"
+        #line 2879 "SchemaEntity202012.tt"
 
     }
     else
@@ -8712,14 +9000,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2803 "SchemaEntity202012.tt"
+        #line 2884 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().Equals(other.AsNumber())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2804 "SchemaEntity202012.tt"
+        #line 2885 "SchemaEntity202012.tt"
 
     }
     
@@ -8727,13 +9015,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2807 "SchemaEntity202012.tt"
+        #line 2888 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2807 "SchemaEntity202012.tt"
+        #line 2888 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -8742,14 +9030,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2811 "SchemaEntity202012.tt"
+        #line 2892 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString.Equals(other.AsString()),\r\n" +
                 "    ");
         
         #line default
         #line hidden
         
-        #line 2812 "SchemaEntity202012.tt"
+        #line 2893 "SchemaEntity202012.tt"
 
     }
     else
@@ -8759,14 +9047,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2817 "SchemaEntity202012.tt"
+        #line 2898 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString().Equals(other.AsString())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2818 "SchemaEntity202012.tt"
+        #line 2899 "SchemaEntity202012.tt"
 
     }
     
@@ -8774,13 +9062,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2821 "SchemaEntity202012.tt"
+        #line 2902 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2821 "SchemaEntity202012.tt"
+        #line 2902 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -8789,14 +9077,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2825 "SchemaEntity202012.tt"
+        #line 2906 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.Equal" +
                 "s(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2826 "SchemaEntity202012.tt"
+        #line 2907 "SchemaEntity202012.tt"
 
     }
     else
@@ -8806,14 +9094,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2831 "SchemaEntity202012.tt"
+        #line 2912 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Equ" +
                 "als(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2832 "SchemaEntity202012.tt"
+        #line 2913 "SchemaEntity202012.tt"
 
     }
     
@@ -8821,20 +9109,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2835 "SchemaEntity202012.tt"
+        #line 2916 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Null => true,\r\n                _ => false,\r\n       " +
                 "     };\r\n        }\r\n\r\n        /// <inheritdoc/>\r\n        public bool Equals(");
         
         #line default
         #line hidden
         
-        #line 2841 "SchemaEntity202012.tt"
+        #line 2922 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2841 "SchemaEntity202012.tt"
+        #line 2922 "SchemaEntity202012.tt"
         this.Write(" other)\r\n        {\r\n            JsonValueKind valueKind = this.ValueKind;\r\n\r\n    " +
                 "        if (other.ValueKind != valueKind)\r\n            {\r\n                return" +
                 " false;\r\n            }\r\n\r\n            return valueKind switch\r\n            {\r\n  " +
@@ -8843,7 +9131,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2852 "SchemaEntity202012.tt"
+        #line 2933 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -8852,14 +9140,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2856 "SchemaEntity202012.tt"
+        #line 2937 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject.Equals(other.AsObject),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2857 "SchemaEntity202012.tt"
+        #line 2938 "SchemaEntity202012.tt"
 
     }
     else
@@ -8869,14 +9157,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2862 "SchemaEntity202012.tt"
+        #line 2943 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Object => this.AsObject().Equals(other.AsObject())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2863 "SchemaEntity202012.tt"
+        #line 2944 "SchemaEntity202012.tt"
 
     }
     
@@ -8884,13 +9172,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2866 "SchemaEntity202012.tt"
+        #line 2947 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2866 "SchemaEntity202012.tt"
+        #line 2947 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -8899,13 +9187,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2870 "SchemaEntity202012.tt"
+        #line 2951 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray.Equals(other.AsArray),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2871 "SchemaEntity202012.tt"
+        #line 2952 "SchemaEntity202012.tt"
 
     }
     else
@@ -8915,14 +9203,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2876 "SchemaEntity202012.tt"
+        #line 2957 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Array => this.AsArray().Equals(other.AsArray()),\r\n " +
                 "   ");
         
         #line default
         #line hidden
         
-        #line 2877 "SchemaEntity202012.tt"
+        #line 2958 "SchemaEntity202012.tt"
 
     }
     
@@ -8930,13 +9218,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2880 "SchemaEntity202012.tt"
+        #line 2961 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2880 "SchemaEntity202012.tt"
+        #line 2961 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -8945,14 +9233,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2884 "SchemaEntity202012.tt"
+        #line 2965 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber.Equals(other.AsNumber),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2885 "SchemaEntity202012.tt"
+        #line 2966 "SchemaEntity202012.tt"
 
     }
     else
@@ -8962,14 +9250,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2890 "SchemaEntity202012.tt"
+        #line 2971 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Number => this.AsNumber().Equals(other.AsNumber())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2891 "SchemaEntity202012.tt"
+        #line 2972 "SchemaEntity202012.tt"
 
     }
     
@@ -8977,13 +9265,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2894 "SchemaEntity202012.tt"
+        #line 2975 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2894 "SchemaEntity202012.tt"
+        #line 2975 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -8992,14 +9280,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2898 "SchemaEntity202012.tt"
+        #line 2979 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString.Equals(other.AsString),\r\n  " +
                 "  ");
         
         #line default
         #line hidden
         
-        #line 2899 "SchemaEntity202012.tt"
+        #line 2980 "SchemaEntity202012.tt"
 
     }
     else
@@ -9009,14 +9297,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2904 "SchemaEntity202012.tt"
+        #line 2985 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.String => this.AsString().Equals(other.AsString())," +
                 "\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2905 "SchemaEntity202012.tt"
+        #line 2986 "SchemaEntity202012.tt"
 
     }
     
@@ -9024,13 +9312,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2908 "SchemaEntity202012.tt"
+        #line 2989 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 2908 "SchemaEntity202012.tt"
+        #line 2989 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -9039,14 +9327,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2912 "SchemaEntity202012.tt"
+        #line 2993 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean.Equal" +
                 "s(other.AsBoolean),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2913 "SchemaEntity202012.tt"
+        #line 2994 "SchemaEntity202012.tt"
 
     }
     else
@@ -9056,14 +9344,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2918 "SchemaEntity202012.tt"
+        #line 2999 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.True or JsonValueKind.False => this.AsBoolean().Equ" +
                 "als(other.AsBoolean()),\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2919 "SchemaEntity202012.tt"
+        #line 3000 "SchemaEntity202012.tt"
 
     }
     
@@ -9071,14 +9359,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2922 "SchemaEntity202012.tt"
+        #line 3003 "SchemaEntity202012.tt"
         this.Write("                JsonValueKind.Null => true,\r\n                _ => false,\r\n       " +
                 "     };\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 2927 "SchemaEntity202012.tt"
+        #line 3008 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -9087,7 +9375,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2931 "SchemaEntity202012.tt"
+        #line 3012 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public bool HasProperty(string name)\r\n      " +
                 "  {\r\n            if (this.objectBacking is ImmutableDictionary<string, JsonAny> " +
                 "properties)\r\n            {\r\n                return properties.TryGetValue(name, " +
@@ -9113,13 +9401,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2979 "SchemaEntity202012.tt"
+        #line 3060 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2979 "SchemaEntity202012.tt"
+        #line 3060 "SchemaEntity202012.tt"
         this.Write(@" SetProperty<TValue>(string name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9137,13 +9425,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 2991 "SchemaEntity202012.tt"
+        #line 3072 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 2991 "SchemaEntity202012.tt"
+        #line 3072 "SchemaEntity202012.tt"
         this.Write(@" SetProperty<TValue>(ReadOnlySpan<char> name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9161,13 +9449,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3003 "SchemaEntity202012.tt"
+        #line 3084 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3003 "SchemaEntity202012.tt"
+        #line 3084 "SchemaEntity202012.tt"
         this.Write(@" SetProperty<TValue>(ReadOnlySpan<byte> utf8name, TValue value)
             where TValue : struct, IJsonValue
         {
@@ -9185,13 +9473,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3015 "SchemaEntity202012.tt"
+        #line 3096 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3015 "SchemaEntity202012.tt"
+        #line 3096 "SchemaEntity202012.tt"
         this.Write(@" RemoveProperty(string name)
         {
             if (this.ValueKind == JsonValueKind.Object)
@@ -9208,13 +9496,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3026 "SchemaEntity202012.tt"
+        #line 3107 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3026 "SchemaEntity202012.tt"
+        #line 3107 "SchemaEntity202012.tt"
         this.Write(@" RemoveProperty(ReadOnlySpan<char> name)
         {
             if (this.ValueKind == JsonValueKind.Object)
@@ -9231,13 +9519,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3037 "SchemaEntity202012.tt"
+        #line 3118 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3037 "SchemaEntity202012.tt"
+        #line 3118 "SchemaEntity202012.tt"
         this.Write(" RemoveProperty(ReadOnlySpan<byte> utf8Name)\r\n        {\r\n            if (this.Val" +
                 "ueKind == JsonValueKind.Object)\r\n            {\r\n                return this.AsOb" +
                 "ject.RemoveProperty(utf8Name);\r\n            }\r\n\r\n            return this;\r\n     " +
@@ -9246,7 +9534,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3047 "SchemaEntity202012.tt"
+        #line 3128 "SchemaEntity202012.tt"
 
     }
     
@@ -9254,13 +9542,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3050 "SchemaEntity202012.tt"
+        #line 3131 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3051 "SchemaEntity202012.tt"
+        #line 3132 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -9269,19 +9557,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3055 "SchemaEntity202012.tt"
+        #line 3136 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public ");
         
         #line default
         #line hidden
         
-        #line 3057 "SchemaEntity202012.tt"
+        #line 3138 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3057 "SchemaEntity202012.tt"
+        #line 3138 "SchemaEntity202012.tt"
         this.Write(@" Add<TItem>(TItem item)
             where TItem : struct, IJsonValue
         {
@@ -9299,13 +9587,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3069 "SchemaEntity202012.tt"
+        #line 3150 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3069 "SchemaEntity202012.tt"
+        #line 3150 "SchemaEntity202012.tt"
         this.Write(@" Add<TItem1, TItem2>(TItem1 item1, TItem2 item2)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9324,13 +9612,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3082 "SchemaEntity202012.tt"
+        #line 3163 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3082 "SchemaEntity202012.tt"
+        #line 3163 "SchemaEntity202012.tt"
         this.Write(@" Add<TItem1, TItem2, TItem3>(TItem1 item1, TItem2 item2, TItem3 item3)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9350,13 +9638,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3096 "SchemaEntity202012.tt"
+        #line 3177 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3096 "SchemaEntity202012.tt"
+        #line 3177 "SchemaEntity202012.tt"
         this.Write(@" Add<TItem1, TItem2, TItem3, TItem4>(TItem1 item1, TItem2 item2, TItem3 item3, TItem4 item4)
             where TItem1 : struct, IJsonValue
             where TItem2 : struct, IJsonValue
@@ -9377,13 +9665,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3111 "SchemaEntity202012.tt"
+        #line 3192 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3111 "SchemaEntity202012.tt"
+        #line 3192 "SchemaEntity202012.tt"
         this.Write(@" Add<TItem>(params TItem[] items)
             where TItem : struct, IJsonValue
         {
@@ -9401,13 +9689,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3123 "SchemaEntity202012.tt"
+        #line 3204 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3123 "SchemaEntity202012.tt"
+        #line 3204 "SchemaEntity202012.tt"
         this.Write(@" AddRange<TItem>(IEnumerable<TItem> items)
             where TItem : struct, IJsonValue
         {
@@ -9425,13 +9713,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3135 "SchemaEntity202012.tt"
+        #line 3216 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3135 "SchemaEntity202012.tt"
+        #line 3216 "SchemaEntity202012.tt"
         this.Write(@" Insert<TItem>(int index, TItem item)
             where TItem : struct, IJsonValue
         {
@@ -9449,13 +9737,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3147 "SchemaEntity202012.tt"
+        #line 3228 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3147 "SchemaEntity202012.tt"
+        #line 3228 "SchemaEntity202012.tt"
         this.Write(@" Replace<TItem>(TItem oldValue, TItem newValue)
             where TItem : struct, IJsonValue
         {
@@ -9473,13 +9761,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3159 "SchemaEntity202012.tt"
+        #line 3240 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3159 "SchemaEntity202012.tt"
+        #line 3240 "SchemaEntity202012.tt"
         this.Write(@" RemoveAt(int index)
         {
             if (this.ValueKind == JsonValueKind.Array)
@@ -9496,13 +9784,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3170 "SchemaEntity202012.tt"
+        #line 3251 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3170 "SchemaEntity202012.tt"
+        #line 3251 "SchemaEntity202012.tt"
         this.Write(@" RemoveRange(int index, int count)
         {
             if (this.ValueKind == JsonValueKind.Array)
@@ -9519,13 +9807,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3181 "SchemaEntity202012.tt"
+        #line 3262 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3181 "SchemaEntity202012.tt"
+        #line 3262 "SchemaEntity202012.tt"
         this.Write(@" SetItem<TItem>(int index, TItem value)
             where TItem : struct, IJsonValue
         {
@@ -9542,7 +9830,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3192 "SchemaEntity202012.tt"
+        #line 3273 "SchemaEntity202012.tt"
 
     }
     
@@ -9550,322 +9838,28 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3195 "SchemaEntity202012.tt"
+        #line 3276 "SchemaEntity202012.tt"
         this.Write("\r\n        /// <inheritdoc/>\r\n        public T As<T>()\r\n            where T : stru" +
                 "ct, IJsonValue\r\n        {\r\n            return this.As<");
         
         #line default
         #line hidden
         
-        #line 3200 "SchemaEntity202012.tt"
+        #line 3281 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3200 "SchemaEntity202012.tt"
-        this.Write(", T>();\r\n        }\r\n\r\n\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3204 "SchemaEntity202012.tt"
-
-    if(HasPatternProperties)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3208 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3209 "SchemaEntity202012.tt"
-
-        foreach(var patternProperty in PatternProperties)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3213 "SchemaEntity202012.tt"
-        this.Write("        /// <summary>\r\n        /// Determines if a property matches ");
-        
-        #line default
-        #line hidden
-        
-        #line 3214 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture(                Formatting.FormatLiteralOrNull(patternProperty.Pattern, true).Trim('"')));
-        
-        #line default
-        #line hidden
-        
-        #line 3214 "SchemaEntity202012.tt"
-        this.Write(" producing a <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 3214 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 3214 "SchemaEntity202012.tt"
-        this.Write("\" />.\r\n        /// </summary>\r\n        public bool MatchesPattern");
-        
-        #line default
-        #line hidden
-        
-        #line 3216 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
-        
-        #line default
-        #line hidden
-        
-        #line 3216 "SchemaEntity202012.tt"
-        this.Write("(in Property property)\r\n        {\r\n            return PatternProperty");
-        
-        #line default
-        #line hidden
-        
-        #line 3218 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
-        
-        #line default
-        #line hidden
-        
-        #line 3218 "SchemaEntity202012.tt"
-        this.Write(".IsMatch(property.Name);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Get a p" +
-                "roperty as the matching property type ");
-        
-        #line default
-        #line hidden
-        
-        #line 3222 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture(                Formatting.FormatLiteralOrNull(patternProperty.Pattern, true).Trim('"')));
-        
-        #line default
-        #line hidden
-        
-        #line 3222 "SchemaEntity202012.tt"
-        this.Write(" as a <see cref=\"");
-        
-        #line default
-        #line hidden
-        
-        #line 3222 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 3222 "SchemaEntity202012.tt"
-        this.Write("\" />.\r\n        /// </summary>\r\n        public ");
-        
-        #line default
-        #line hidden
-        
-        #line 3224 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 3224 "SchemaEntity202012.tt"
-        this.Write(" AsPattern");
-        
-        #line default
-        #line hidden
-        
-        #line 3224 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
-        
-        #line default
-        #line hidden
-        
-        #line 3224 "SchemaEntity202012.tt"
-        this.Write("(in Property property)\r\n        {\r\n            return property.ValueAs<");
-        
-        #line default
-        #line hidden
-        
-        #line 3226 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 3226 "SchemaEntity202012.tt"
-        this.Write(">();\r\n        }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3229 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3232 "SchemaEntity202012.tt"
-        this.Write("    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3232 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3235 "SchemaEntity202012.tt"
-        this.Write(@"
-        /// <inheritdoc/>
-        public ValidationContext Validate(in ValidationContext? validationContext = null, ValidationLevel level = ValidationLevel.Flag)
-        {
-            ValidationContext result = validationContext ?? ValidationContext.ValidContext;
-            if (level != ValidationLevel.Flag)
-            {
-                result = result.UsingStack();
-            }
-        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3244 "SchemaEntity202012.tt"
-
-        if (HasAdditionalProperties || HasUnevaluatedProperties)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3248 "SchemaEntity202012.tt"
-        this.Write("            result = result.UsingEvaluatedProperties();\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3249 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3252 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3253 "SchemaEntity202012.tt"
-
-        if (HasUnevaluatedItems)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3257 "SchemaEntity202012.tt"
-        this.Write("            result = result.UsingEvaluatedItems();\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3258 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3261 "SchemaEntity202012.tt"
-        this.Write("\r\n\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3263 "SchemaEntity202012.tt"
-
-    if (HasRef)
-    {    
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3267 "SchemaEntity202012.tt"
-        this.Write("            result = this.ValidateRef(result, level);\r\n            if (level == V" +
-                "alidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return r" +
-                "esult;\r\n            }\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3272 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3275 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3276 "SchemaEntity202012.tt"
-
-    if ((HasExplicitType || HasFormat || HasMediaTypeOrEncoding) || (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasPrefixItems) || (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties || HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)))))
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3280 "SchemaEntity202012.tt"
-        this.Write("            JsonValueKind valueKind = this.ValueKind;\r\n    ");
-        
-        #line default
-        #line hidden
-        
         #line 3281 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3284 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
+        this.Write(", T>();\r\n        }\r\n\r\n\r\n    ");
         
         #line default
         #line hidden
         
         #line 3285 "SchemaEntity202012.tt"
 
-    if (HasExplicitType || HasFormat || HasMediaTypeOrEncoding)
+    if(HasPatternProperties)
     {
     
         
@@ -9880,7 +9874,7 @@ namespace ");
         
         #line 3290 "SchemaEntity202012.tt"
 
-        if (HasExplicitType)
+        foreach(var patternProperty in PatternProperties)
         {
         
         
@@ -9888,14 +9882,121 @@ namespace ");
         #line hidden
         
         #line 3294 "SchemaEntity202012.tt"
-        this.Write("            result = this.ValidateType(valueKind, result, level);\r\n            if" +
-                " (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n            " +
-                "    return result;\r\n            }\r\n        ");
+        this.Write("        /// <summary>\r\n        /// Determines if a property matches ");
+        
+        #line default
+        #line hidden
+        
+        #line 3295 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture(                Formatting.FormatLiteralOrNull(patternProperty.Pattern, true).Trim('"')));
+        
+        #line default
+        #line hidden
+        
+        #line 3295 "SchemaEntity202012.tt"
+        this.Write(" producing a <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 3295 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 3295 "SchemaEntity202012.tt"
+        this.Write("\" />.\r\n        /// </summary>\r\n        public bool MatchesPattern");
+        
+        #line default
+        #line hidden
+        
+        #line 3297 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
+        
+        #line default
+        #line hidden
+        
+        #line 3297 "SchemaEntity202012.tt"
+        this.Write("(in Property property)\r\n        {\r\n            return PatternProperty");
         
         #line default
         #line hidden
         
         #line 3299 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
+        
+        #line default
+        #line hidden
+        
+        #line 3299 "SchemaEntity202012.tt"
+        this.Write(".IsMatch(property.Name);\r\n        }\r\n\r\n        /// <summary>\r\n        /// Get a p" +
+                "roperty as the matching property type ");
+        
+        #line default
+        #line hidden
+        
+        #line 3303 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture(                Formatting.FormatLiteralOrNull(patternProperty.Pattern, true).Trim('"')));
+        
+        #line default
+        #line hidden
+        
+        #line 3303 "SchemaEntity202012.tt"
+        this.Write(" as a <see cref=\"");
+        
+        #line default
+        #line hidden
+        
+        #line 3303 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 3303 "SchemaEntity202012.tt"
+        this.Write("\" />.\r\n        /// </summary>\r\n        public ");
+        
+        #line default
+        #line hidden
+        
+        #line 3305 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 3305 "SchemaEntity202012.tt"
+        this.Write(" AsPattern");
+        
+        #line default
+        #line hidden
+        
+        #line 3305 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
+        
+        #line default
+        #line hidden
+        
+        #line 3305 "SchemaEntity202012.tt"
+        this.Write("(in Property property)\r\n        {\r\n            return property.ValueAs<");
+        
+        #line default
+        #line hidden
+        
+        #line 3307 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 3307 "SchemaEntity202012.tt"
+        this.Write(">();\r\n        }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3310 "SchemaEntity202012.tt"
 
         }
         
@@ -9903,13 +10004,200 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3302 "SchemaEntity202012.tt"
+        #line 3313 "SchemaEntity202012.tt"
+        this.Write("    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3313 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3316 "SchemaEntity202012.tt"
+        this.Write(@"
+        /// <inheritdoc/>
+        public ValidationContext Validate(in ValidationContext? validationContext = null, ValidationLevel level = ValidationLevel.Flag)
+        {
+            ValidationContext result = validationContext ?? ValidationContext.ValidContext;
+            if (level != ValidationLevel.Flag)
+            {
+                result = result.UsingStack();
+            }
+        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3325 "SchemaEntity202012.tt"
+
+        if (HasAdditionalProperties || HasUnevaluatedProperties)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3329 "SchemaEntity202012.tt"
+        this.Write("            result = result.UsingEvaluatedProperties();\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3330 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3333 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3303 "SchemaEntity202012.tt"
+        #line 3334 "SchemaEntity202012.tt"
+
+        if (HasUnevaluatedItems)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3338 "SchemaEntity202012.tt"
+        this.Write("            result = result.UsingEvaluatedItems();\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3339 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3342 "SchemaEntity202012.tt"
+        this.Write("\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3344 "SchemaEntity202012.tt"
+
+    if (HasRef)
+    {    
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3348 "SchemaEntity202012.tt"
+        this.Write("            result = this.ValidateRef(result, level);\r\n            if (level == V" +
+                "alidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return r" +
+                "esult;\r\n            }\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3353 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3356 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3357 "SchemaEntity202012.tt"
+
+    if ((HasExplicitType || HasFormat || HasMediaTypeOrEncoding) || (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasPrefixItems) || (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties || HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)))))
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3361 "SchemaEntity202012.tt"
+        this.Write("            JsonValueKind valueKind = this.ValueKind;\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3362 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3365 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3366 "SchemaEntity202012.tt"
+
+    if (HasExplicitType || HasFormat || HasMediaTypeOrEncoding)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3370 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3371 "SchemaEntity202012.tt"
+
+        if (HasExplicitType)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3375 "SchemaEntity202012.tt"
+        this.Write("            result = this.ValidateType(valueKind, result, level);\r\n            if" +
+                " (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n            " +
+                "    return result;\r\n            }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3380 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3383 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3384 "SchemaEntity202012.tt"
 
         if (HasFormat)
         {
@@ -9918,231 +10206,10 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3307 "SchemaEntity202012.tt"
+        #line 3388 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateFormat(valueKind, result, level);\r\n            " +
                 "if (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n          " +
                 "      return result;\r\n            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3312 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3315 "SchemaEntity202012.tt"
-        this.Write("\r\n        \r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3317 "SchemaEntity202012.tt"
-
-        if (HasMediaTypeOrEncoding)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3321 "SchemaEntity202012.tt"
-        this.Write("            result = this.ValidateMediaTypeAndEncoding(valueKind, result, level);" +
-                "\r\n            if (level == ValidationLevel.Flag && !result.IsValid)\r\n           " +
-                " {\r\n                return result;\r\n            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3326 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3329 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3330 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3333 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3334 "SchemaEntity202012.tt"
-
-    if (HasConst)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3338 "SchemaEntity202012.tt"
-        this.Write("            result = Corvus.Json.Validate.ValidateConst(this, result, level, __Co" +
-                "rvusConstValue);\r\n            if (level == ValidationLevel.Flag && !result.IsVal" +
-                "id)\r\n            {\r\n                return result;\r\n            }\r\n\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3344 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3347 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3348 "SchemaEntity202012.tt"
-
-    if (HasEnum)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3352 "SchemaEntity202012.tt"
-        this.Write("            result = Corvus.Json.Validate.ValidateEnum(\r\n                this,\r\n " +
-                "               result,\r\n                level\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3356 "SchemaEntity202012.tt"
-
-        for(int enumIndex = 0; enumIndex < EnumValues.Length; ++enumIndex)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3360 "SchemaEntity202012.tt"
-        this.Write("                , EnumValues.Item");
-        
-        #line default
-        #line hidden
-        
-        #line 3360 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( enumIndex ));
-        
-        #line default
-        #line hidden
-        
-        #line 3360 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3361 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3364 "SchemaEntity202012.tt"
-        this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
-                "Valid)\r\n            {\r\n                return result;\r\n            }\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3370 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3373 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3374 "SchemaEntity202012.tt"
-
-    if (HasMultipleOf || HasMaximum || HasExclusiveMaximum|| HasMinimum || HasExclusiveMinimum)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3378 "SchemaEntity202012.tt"
-        this.Write("            result = Corvus.Json.Validate.ValidateNumber(\r\n                this,\r" +
-                "\n                result,\r\n                level,\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3382 "SchemaEntity202012.tt"
-
-        if (HasMultipleOf)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3386 "SchemaEntity202012.tt"
-        this.Write("                ");
-        
-        #line default
-        #line hidden
-        
-        #line 3386 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( MultipleOf ));
-        
-        #line default
-        #line hidden
-        
-        #line 3386 "SchemaEntity202012.tt"
-        this.Write(",\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3387 "SchemaEntity202012.tt"
-
-        }
-        else
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3392 "SchemaEntity202012.tt"
-        this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
@@ -10156,50 +10223,24 @@ namespace ");
         #line hidden
         
         #line 3396 "SchemaEntity202012.tt"
-        this.Write("        ");
+        this.Write("\r\n        \r\n        ");
         
         #line default
         #line hidden
         
-        #line 3396 "SchemaEntity202012.tt"
+        #line 3398 "SchemaEntity202012.tt"
 
-        if (HasMaximum)
+        if (HasMediaTypeOrEncoding)
         {
         
         
         #line default
         #line hidden
         
-        #line 3400 "SchemaEntity202012.tt"
-        this.Write("                 ");
-        
-        #line default
-        #line hidden
-        
-        #line 3400 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( Maximum ));
-        
-        #line default
-        #line hidden
-        
-        #line 3400 "SchemaEntity202012.tt"
-        this.Write(",\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3401 "SchemaEntity202012.tt"
-
-        }
-        else
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3406 "SchemaEntity202012.tt"
-        this.Write("                null,\r\n        ");
+        #line 3402 "SchemaEntity202012.tt"
+        this.Write("            result = this.ValidateMediaTypeAndEncoding(valueKind, result, level);" +
+                "\r\n            if (level == ValidationLevel.Flag && !result.IsValid)\r\n           " +
+                " {\r\n                return result;\r\n            }\r\n        ");
         
         #line default
         #line hidden
@@ -10213,12 +10254,259 @@ namespace ");
         #line hidden
         
         #line 3410 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3411 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3414 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3415 "SchemaEntity202012.tt"
+
+    if (HasConst)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3419 "SchemaEntity202012.tt"
+        this.Write("            result = Corvus.Json.Validate.ValidateConst(this, result, level, __Co" +
+                "rvusConstValue);\r\n            if (level == ValidationLevel.Flag && !result.IsVal" +
+                "id)\r\n            {\r\n                return result;\r\n            }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3425 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3428 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3429 "SchemaEntity202012.tt"
+
+    if (HasEnum)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3433 "SchemaEntity202012.tt"
+        this.Write("            result = Corvus.Json.Validate.ValidateEnum(\r\n                this,\r\n " +
+                "               result,\r\n                level\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3437 "SchemaEntity202012.tt"
+
+        for(int enumIndex = 0; enumIndex < EnumValues.Length; ++enumIndex)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3441 "SchemaEntity202012.tt"
+        this.Write("                , EnumValues.Item");
+        
+        #line default
+        #line hidden
+        
+        #line 3441 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( enumIndex ));
+        
+        #line default
+        #line hidden
+        
+        #line 3441 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3442 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3445 "SchemaEntity202012.tt"
+        this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
+                "Valid)\r\n            {\r\n                return result;\r\n            }\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3451 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3454 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3455 "SchemaEntity202012.tt"
+
+    if (HasMultipleOf || HasMaximum || HasExclusiveMaximum|| HasMinimum || HasExclusiveMinimum)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3459 "SchemaEntity202012.tt"
+        this.Write("            result = Corvus.Json.Validate.ValidateNumber(\r\n                this,\r" +
+                "\n                result,\r\n                level,\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3463 "SchemaEntity202012.tt"
+
+        if (HasMultipleOf)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3467 "SchemaEntity202012.tt"
+        this.Write("                ");
+        
+        #line default
+        #line hidden
+        
+        #line 3467 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( MultipleOf ));
+        
+        #line default
+        #line hidden
+        
+        #line 3467 "SchemaEntity202012.tt"
+        this.Write(",\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3468 "SchemaEntity202012.tt"
+
+        }
+        else
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3473 "SchemaEntity202012.tt"
+        this.Write("                null,\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3474 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3477 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3410 "SchemaEntity202012.tt"
+        #line 3477 "SchemaEntity202012.tt"
+
+        if (HasMaximum)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3481 "SchemaEntity202012.tt"
+        this.Write("                 ");
+        
+        #line default
+        #line hidden
+        
+        #line 3481 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( Maximum ));
+        
+        #line default
+        #line hidden
+        
+        #line 3481 "SchemaEntity202012.tt"
+        this.Write(",\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3482 "SchemaEntity202012.tt"
+
+        }
+        else
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3487 "SchemaEntity202012.tt"
+        this.Write("                null,\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3488 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3491 "SchemaEntity202012.tt"
+        this.Write("        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3491 "SchemaEntity202012.tt"
 
         if (HasExclusiveMaximum)
         {
@@ -10227,25 +10515,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3414 "SchemaEntity202012.tt"
+        #line 3495 "SchemaEntity202012.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3414 "SchemaEntity202012.tt"
+        #line 3495 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ExclusiveMaximum ));
         
         #line default
         #line hidden
         
-        #line 3414 "SchemaEntity202012.tt"
+        #line 3495 "SchemaEntity202012.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3415 "SchemaEntity202012.tt"
+        #line 3496 "SchemaEntity202012.tt"
 
         }
         else
@@ -10255,13 +10543,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3420 "SchemaEntity202012.tt"
+        #line 3501 "SchemaEntity202012.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3421 "SchemaEntity202012.tt"
+        #line 3502 "SchemaEntity202012.tt"
 
         }
         
@@ -10269,13 +10557,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3424 "SchemaEntity202012.tt"
+        #line 3505 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3424 "SchemaEntity202012.tt"
+        #line 3505 "SchemaEntity202012.tt"
 
         if (HasMinimum)
         {
@@ -10284,25 +10572,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3428 "SchemaEntity202012.tt"
+        #line 3509 "SchemaEntity202012.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3428 "SchemaEntity202012.tt"
+        #line 3509 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Minimum ));
         
         #line default
         #line hidden
         
-        #line 3428 "SchemaEntity202012.tt"
+        #line 3509 "SchemaEntity202012.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3429 "SchemaEntity202012.tt"
+        #line 3510 "SchemaEntity202012.tt"
 
         }
         else
@@ -10312,13 +10600,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3434 "SchemaEntity202012.tt"
+        #line 3515 "SchemaEntity202012.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3435 "SchemaEntity202012.tt"
+        #line 3516 "SchemaEntity202012.tt"
 
         }
         
@@ -10326,13 +10614,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3438 "SchemaEntity202012.tt"
+        #line 3519 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3438 "SchemaEntity202012.tt"
+        #line 3519 "SchemaEntity202012.tt"
 
         if (HasExclusiveMinimum)
         {
@@ -10341,25 +10629,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3442 "SchemaEntity202012.tt"
+        #line 3523 "SchemaEntity202012.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3442 "SchemaEntity202012.tt"
+        #line 3523 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ExclusiveMinimum ));
         
         #line default
         #line hidden
         
-        #line 3442 "SchemaEntity202012.tt"
+        #line 3523 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3443 "SchemaEntity202012.tt"
+        #line 3524 "SchemaEntity202012.tt"
 
         }
         else
@@ -10369,13 +10657,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3448 "SchemaEntity202012.tt"
+        #line 3529 "SchemaEntity202012.tt"
         this.Write("                null\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3449 "SchemaEntity202012.tt"
+        #line 3530 "SchemaEntity202012.tt"
 
         }
         
@@ -10383,14 +10671,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3452 "SchemaEntity202012.tt"
+        #line 3533 "SchemaEntity202012.tt"
         this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
                 "Valid)\r\n            {\r\n                return result;\r\n            }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3459 "SchemaEntity202012.tt"
+        #line 3540 "SchemaEntity202012.tt"
 
     }
     
@@ -10398,13 +10686,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3462 "SchemaEntity202012.tt"
+        #line 3543 "SchemaEntity202012.tt"
         this.Write("    \r\n    ");
         
         #line default
         #line hidden
         
-        #line 3463 "SchemaEntity202012.tt"
+        #line 3544 "SchemaEntity202012.tt"
 
     if (HasMaxLength || HasMinLength || HasPattern)
     {
@@ -10413,14 +10701,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3467 "SchemaEntity202012.tt"
+        #line 3548 "SchemaEntity202012.tt"
         this.Write("            result = Corvus.Json.Validate.ValidateString(\r\n                this,\r" +
                 "\n                result,\r\n                level,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3471 "SchemaEntity202012.tt"
+        #line 3552 "SchemaEntity202012.tt"
 
         if (HasMaxLength)
         {
@@ -10429,25 +10717,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3475 "SchemaEntity202012.tt"
+        #line 3556 "SchemaEntity202012.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3475 "SchemaEntity202012.tt"
+        #line 3556 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxLength ));
         
         #line default
         #line hidden
         
-        #line 3475 "SchemaEntity202012.tt"
+        #line 3556 "SchemaEntity202012.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3476 "SchemaEntity202012.tt"
+        #line 3557 "SchemaEntity202012.tt"
 
         }
         else
@@ -10457,13 +10745,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3481 "SchemaEntity202012.tt"
+        #line 3562 "SchemaEntity202012.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3482 "SchemaEntity202012.tt"
+        #line 3563 "SchemaEntity202012.tt"
 
         }
         
@@ -10471,13 +10759,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3485 "SchemaEntity202012.tt"
+        #line 3566 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3485 "SchemaEntity202012.tt"
+        #line 3566 "SchemaEntity202012.tt"
 
         if (HasMinLength)
         {
@@ -10486,25 +10774,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3489 "SchemaEntity202012.tt"
+        #line 3570 "SchemaEntity202012.tt"
         this.Write("                 ");
         
         #line default
         #line hidden
         
-        #line 3489 "SchemaEntity202012.tt"
+        #line 3570 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinLength ));
         
         #line default
         #line hidden
         
-        #line 3489 "SchemaEntity202012.tt"
+        #line 3570 "SchemaEntity202012.tt"
         this.Write(",\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3490 "SchemaEntity202012.tt"
+        #line 3571 "SchemaEntity202012.tt"
 
         }
         else
@@ -10514,13 +10802,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3495 "SchemaEntity202012.tt"
+        #line 3576 "SchemaEntity202012.tt"
         this.Write("                null,\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3496 "SchemaEntity202012.tt"
+        #line 3577 "SchemaEntity202012.tt"
 
         }
         
@@ -10528,13 +10816,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3499 "SchemaEntity202012.tt"
+        #line 3580 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 3499 "SchemaEntity202012.tt"
+        #line 3580 "SchemaEntity202012.tt"
 
         if (HasPattern)
         {
@@ -10543,13 +10831,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3503 "SchemaEntity202012.tt"
+        #line 3584 "SchemaEntity202012.tt"
         this.Write("                __CorvusPatternExpression\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3504 "SchemaEntity202012.tt"
+        #line 3585 "SchemaEntity202012.tt"
 
         }
         else
@@ -10559,13 +10847,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3509 "SchemaEntity202012.tt"
+        #line 3590 "SchemaEntity202012.tt"
         this.Write("                null\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3510 "SchemaEntity202012.tt"
+        #line 3591 "SchemaEntity202012.tt"
 
         }
         
@@ -10573,14 +10861,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3513 "SchemaEntity202012.tt"
+        #line 3594 "SchemaEntity202012.tt"
         this.Write("                );\r\n\r\n            if (level == ValidationLevel.Flag && !result.Is" +
                 "Valid)\r\n            {\r\n                return result;\r\n            }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3519 "SchemaEntity202012.tt"
+        #line 3600 "SchemaEntity202012.tt"
 
     }
     
@@ -10588,13 +10876,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3522 "SchemaEntity202012.tt"
+        #line 3603 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3523 "SchemaEntity202012.tt"
+        #line 3604 "SchemaEntity202012.tt"
 
     if (HasIfThenElse)
     {
@@ -10603,7 +10891,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3527 "SchemaEntity202012.tt"
+        #line 3608 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateIfThenElse(result, level);\r\n            if (lev" +
                 "el == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                r" +
                 "eturn result;\r\n            }\r\n\r\n    ");
@@ -10611,7 +10899,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3533 "SchemaEntity202012.tt"
+        #line 3614 "SchemaEntity202012.tt"
 
     }
     
@@ -10619,13 +10907,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3536 "SchemaEntity202012.tt"
+        #line 3617 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3537 "SchemaEntity202012.tt"
+        #line 3618 "SchemaEntity202012.tt"
 
     if (HasNot)
     {
@@ -10634,7 +10922,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3541 "SchemaEntity202012.tt"
+        #line 3622 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateNot(result, level);\r\n            if (level == V" +
                 "alidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return r" +
                 "esult;\r\n            }\r\n\r\n    ");
@@ -10642,7 +10930,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3547 "SchemaEntity202012.tt"
+        #line 3628 "SchemaEntity202012.tt"
 
     }
     
@@ -10650,13 +10938,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3550 "SchemaEntity202012.tt"
+        #line 3631 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3551 "SchemaEntity202012.tt"
+        #line 3632 "SchemaEntity202012.tt"
 
     if (HasAllOf)
     {
@@ -10665,7 +10953,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3555 "SchemaEntity202012.tt"
+        #line 3636 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateAllOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n    ");
@@ -10673,7 +10961,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3560 "SchemaEntity202012.tt"
+        #line 3641 "SchemaEntity202012.tt"
 
     }
     
@@ -10681,13 +10969,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3563 "SchemaEntity202012.tt"
+        #line 3644 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3564 "SchemaEntity202012.tt"
+        #line 3645 "SchemaEntity202012.tt"
 
     if (HasAnyOf)
     {
@@ -10696,7 +10984,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3568 "SchemaEntity202012.tt"
+        #line 3649 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateAnyOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n    ");
@@ -10704,7 +10992,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3573 "SchemaEntity202012.tt"
+        #line 3654 "SchemaEntity202012.tt"
 
     }
     
@@ -10712,13 +11000,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3576 "SchemaEntity202012.tt"
+        #line 3657 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3577 "SchemaEntity202012.tt"
+        #line 3658 "SchemaEntity202012.tt"
 
     if (HasOneOf)
     {
@@ -10727,7 +11015,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3581 "SchemaEntity202012.tt"
+        #line 3662 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateOneOf(result, level);\r\n            if (level ==" +
                 " ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n                return" +
                 " result;\r\n            }\r\n\r\n    ");
@@ -10735,7 +11023,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3587 "SchemaEntity202012.tt"
+        #line 3668 "SchemaEntity202012.tt"
 
     }
     
@@ -10743,13 +11031,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3590 "SchemaEntity202012.tt"
+        #line 3671 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3591 "SchemaEntity202012.tt"
+        #line 3672 "SchemaEntity202012.tt"
 
     if (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties || HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)) || !AllowsAdditionalProperties))
     {
@@ -10758,7 +11046,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3595 "SchemaEntity202012.tt"
+        #line 3676 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateObject(valueKind, result, level);\r\n            " +
                 "if (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n          " +
                 "      return result;\r\n            }\r\n\r\n    ");
@@ -10766,7 +11054,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3601 "SchemaEntity202012.tt"
+        #line 3682 "SchemaEntity202012.tt"
 
     }
     
@@ -10774,13 +11062,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3604 "SchemaEntity202012.tt"
+        #line 3685 "SchemaEntity202012.tt"
         this.Write("\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3606 "SchemaEntity202012.tt"
+        #line 3687 "SchemaEntity202012.tt"
 
     if (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasPrefixItems)
     {
@@ -10789,7 +11077,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3610 "SchemaEntity202012.tt"
+        #line 3691 "SchemaEntity202012.tt"
         this.Write("            result = this.ValidateArray(valueKind, result, level);\r\n            i" +
                 "f (level == ValidationLevel.Flag && !result.IsValid)\r\n            {\r\n           " +
                 "     return result;\r\n            }\r\n    ");
@@ -10797,7 +11085,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3615 "SchemaEntity202012.tt"
+        #line 3696 "SchemaEntity202012.tt"
 
     }
     
@@ -10805,13 +11093,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3618 "SchemaEntity202012.tt"
+        #line 3699 "SchemaEntity202012.tt"
         this.Write("            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3621 "SchemaEntity202012.tt"
+        #line 3702 "SchemaEntity202012.tt"
 
     if (IsImplicitObject)
     {
@@ -10820,7 +11108,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3625 "SchemaEntity202012.tt"
+        #line 3706 "SchemaEntity202012.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonObject""/>.
         /// </summary>
@@ -10841,7 +11129,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3640 "SchemaEntity202012.tt"
+        #line 3721 "SchemaEntity202012.tt"
 
     }
     
@@ -10849,13 +11137,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3643 "SchemaEntity202012.tt"
+        #line 3724 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3644 "SchemaEntity202012.tt"
+        #line 3725 "SchemaEntity202012.tt"
 
     if (IsImplicitArray)
     {
@@ -10864,7 +11152,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3648 "SchemaEntity202012.tt"
+        #line 3729 "SchemaEntity202012.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonArray""/>.
         /// </summary>
@@ -10885,7 +11173,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3663 "SchemaEntity202012.tt"
+        #line 3744 "SchemaEntity202012.tt"
 
     }
     
@@ -10893,13 +11181,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3666 "SchemaEntity202012.tt"
+        #line 3747 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3667 "SchemaEntity202012.tt"
+        #line 3748 "SchemaEntity202012.tt"
 
     if (IsImplicitNumber)
     {
@@ -10908,7 +11196,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3671 "SchemaEntity202012.tt"
+        #line 3752 "SchemaEntity202012.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonNumber""/>.
         /// </summary>
@@ -10929,7 +11217,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3686 "SchemaEntity202012.tt"
+        #line 3767 "SchemaEntity202012.tt"
 
     }
     
@@ -10937,13 +11225,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3689 "SchemaEntity202012.tt"
+        #line 3770 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3690 "SchemaEntity202012.tt"
+        #line 3771 "SchemaEntity202012.tt"
 
     if (IsImplicitString)
     {
@@ -10952,7 +11240,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3694 "SchemaEntity202012.tt"
+        #line 3775 "SchemaEntity202012.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonString""/>.
         /// </summary>
@@ -10973,7 +11261,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3709 "SchemaEntity202012.tt"
+        #line 3790 "SchemaEntity202012.tt"
 
     }
     
@@ -10981,13 +11269,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3712 "SchemaEntity202012.tt"
+        #line 3793 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3713 "SchemaEntity202012.tt"
+        #line 3794 "SchemaEntity202012.tt"
 
     if (IsImplicitBoolean)
     {
@@ -10996,7 +11284,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3717 "SchemaEntity202012.tt"
+        #line 3798 "SchemaEntity202012.tt"
         this.Write(@"        /// <summary>
         /// Gets the value as a <see cref=""JsonBoolean""/>.
         /// </summary>
@@ -11017,337 +11305,6 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3732 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3735 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3736 "SchemaEntity202012.tt"
-
-    if (HasPatternProperties)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3740 "SchemaEntity202012.tt"
-        this.Write(@"        private static ImmutableDictionary<Regex, PatternPropertyValidator> CreatePatternPropertiesValidators()
-        {
-            ImmutableDictionary<Regex, PatternPropertyValidator>.Builder builder =
-                ImmutableDictionary.CreateBuilder<Regex, PatternPropertyValidator>();
-
-        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3745 "SchemaEntity202012.tt"
-
-        foreach (var patternProperty in PatternProperties)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3749 "SchemaEntity202012.tt"
-        this.Write("            builder.Add(\r\n                PatternProperty");
-        
-        #line default
-        #line hidden
-        
-        #line 3750 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
-        
-        #line default
-        #line hidden
-        
-        #line 3750 "SchemaEntity202012.tt"
-        this.Write(",__CorvusValidatePatternProperty");
-        
-        #line default
-        #line hidden
-        
-        #line 3750 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
-        
-        #line default
-        #line hidden
-        
-        #line 3750 "SchemaEntity202012.tt"
-        this.Write(");\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3751 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3754 "SchemaEntity202012.tt"
-        this.Write("\r\n            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3758 "SchemaEntity202012.tt"
-
-        foreach (var patternProperty in PatternProperties)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3762 "SchemaEntity202012.tt"
-        this.Write("        private static ValidationContext __CorvusValidatePatternProperty");
-        
-        #line default
-        #line hidden
-        
-        #line 3762 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
-        
-        #line default
-        #line hidden
-        
-        #line 3762 "SchemaEntity202012.tt"
-        this.Write("(in Property that, in ValidationContext validationContext, ValidationLevel level)" +
-                "\r\n        {\r\n            return that.ValueAs<");
-        
-        #line default
-        #line hidden
-        
-        #line 3764 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 3764 "SchemaEntity202012.tt"
-        this.Write(">().Validate(validationContext, level);\r\n        }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3766 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3769 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3770 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3773 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 3774 "SchemaEntity202012.tt"
-
-    if (HasDependentSchemas)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 3778 "SchemaEntity202012.tt"
-        this.Write("\r\n        private static ImmutableDictionary<string, PropertyValidator<");
-        
-        #line default
-        #line hidden
-        
-        #line 3779 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 3779 "SchemaEntity202012.tt"
-        this.Write(">> CreateDependentSchemaValidators()\r\n        {\r\n            ImmutableDictionary<" +
-                "string, PropertyValidator<");
-        
-        #line default
-        #line hidden
-        
-        #line 3781 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 3781 "SchemaEntity202012.tt"
-        this.Write(">>.Builder builder =\r\n                ImmutableDictionary.CreateBuilder<string, P" +
-                "ropertyValidator<");
-        
-        #line default
-        #line hidden
-        
-        #line 3782 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 3782 "SchemaEntity202012.tt"
-        this.Write(">>();\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3784 "SchemaEntity202012.tt"
-
-        int dsIndex = 0;
-        foreach (var dependentSchema in DependentSchemas)
-        {
-            dsIndex++;
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3790 "SchemaEntity202012.tt"
-        this.Write("            builder.Add(\r\n                \"");
-        
-        #line default
-        #line hidden
-        
-        #line 3791 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( dependentSchema.Name ));
-        
-        #line default
-        #line hidden
-        
-        #line 3791 "SchemaEntity202012.tt"
-        this.Write("\", __CorvusValidateDependentSchema");
-        
-        #line default
-        #line hidden
-        
-        #line 3791 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( dsIndex ));
-        
-        #line default
-        #line hidden
-        
-        #line 3791 "SchemaEntity202012.tt"
-        this.Write(");\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3793 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3796 "SchemaEntity202012.tt"
-        this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3799 "SchemaEntity202012.tt"
-
-        int dsIndexV = 0;
-        foreach (var dependentSchema in DependentSchemas)
-        {
-            dsIndexV++;
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3805 "SchemaEntity202012.tt"
-        this.Write("        private static ValidationContext __CorvusValidateDependentSchema");
-        
-        #line default
-        #line hidden
-        
-        #line 3805 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( dsIndexV ));
-        
-        #line default
-        #line hidden
-        
-        #line 3805 "SchemaEntity202012.tt"
-        this.Write("(in ");
-        
-        #line default
-        #line hidden
-        
-        #line 3805 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 3805 "SchemaEntity202012.tt"
-        this.Write(" that, in ValidationContext validationContext, ValidationLevel level)\r\n        {\r" +
-                "\n            return that.As<");
-        
-        #line default
-        #line hidden
-        
-        #line 3807 "SchemaEntity202012.tt"
-        this.Write(this.ToStringHelper.ToStringWithCulture( dependentSchema.DotnetTypeName ));
-        
-        #line default
-        #line hidden
-        
-        #line 3807 "SchemaEntity202012.tt"
-        this.Write(">().Validate(validationContext, level);\r\n        }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 3809 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 3812 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
         #line 3813 "SchemaEntity202012.tt"
 
     }
@@ -11364,7 +11321,7 @@ namespace ");
         
         #line 3817 "SchemaEntity202012.tt"
 
-    if (HasDefaults)
+    if (HasPatternProperties)
     {
     
         
@@ -11372,6 +11329,337 @@ namespace ");
         #line hidden
         
         #line 3821 "SchemaEntity202012.tt"
+        this.Write(@"        private static ImmutableDictionary<Regex, PatternPropertyValidator> CreatePatternPropertiesValidators()
+        {
+            ImmutableDictionary<Regex, PatternPropertyValidator>.Builder builder =
+                ImmutableDictionary.CreateBuilder<Regex, PatternPropertyValidator>();
+
+        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3826 "SchemaEntity202012.tt"
+
+        foreach (var patternProperty in PatternProperties)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3830 "SchemaEntity202012.tt"
+        this.Write("            builder.Add(\r\n                PatternProperty");
+        
+        #line default
+        #line hidden
+        
+        #line 3831 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
+        
+        #line default
+        #line hidden
+        
+        #line 3831 "SchemaEntity202012.tt"
+        this.Write(",__CorvusValidatePatternProperty");
+        
+        #line default
+        #line hidden
+        
+        #line 3831 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
+        
+        #line default
+        #line hidden
+        
+        #line 3831 "SchemaEntity202012.tt"
+        this.Write(");\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3832 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3835 "SchemaEntity202012.tt"
+        this.Write("\r\n            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3839 "SchemaEntity202012.tt"
+
+        foreach (var patternProperty in PatternProperties)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3843 "SchemaEntity202012.tt"
+        this.Write("        private static ValidationContext __CorvusValidatePatternProperty");
+        
+        #line default
+        #line hidden
+        
+        #line 3843 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( PatternPropertySuffix(patternProperty) ));
+        
+        #line default
+        #line hidden
+        
+        #line 3843 "SchemaEntity202012.tt"
+        this.Write("(in Property that, in ValidationContext validationContext, ValidationLevel level)" +
+                "\r\n        {\r\n            return that.ValueAs<");
+        
+        #line default
+        #line hidden
+        
+        #line 3845 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( patternProperty.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 3845 "SchemaEntity202012.tt"
+        this.Write(">().Validate(validationContext, level);\r\n        }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3847 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3850 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3851 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3854 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3855 "SchemaEntity202012.tt"
+
+    if (HasDependentSchemas)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3859 "SchemaEntity202012.tt"
+        this.Write("\r\n        private static ImmutableDictionary<string, PropertyValidator<");
+        
+        #line default
+        #line hidden
+        
+        #line 3860 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 3860 "SchemaEntity202012.tt"
+        this.Write(">> CreateDependentSchemaValidators()\r\n        {\r\n            ImmutableDictionary<" +
+                "string, PropertyValidator<");
+        
+        #line default
+        #line hidden
+        
+        #line 3862 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 3862 "SchemaEntity202012.tt"
+        this.Write(">>.Builder builder =\r\n                ImmutableDictionary.CreateBuilder<string, P" +
+                "ropertyValidator<");
+        
+        #line default
+        #line hidden
+        
+        #line 3863 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 3863 "SchemaEntity202012.tt"
+        this.Write(">>();\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3865 "SchemaEntity202012.tt"
+
+        int dsIndex = 0;
+        foreach (var dependentSchema in DependentSchemas)
+        {
+            dsIndex++;
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3871 "SchemaEntity202012.tt"
+        this.Write("            builder.Add(\r\n                \"");
+        
+        #line default
+        #line hidden
+        
+        #line 3872 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( dependentSchema.Name ));
+        
+        #line default
+        #line hidden
+        
+        #line 3872 "SchemaEntity202012.tt"
+        this.Write("\", __CorvusValidateDependentSchema");
+        
+        #line default
+        #line hidden
+        
+        #line 3872 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( dsIndex ));
+        
+        #line default
+        #line hidden
+        
+        #line 3872 "SchemaEntity202012.tt"
+        this.Write(");\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3874 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3877 "SchemaEntity202012.tt"
+        this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3880 "SchemaEntity202012.tt"
+
+        int dsIndexV = 0;
+        foreach (var dependentSchema in DependentSchemas)
+        {
+            dsIndexV++;
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3886 "SchemaEntity202012.tt"
+        this.Write("        private static ValidationContext __CorvusValidateDependentSchema");
+        
+        #line default
+        #line hidden
+        
+        #line 3886 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( dsIndexV ));
+        
+        #line default
+        #line hidden
+        
+        #line 3886 "SchemaEntity202012.tt"
+        this.Write("(in ");
+        
+        #line default
+        #line hidden
+        
+        #line 3886 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 3886 "SchemaEntity202012.tt"
+        this.Write(" that, in ValidationContext validationContext, ValidationLevel level)\r\n        {\r" +
+                "\n            return that.As<");
+        
+        #line default
+        #line hidden
+        
+        #line 3888 "SchemaEntity202012.tt"
+        this.Write(this.ToStringHelper.ToStringWithCulture( dependentSchema.DotnetTypeName ));
+        
+        #line default
+        #line hidden
+        
+        #line 3888 "SchemaEntity202012.tt"
+        this.Write(">().Validate(validationContext, level);\r\n        }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 3890 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 3893 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3894 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3897 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 3898 "SchemaEntity202012.tt"
+
+    if (HasDefaults)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 3902 "SchemaEntity202012.tt"
         this.Write("        private static ImmutableDictionary<string, JsonAny> BuildDefaults()\r\n    " +
                 "    {\r\n            ImmutableDictionary<string, JsonAny>.Builder builder =\r\n     " +
                 "           ImmutableDictionary.CreateBuilder<string, JsonAny>();\r\n\r\n        ");
@@ -11379,7 +11667,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3826 "SchemaEntity202012.tt"
+        #line 3907 "SchemaEntity202012.tt"
 
         foreach (var property in Defaults)
         {
@@ -11388,37 +11676,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3830 "SchemaEntity202012.tt"
+        #line 3911 "SchemaEntity202012.tt"
         this.Write("            builder.Add(");
         
         #line default
         #line hidden
         
-        #line 3830 "SchemaEntity202012.tt"
+        #line 3911 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3830 "SchemaEntity202012.tt"
+        #line 3911 "SchemaEntity202012.tt"
         this.Write("JsonPropertyName, JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 3830 "SchemaEntity202012.tt"
+        #line 3911 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(property.DefaultValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3830 "SchemaEntity202012.tt"
+        #line 3911 "SchemaEntity202012.tt"
         this.Write("));\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3831 "SchemaEntity202012.tt"
+        #line 3912 "SchemaEntity202012.tt"
 
         }
         
@@ -11426,13 +11714,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3834 "SchemaEntity202012.tt"
+        #line 3915 "SchemaEntity202012.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3836 "SchemaEntity202012.tt"
+        #line 3917 "SchemaEntity202012.tt"
 
     }
     
@@ -11440,13 +11728,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3839 "SchemaEntity202012.tt"
+        #line 3920 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3840 "SchemaEntity202012.tt"
+        #line 3921 "SchemaEntity202012.tt"
 
     if (HasDependentRequired)
     {
@@ -11455,7 +11743,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3844 "SchemaEntity202012.tt"
+        #line 3925 "SchemaEntity202012.tt"
         this.Write(@"
         private static ImmutableDictionary<string, ImmutableArray<ReadOnlyMemory<byte>>> BuildDependentRequired()
         {
@@ -11467,7 +11755,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3850 "SchemaEntity202012.tt"
+        #line 3931 "SchemaEntity202012.tt"
 
         foreach (var dependentRequired in DependentRequired)
         {
@@ -11476,26 +11764,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3854 "SchemaEntity202012.tt"
+        #line 3935 "SchemaEntity202012.tt"
         this.Write("            builder.Add(\r\n                    ");
         
         #line default
         #line hidden
         
-        #line 3855 "SchemaEntity202012.tt"
+        #line 3936 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( Formatting.FormatLiteralOrNull(dependentRequired.Name, true) ));
         
         #line default
         #line hidden
         
-        #line 3855 "SchemaEntity202012.tt"
+        #line 3936 "SchemaEntity202012.tt"
         this.Write(",\r\n                    ImmutableArray.Create<ReadOnlyMemory<byte>>(\r\n            " +
                 "");
         
         #line default
         #line hidden
         
-        #line 3857 "SchemaEntity202012.tt"
+        #line 3938 "SchemaEntity202012.tt"
 
             bool isFirst1 = true;
             foreach (var dependentRequiredValue in dependentRequired.RequiredNames)
@@ -11505,13 +11793,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3862 "SchemaEntity202012.tt"
+        #line 3943 "SchemaEntity202012.tt"
         this.Write("                ");
         
         #line default
         #line hidden
         
-        #line 3862 "SchemaEntity202012.tt"
+        #line 3943 "SchemaEntity202012.tt"
 
                 if (isFirst1)
                 {
@@ -11521,25 +11809,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3867 "SchemaEntity202012.tt"
+        #line 3948 "SchemaEntity202012.tt"
         this.Write("                        System.Text.Encoding.UTF8.GetBytes(");
         
         #line default
         #line hidden
         
-        #line 3867 "SchemaEntity202012.tt"
+        #line 3948 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  Formatting.FormatLiteralOrNull(dependentRequiredValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3867 "SchemaEntity202012.tt"
+        #line 3948 "SchemaEntity202012.tt"
         this.Write(").AsMemory()\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3868 "SchemaEntity202012.tt"
+        #line 3949 "SchemaEntity202012.tt"
 
                 }
                 else
@@ -11549,25 +11837,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3873 "SchemaEntity202012.tt"
+        #line 3954 "SchemaEntity202012.tt"
         this.Write("                        , System.Text.Encoding.UTF8.GetBytes(");
         
         #line default
         #line hidden
         
-        #line 3873 "SchemaEntity202012.tt"
+        #line 3954 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  Formatting.FormatLiteralOrNull(dependentRequiredValue, true) ));
         
         #line default
         #line hidden
         
-        #line 3873 "SchemaEntity202012.tt"
+        #line 3954 "SchemaEntity202012.tt"
         this.Write(").AsMemory()\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3874 "SchemaEntity202012.tt"
+        #line 3955 "SchemaEntity202012.tt"
 
                 }
                 
@@ -11575,13 +11863,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3877 "SchemaEntity202012.tt"
+        #line 3958 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 3877 "SchemaEntity202012.tt"
+        #line 3958 "SchemaEntity202012.tt"
 
             }
             
@@ -11589,13 +11877,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3880 "SchemaEntity202012.tt"
+        #line 3961 "SchemaEntity202012.tt"
         this.Write("                        ));\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3881 "SchemaEntity202012.tt"
+        #line 3962 "SchemaEntity202012.tt"
 
         }
         
@@ -11603,13 +11891,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3884 "SchemaEntity202012.tt"
+        #line 3965 "SchemaEntity202012.tt"
         this.Write("            return builder.ToImmutable();\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3887 "SchemaEntity202012.tt"
+        #line 3968 "SchemaEntity202012.tt"
 
     }
     
@@ -11617,13 +11905,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3890 "SchemaEntity202012.tt"
+        #line 3971 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3891 "SchemaEntity202012.tt"
+        #line 3972 "SchemaEntity202012.tt"
 
     if (HasLocalProperties)
     {
@@ -11632,51 +11920,51 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3895 "SchemaEntity202012.tt"
+        #line 3976 "SchemaEntity202012.tt"
         this.Write("\r\n        private static ImmutableDictionary<string, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3896 "SchemaEntity202012.tt"
+        #line 3977 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3896 "SchemaEntity202012.tt"
+        #line 3977 "SchemaEntity202012.tt"
         this.Write(">> CreateLocalPropertyValidators()\r\n        {\r\n            ImmutableDictionary<st" +
                 "ring, PropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3898 "SchemaEntity202012.tt"
+        #line 3979 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3898 "SchemaEntity202012.tt"
+        #line 3979 "SchemaEntity202012.tt"
         this.Write(">>.Builder builder =\r\n                ImmutableDictionary.CreateBuilder<string, P" +
                 "ropertyValidator<");
         
         #line default
         #line hidden
         
-        #line 3899 "SchemaEntity202012.tt"
+        #line 3980 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3899 "SchemaEntity202012.tt"
+        #line 3980 "SchemaEntity202012.tt"
         this.Write(">>();\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3901 "SchemaEntity202012.tt"
+        #line 3982 "SchemaEntity202012.tt"
 
         foreach (var property in LocalProperties)
         {
@@ -11685,37 +11973,37 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3905 "SchemaEntity202012.tt"
+        #line 3986 "SchemaEntity202012.tt"
         this.Write("            builder.Add(\r\n                ");
         
         #line default
         #line hidden
         
-        #line 3906 "SchemaEntity202012.tt"
+        #line 3987 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3906 "SchemaEntity202012.tt"
+        #line 3987 "SchemaEntity202012.tt"
         this.Write("JsonPropertyName, __CorvusValidate");
         
         #line default
         #line hidden
         
-        #line 3906 "SchemaEntity202012.tt"
+        #line 3987 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3906 "SchemaEntity202012.tt"
+        #line 3987 "SchemaEntity202012.tt"
         this.Write(");\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3907 "SchemaEntity202012.tt"
+        #line 3988 "SchemaEntity202012.tt"
 
         }
         
@@ -11723,13 +12011,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3910 "SchemaEntity202012.tt"
+        #line 3991 "SchemaEntity202012.tt"
         this.Write("\r\n            return builder.ToImmutable();\r\n        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3914 "SchemaEntity202012.tt"
+        #line 3995 "SchemaEntity202012.tt"
 
         foreach (var property in LocalProperties)
         {
@@ -11738,63 +12026,63 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3918 "SchemaEntity202012.tt"
+        #line 3999 "SchemaEntity202012.tt"
         this.Write("        private static ValidationContext __CorvusValidate");
         
         #line default
         #line hidden
         
-        #line 3918 "SchemaEntity202012.tt"
+        #line 3999 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3918 "SchemaEntity202012.tt"
+        #line 3999 "SchemaEntity202012.tt"
         this.Write("(in ");
         
         #line default
         #line hidden
         
-        #line 3918 "SchemaEntity202012.tt"
+        #line 3999 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3918 "SchemaEntity202012.tt"
+        #line 3999 "SchemaEntity202012.tt"
         this.Write(" that, in ValidationContext validationContext, ValidationLevel level)\r\n        {\r" +
                 "\n            ");
         
         #line default
         #line hidden
         
-        #line 3920 "SchemaEntity202012.tt"
+        #line 4001 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.Type.FullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3920 "SchemaEntity202012.tt"
+        #line 4001 "SchemaEntity202012.tt"
         this.Write(" property = that.");
         
         #line default
         #line hidden
         
-        #line 3920 "SchemaEntity202012.tt"
+        #line 4001 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 3920 "SchemaEntity202012.tt"
+        #line 4001 "SchemaEntity202012.tt"
         this.Write(";\r\n            return property.Validate(validationContext, level);\r\n        }\r\n  " +
                 "      ");
         
         #line default
         #line hidden
         
-        #line 3923 "SchemaEntity202012.tt"
+        #line 4004 "SchemaEntity202012.tt"
 
         }
         
@@ -11802,13 +12090,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3926 "SchemaEntity202012.tt"
+        #line 4007 "SchemaEntity202012.tt"
         this.Write("    ");
         
         #line default
         #line hidden
         
-        #line 3926 "SchemaEntity202012.tt"
+        #line 4007 "SchemaEntity202012.tt"
 
     }
     
@@ -11816,13 +12104,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3929 "SchemaEntity202012.tt"
+        #line 4010 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3930 "SchemaEntity202012.tt"
+        #line 4011 "SchemaEntity202012.tt"
 
     if (HasRef)
     {
@@ -11831,7 +12119,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3934 "SchemaEntity202012.tt"
+        #line 4015 "SchemaEntity202012.tt"
         this.Write("        private ValidationContext ValidateRef(in ValidationContext validationCont" +
                 "ext, ValidationLevel level)\r\n        {\r\n            ValidationContext result = v" +
                 "alidationContext;\r\n\r\n            ValidationContext refResult = this.As<");
@@ -11839,13 +12127,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3938 "SchemaEntity202012.tt"
+        #line 4019 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( RefDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 3938 "SchemaEntity202012.tt"
+        #line 4019 "SchemaEntity202012.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
             if (!refResult.IsValid)
@@ -11880,7 +12168,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3967 "SchemaEntity202012.tt"
+        #line 4048 "SchemaEntity202012.tt"
 
     }
     
@@ -11888,13 +12176,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3970 "SchemaEntity202012.tt"
+        #line 4051 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 3971 "SchemaEntity202012.tt"
+        #line 4052 "SchemaEntity202012.tt"
 
     if (HasItems || HasContains || HasUniqueItems || HasMaxItems || HasMinItems || HasUnevaluatedItems || HasPrefixItems)
     {
@@ -11903,7 +12191,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3975 "SchemaEntity202012.tt"
+        #line 4056 "SchemaEntity202012.tt"
         this.Write(@"        private ValidationContext ValidateArray(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
             ValidationContext result = validationContext;
@@ -11918,7 +12206,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3984 "SchemaEntity202012.tt"
+        #line 4065 "SchemaEntity202012.tt"
 
         if (HasItems || HasContains || HasUniqueItems || HasUnevaluatedItems || HasPrefixItems)
         {
@@ -11927,13 +12215,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3988 "SchemaEntity202012.tt"
+        #line 4069 "SchemaEntity202012.tt"
         this.Write("\r\n            int arrayLength = 0;\r\n         ");
         
         #line default
         #line hidden
         
-        #line 3990 "SchemaEntity202012.tt"
+        #line 4071 "SchemaEntity202012.tt"
 
         }
         else
@@ -11943,13 +12231,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3995 "SchemaEntity202012.tt"
+        #line 4076 "SchemaEntity202012.tt"
         this.Write("            int arrayLength = this.Length;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 3996 "SchemaEntity202012.tt"
+        #line 4077 "SchemaEntity202012.tt"
 
         }
         
@@ -11957,13 +12245,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 3999 "SchemaEntity202012.tt"
+        #line 4080 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4000 "SchemaEntity202012.tt"
+        #line 4081 "SchemaEntity202012.tt"
 
         if (HasContains)
         {
@@ -11972,13 +12260,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4004 "SchemaEntity202012.tt"
+        #line 4085 "SchemaEntity202012.tt"
         this.Write("            int containsCount = 0;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4006 "SchemaEntity202012.tt"
+        #line 4087 "SchemaEntity202012.tt"
 
         }
 
@@ -11987,13 +12275,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4010 "SchemaEntity202012.tt"
+        #line 4091 "SchemaEntity202012.tt"
         this.Write("\r\n         ");
         
         #line default
         #line hidden
         
-        #line 4011 "SchemaEntity202012.tt"
+        #line 4092 "SchemaEntity202012.tt"
 
         if (HasItems || HasContains || HasUniqueItems || HasUnevaluatedItems || HasPrefixItems)
         {
@@ -12002,14 +12290,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4015 "SchemaEntity202012.tt"
+        #line 4096 "SchemaEntity202012.tt"
         this.Write("            JsonArrayEnumerator arrayEnumerator = this.EnumerateArray();\r\n\r\n     " +
                 "       while (arrayEnumerator.MoveNext())\r\n            {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4019 "SchemaEntity202012.tt"
+        #line 4100 "SchemaEntity202012.tt"
 
             if (HasUniqueItems)
             {
@@ -12018,7 +12306,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4023 "SchemaEntity202012.tt"
+        #line 4104 "SchemaEntity202012.tt"
         this.Write(@"                JsonArrayEnumerator innerEnumerator = this.EnumerateArray();
                 int innerIndex = -1;
                 while (innerIndex < arrayLength && innerEnumerator.MoveNext())
@@ -12050,7 +12338,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4049 "SchemaEntity202012.tt"
+        #line 4130 "SchemaEntity202012.tt"
 
             }
         
@@ -12058,13 +12346,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4052 "SchemaEntity202012.tt"
+        #line 4133 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4053 "SchemaEntity202012.tt"
+        #line 4134 "SchemaEntity202012.tt"
 
             if (HasContains)
             {
@@ -12073,19 +12361,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4057 "SchemaEntity202012.tt"
+        #line 4138 "SchemaEntity202012.tt"
         this.Write("                ValidationContext containsResult = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4057 "SchemaEntity202012.tt"
+        #line 4138 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     ContainsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4057 "SchemaEntity202012.tt"
+        #line 4138 "SchemaEntity202012.tt"
         this.Write(">().Validate(result.CreateChildContext(), level);\r\n\r\n                if (contains" +
                 "Result.IsValid)\r\n                {\r\n                    result = result.WithLoca" +
                 "lItemIndex(arrayLength);\r\n                    containsCount++;\r\n\r\n            ");
@@ -12093,7 +12381,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4064 "SchemaEntity202012.tt"
+        #line 4145 "SchemaEntity202012.tt"
 
                 if (HasMaxContains && !HasUnevaluatedItems)
                 {
@@ -12102,26 +12390,26 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4068 "SchemaEntity202012.tt"
+        #line 4149 "SchemaEntity202012.tt"
         this.Write("                    if (level == ValidationLevel.Flag && containsCount > ");
         
         #line default
         #line hidden
         
-        #line 4068 "SchemaEntity202012.tt"
+        #line 4149 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4068 "SchemaEntity202012.tt"
+        #line 4149 "SchemaEntity202012.tt"
         this.Write(")\r\n                    {\r\n                        return result.WithResult(isVali" +
                 "d: false);\r\n                    }\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4072 "SchemaEntity202012.tt"
+        #line 4153 "SchemaEntity202012.tt"
 
                 }
             
@@ -12129,13 +12417,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4075 "SchemaEntity202012.tt"
+        #line 4156 "SchemaEntity202012.tt"
         this.Write("                }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4077 "SchemaEntity202012.tt"
+        #line 4158 "SchemaEntity202012.tt"
 
             }
         
@@ -12143,13 +12431,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4080 "SchemaEntity202012.tt"
+        #line 4161 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4081 "SchemaEntity202012.tt"
+        #line 4162 "SchemaEntity202012.tt"
 
             if (HasSingleItemsType && !HasPrefixItems)
             {
@@ -12158,19 +12446,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4085 "SchemaEntity202012.tt"
+        #line 4166 "SchemaEntity202012.tt"
         this.Write("                result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4085 "SchemaEntity202012.tt"
+        #line 4166 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4085 "SchemaEntity202012.tt"
+        #line 4166 "SchemaEntity202012.tt"
         this.Write(">().Validate(result, level);\r\n                if (level == ValidationLevel.Flag &" +
                 "& !result.IsValid)\r\n                {\r\n                    return result;\r\n     " +
                 "           }\r\n\r\n                result = result.WithLocalItemIndex(arrayLength);" +
@@ -12179,7 +12467,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4093 "SchemaEntity202012.tt"
+        #line 4174 "SchemaEntity202012.tt"
 
             }
             else if (HasMultipleItemsType || HasPrefixItems)
@@ -12190,13 +12478,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4099 "SchemaEntity202012.tt"
+        #line 4180 "SchemaEntity202012.tt"
         this.Write("                switch (arrayLength)\r\n                {\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4101 "SchemaEntity202012.tt"
+        #line 4182 "SchemaEntity202012.tt"
 
                 if (HasPrefixItems)
                 {
@@ -12208,32 +12496,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4108 "SchemaEntity202012.tt"
+        #line 4189 "SchemaEntity202012.tt"
         this.Write("                    case ");
         
         #line default
         #line hidden
         
-        #line 4108 "SchemaEntity202012.tt"
+        #line 4189 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( itemsIndex ));
         
         #line default
         #line hidden
         
-        #line 4108 "SchemaEntity202012.tt"
+        #line 4189 "SchemaEntity202012.tt"
         this.Write(":\r\n                    \r\n                        result = arrayEnumerator.Current" +
                 ".As<");
         
         #line default
         #line hidden
         
-        #line 4110 "SchemaEntity202012.tt"
+        #line 4191 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( prefixItem ));
         
         #line default
         #line hidden
         
-        #line 4110 "SchemaEntity202012.tt"
+        #line 4191 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
                         if (level == ValidationLevel.Flag && !result.IsValid)
                         {
@@ -12246,7 +12534,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4117 "SchemaEntity202012.tt"
+        #line 4198 "SchemaEntity202012.tt"
 
                         itemsIndex++;
                     }
@@ -12256,13 +12544,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4122 "SchemaEntity202012.tt"
+        #line 4203 "SchemaEntity202012.tt"
         this.Write("\r\n                    default:\r\n                ");
         
         #line default
         #line hidden
         
-        #line 4124 "SchemaEntity202012.tt"
+        #line 4205 "SchemaEntity202012.tt"
 
                 if (HasSingleItemsType)
                 {
@@ -12271,19 +12559,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4128 "SchemaEntity202012.tt"
+        #line 4209 "SchemaEntity202012.tt"
         this.Write("                        result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4128 "SchemaEntity202012.tt"
+        #line 4209 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     SingleItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4128 "SchemaEntity202012.tt"
+        #line 4209 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
                         if (level == ValidationLevel.Flag && !result.IsValid)
                         {
@@ -12296,7 +12584,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4135 "SchemaEntity202012.tt"
+        #line 4216 "SchemaEntity202012.tt"
 
                 }
                 else if (HasUnevaluatedItems)
@@ -12306,7 +12594,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4140 "SchemaEntity202012.tt"
+        #line 4221 "SchemaEntity202012.tt"
         this.Write("                        if (!result.HasEvaluatedLocalOrAppliedItemIndex(arrayLeng" +
                 "th))\r\n                        {\r\n\r\n                            result = arrayEnu" +
                 "merator.Current.As<");
@@ -12314,13 +12602,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4143 "SchemaEntity202012.tt"
+        #line 4224 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  UnevaluatedItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4143 "SchemaEntity202012.tt"
+        #line 4224 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
 
                             if (level == ValidationLevel.Flag && !result.IsValid)
@@ -12335,7 +12623,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4152 "SchemaEntity202012.tt"
+        #line 4233 "SchemaEntity202012.tt"
 
                 }
                 
@@ -12343,13 +12631,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4155 "SchemaEntity202012.tt"
+        #line 4236 "SchemaEntity202012.tt"
         this.Write("\r\n                        break;\r\n                }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4159 "SchemaEntity202012.tt"
+        #line 4240 "SchemaEntity202012.tt"
 
             }
             else if (HasUnevaluatedItems)
@@ -12359,20 +12647,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4164 "SchemaEntity202012.tt"
+        #line 4245 "SchemaEntity202012.tt"
         this.Write("                if (!result.HasEvaluatedLocalOrAppliedItemIndex(arrayLength))\r\n  " +
                 "              {\r\n                    result = arrayEnumerator.Current.As<");
         
         #line default
         #line hidden
         
-        #line 4166 "SchemaEntity202012.tt"
+        #line 4247 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  UnevaluatedItemsDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4166 "SchemaEntity202012.tt"
+        #line 4247 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
 
                     if (level == ValidationLevel.Flag && !result.IsValid)
@@ -12388,7 +12676,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4176 "SchemaEntity202012.tt"
+        #line 4257 "SchemaEntity202012.tt"
 
             }
         
@@ -12396,13 +12684,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4179 "SchemaEntity202012.tt"
+        #line 4260 "SchemaEntity202012.tt"
         this.Write("\r\n                arrayLength++;\r\n            }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4182 "SchemaEntity202012.tt"
+        #line 4263 "SchemaEntity202012.tt"
 
         }
         
@@ -12410,13 +12698,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4185 "SchemaEntity202012.tt"
+        #line 4266 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4186 "SchemaEntity202012.tt"
+        #line 4267 "SchemaEntity202012.tt"
 
         if (HasMaxItems)
         {
@@ -12425,19 +12713,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4190 "SchemaEntity202012.tt"
+        #line 4271 "SchemaEntity202012.tt"
         this.Write("            if (arrayLength > ");
         
         #line default
         #line hidden
         
-        #line 4190 "SchemaEntity202012.tt"
+        #line 4271 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4190 "SchemaEntity202012.tt"
+        #line 4271 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".1. maxItems - {arrayLength} exceeds maximum number of items ");
@@ -12445,13 +12733,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4194 "SchemaEntity202012.tt"
+        #line 4275 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4194 "SchemaEntity202012.tt"
+        #line 4275 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.1. maxItems - item count exceeds maximum number of items ");
@@ -12459,13 +12747,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4198 "SchemaEntity202012.tt"
+        #line 4279 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxItems ));
         
         #line default
         #line hidden
         
-        #line 4198 "SchemaEntity202012.tt"
+        #line 4279 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n\r\n           " +
                 " }\r\n        ");
@@ -12473,7 +12761,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4206 "SchemaEntity202012.tt"
+        #line 4287 "SchemaEntity202012.tt"
 
         }
         
@@ -12481,13 +12769,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4209 "SchemaEntity202012.tt"
+        #line 4290 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4210 "SchemaEntity202012.tt"
+        #line 4291 "SchemaEntity202012.tt"
 
         if (HasMinItems)
         {
@@ -12496,19 +12784,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4214 "SchemaEntity202012.tt"
+        #line 4295 "SchemaEntity202012.tt"
         this.Write("            if (arrayLength < ");
         
         #line default
         #line hidden
         
-        #line 4214 "SchemaEntity202012.tt"
+        #line 4295 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4214 "SchemaEntity202012.tt"
+        #line 4295 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".2. minItems - {arrayLength} is less than the minimum number of items ");
@@ -12516,13 +12804,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4218 "SchemaEntity202012.tt"
+        #line 4299 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4218 "SchemaEntity202012.tt"
+        #line 4299 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.2. minItems - item count is less than the minimum number of items ");
@@ -12530,13 +12818,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4222 "SchemaEntity202012.tt"
+        #line 4303 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinItems ));
         
         #line default
         #line hidden
         
-        #line 4222 "SchemaEntity202012.tt"
+        #line 4303 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n\r\n           " +
                 " }\r\n        ");
@@ -12544,7 +12832,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4230 "SchemaEntity202012.tt"
+        #line 4311 "SchemaEntity202012.tt"
 
         }
         
@@ -12552,13 +12840,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4233 "SchemaEntity202012.tt"
+        #line 4314 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4234 "SchemaEntity202012.tt"
+        #line 4315 "SchemaEntity202012.tt"
 
         if (HasContains)
         {
@@ -12567,13 +12855,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4238 "SchemaEntity202012.tt"
+        #line 4319 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4238 "SchemaEntity202012.tt"
+        #line 4319 "SchemaEntity202012.tt"
 
             if (HasMaxContains)
             {
@@ -12582,19 +12870,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4242 "SchemaEntity202012.tt"
+        #line 4323 "SchemaEntity202012.tt"
         this.Write("\r\n            if (containsCount > ");
         
         #line default
         #line hidden
         
-        #line 4243 "SchemaEntity202012.tt"
+        #line 4324 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4243 "SchemaEntity202012.tt"
+        #line 4324 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".4. maxContains - {containsCount} exceeds maximum number of matching items ");
@@ -12602,13 +12890,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4247 "SchemaEntity202012.tt"
+        #line 4328 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4247 "SchemaEntity202012.tt"
+        #line 4328 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.4. maxContains - item count exceeds maximum number of matching items ");
@@ -12616,13 +12904,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4251 "SchemaEntity202012.tt"
+        #line 4332 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MaxContains ));
         
         #line default
         #line hidden
         
-        #line 4251 "SchemaEntity202012.tt"
+        #line 4332 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n            ");
@@ -12630,7 +12918,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4259 "SchemaEntity202012.tt"
+        #line 4340 "SchemaEntity202012.tt"
 
             }
             
@@ -12638,13 +12926,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4262 "SchemaEntity202012.tt"
+        #line 4343 "SchemaEntity202012.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4263 "SchemaEntity202012.tt"
+        #line 4344 "SchemaEntity202012.tt"
 
             if (HasMinContains)
             {
@@ -12653,19 +12941,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4267 "SchemaEntity202012.tt"
+        #line 4348 "SchemaEntity202012.tt"
         this.Write("            if (containsCount < ");
         
         #line default
         #line hidden
         
-        #line 4267 "SchemaEntity202012.tt"
+        #line 4348 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4267 "SchemaEntity202012.tt"
+        #line 4348 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.4" +
                 ".5. minContains - {containsCount} is less than minimum number of matching items " +
@@ -12674,13 +12962,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4271 "SchemaEntity202012.tt"
+        #line 4352 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4271 "SchemaEntity202012.tt"
+        #line 4352 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.4.5. minContains - item count is less than minimum number of matching ite" +
@@ -12689,13 +12977,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4275 "SchemaEntity202012.tt"
+        #line 4356 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     MinContains ));
         
         #line default
         #line hidden
         
-        #line 4275 "SchemaEntity202012.tt"
+        #line 4356 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n            ");
@@ -12703,7 +12991,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4283 "SchemaEntity202012.tt"
+        #line 4364 "SchemaEntity202012.tt"
 
             }
             else
@@ -12713,7 +13001,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4288 "SchemaEntity202012.tt"
+        #line 4369 "SchemaEntity202012.tt"
         this.Write(@"            if (containsCount == 0)
             {
                 if (level >= ValidationLevel.Detailed)
@@ -12735,7 +13023,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4304 "SchemaEntity202012.tt"
+        #line 4385 "SchemaEntity202012.tt"
 
             }
             
@@ -12743,13 +13031,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4307 "SchemaEntity202012.tt"
+        #line 4388 "SchemaEntity202012.tt"
         this.Write("\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4309 "SchemaEntity202012.tt"
+        #line 4390 "SchemaEntity202012.tt"
 
         }
         
@@ -12757,13 +13045,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4312 "SchemaEntity202012.tt"
+        #line 4393 "SchemaEntity202012.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4316 "SchemaEntity202012.tt"
+        #line 4397 "SchemaEntity202012.tt"
 
     }
     
@@ -12771,13 +13059,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4319 "SchemaEntity202012.tt"
+        #line 4400 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4320 "SchemaEntity202012.tt"
+        #line 4401 "SchemaEntity202012.tt"
 
     if (HasDependentRequired || HasLocalProperties || HasRequired || HasMaxProperties || HasMinProperties|| HasDependentSchemas || HasPropertyNames || HasPatternProperties || ((AllowsAdditionalProperties && (HasAdditionalProperties || HasUnevaluatedProperties)) || !AllowsAdditionalProperties))
     {
@@ -12786,7 +13074,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4324 "SchemaEntity202012.tt"
+        #line 4405 "SchemaEntity202012.tt"
         this.Write(@"        private ValidationContext ValidateObject(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
             ValidationContext result = validationContext;
@@ -12801,7 +13089,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4333 "SchemaEntity202012.tt"
+        #line 4414 "SchemaEntity202012.tt"
 
         if (HasMaxProperties || HasMinProperties || HasLocalProperties || HasRequired || HasDependentSchemas || HasPatternProperties || HasAdditionalProperties || HasUnevaluatedProperties)
         {
@@ -12810,13 +13098,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4337 "SchemaEntity202012.tt"
+        #line 4418 "SchemaEntity202012.tt"
         this.Write("            int propertyCount = 0;\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4338 "SchemaEntity202012.tt"
+        #line 4419 "SchemaEntity202012.tt"
 
         }
         
@@ -12824,13 +13112,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4341 "SchemaEntity202012.tt"
+        #line 4422 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4342 "SchemaEntity202012.tt"
+        #line 4423 "SchemaEntity202012.tt"
 
         if (HasRequired)
         {
@@ -12839,13 +13127,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4346 "SchemaEntity202012.tt"
+        #line 4427 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4346 "SchemaEntity202012.tt"
+        #line 4427 "SchemaEntity202012.tt"
  
             foreach(var property in RequiredProperties)
             {
@@ -12854,25 +13142,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4350 "SchemaEntity202012.tt"
+        #line 4431 "SchemaEntity202012.tt"
         this.Write("            bool found");
         
         #line default
         #line hidden
         
-        #line 4350 "SchemaEntity202012.tt"
+        #line 4431 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4350 "SchemaEntity202012.tt"
+        #line 4431 "SchemaEntity202012.tt"
         this.Write(" = false;\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4351 "SchemaEntity202012.tt"
+        #line 4432 "SchemaEntity202012.tt"
 
             }
             
@@ -12880,13 +13168,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4354 "SchemaEntity202012.tt"
+        #line 4435 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4354 "SchemaEntity202012.tt"
+        #line 4435 "SchemaEntity202012.tt"
 
         }
         
@@ -12894,14 +13182,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4357 "SchemaEntity202012.tt"
+        #line 4438 "SchemaEntity202012.tt"
         this.Write("\r\n            foreach (Property property in this.EnumerateObject())\r\n            " +
                 "{\r\n                string propertyName = property.Name;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4362 "SchemaEntity202012.tt"
+        #line 4443 "SchemaEntity202012.tt"
 
         if (HasDependentRequired)
         {
@@ -12910,7 +13198,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4366 "SchemaEntity202012.tt"
+        #line 4447 "SchemaEntity202012.tt"
         this.Write(@"                if (__CorvusDependentRequired.TryGetValue(propertyName, out ImmutableArray<ReadOnlyMemory<byte>> dependencies))
                 {
                     foreach (ReadOnlyMemory<byte> dependency in dependencies)
@@ -12921,7 +13209,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4371 "SchemaEntity202012.tt"
+        #line 4452 "SchemaEntity202012.tt"
 
             if (HasDefaults)
             {
@@ -12930,13 +13218,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4375 "SchemaEntity202012.tt"
+        #line 4456 "SchemaEntity202012.tt"
         this.Write("                        && !this.HasDefault(dependency.Span)\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4376 "SchemaEntity202012.tt"
+        #line 4457 "SchemaEntity202012.tt"
 
             }
             
@@ -12944,7 +13232,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4379 "SchemaEntity202012.tt"
+        #line 4460 "SchemaEntity202012.tt"
         this.Write(@"                        )
                         {
                             if (level >= ValidationLevel.Detailed)
@@ -12968,7 +13256,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4397 "SchemaEntity202012.tt"
+        #line 4478 "SchemaEntity202012.tt"
 
         }
         
@@ -12976,13 +13264,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4400 "SchemaEntity202012.tt"
+        #line 4481 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4401 "SchemaEntity202012.tt"
+        #line 4482 "SchemaEntity202012.tt"
 
         if (HasLocalProperties || HasRequired)
         {
@@ -12991,20 +13279,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4405 "SchemaEntity202012.tt"
+        #line 4486 "SchemaEntity202012.tt"
         this.Write("                if (__CorvusLocalProperties.TryGetValue(propertyName, out Propert" +
                 "yValidator<");
         
         #line default
         #line hidden
         
-        #line 4405 "SchemaEntity202012.tt"
+        #line 4486 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4405 "SchemaEntity202012.tt"
+        #line 4486 "SchemaEntity202012.tt"
         this.Write(@">? propertyValidator))
                 {
                     result = result.WithLocalProperty(propertyCount);
@@ -13020,7 +13308,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4415 "SchemaEntity202012.tt"
+        #line 4496 "SchemaEntity202012.tt"
 
             if (HasRequired)
             {
@@ -13034,13 +13322,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4424 "SchemaEntity202012.tt"
+        #line 4505 "SchemaEntity202012.tt"
         this.Write("                else \r\n                    ");
         
         #line default
         #line hidden
         
-        #line 4425 "SchemaEntity202012.tt"
+        #line 4506 "SchemaEntity202012.tt"
 
                     }
                     else
@@ -13052,38 +13340,38 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4432 "SchemaEntity202012.tt"
+        #line 4513 "SchemaEntity202012.tt"
         this.Write("\r\n                if (");
         
         #line default
         #line hidden
         
-        #line 4433 "SchemaEntity202012.tt"
+        #line 4514 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4433 "SchemaEntity202012.tt"
+        #line 4514 "SchemaEntity202012.tt"
         this.Write("JsonPropertyName.Equals(propertyName))\r\n                {\r\n                    fo" +
                 "und");
         
         #line default
         #line hidden
         
-        #line 4435 "SchemaEntity202012.tt"
+        #line 4516 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(  property.DotnetPropertyName));
         
         #line default
         #line hidden
         
-        #line 4435 "SchemaEntity202012.tt"
+        #line 4516 "SchemaEntity202012.tt"
         this.Write(" = true;\r\n                }\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4437 "SchemaEntity202012.tt"
+        #line 4518 "SchemaEntity202012.tt"
 
                 }
             }
@@ -13092,13 +13380,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4441 "SchemaEntity202012.tt"
+        #line 4522 "SchemaEntity202012.tt"
         this.Write("\r\n                }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4443 "SchemaEntity202012.tt"
+        #line 4524 "SchemaEntity202012.tt"
 
         }
         
@@ -13106,13 +13394,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4446 "SchemaEntity202012.tt"
+        #line 4527 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4447 "SchemaEntity202012.tt"
+        #line 4528 "SchemaEntity202012.tt"
 
         if (HasDependentSchemas)
         {
@@ -13121,20 +13409,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4451 "SchemaEntity202012.tt"
+        #line 4532 "SchemaEntity202012.tt"
         this.Write("                if (__CorvusDependentSchema.TryGetValue(propertyName, out Propert" +
                 "yValidator<");
         
         #line default
         #line hidden
         
-        #line 4451 "SchemaEntity202012.tt"
+        #line 4532 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4451 "SchemaEntity202012.tt"
+        #line 4532 "SchemaEntity202012.tt"
         this.Write(@">? dependentSchemaValidator))
                 {
                     result = result.WithLocalProperty(propertyCount);
@@ -13149,7 +13437,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4460 "SchemaEntity202012.tt"
+        #line 4541 "SchemaEntity202012.tt"
 
         }
         
@@ -13157,13 +13445,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4463 "SchemaEntity202012.tt"
+        #line 4544 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4464 "SchemaEntity202012.tt"
+        #line 4545 "SchemaEntity202012.tt"
 
         if (HasPropertyNames || HasPatternProperties)
         {
@@ -13172,13 +13460,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4468 "SchemaEntity202012.tt"
+        #line 4549 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 4468 "SchemaEntity202012.tt"
+        #line 4549 "SchemaEntity202012.tt"
 
             if (HasPropertyNames)
             {
@@ -13187,19 +13475,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4472 "SchemaEntity202012.tt"
+        #line 4553 "SchemaEntity202012.tt"
         this.Write("                result = new JsonString(propertyName).As<");
         
         #line default
         #line hidden
         
-        #line 4472 "SchemaEntity202012.tt"
+        #line 4553 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     PropertyNamesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4472 "SchemaEntity202012.tt"
+        #line 4553 "SchemaEntity202012.tt"
         this.Write(">().Validate(result, level);\r\n                if (level == ValidationLevel.Flag &" +
                 "& !result.IsValid)\r\n                {\r\n                    return result;\r\n     " +
                 "           }\r\n            ");
@@ -13207,7 +13495,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4477 "SchemaEntity202012.tt"
+        #line 4558 "SchemaEntity202012.tt"
 
             }
             
@@ -13215,13 +13503,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4480 "SchemaEntity202012.tt"
+        #line 4561 "SchemaEntity202012.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4481 "SchemaEntity202012.tt"
+        #line 4562 "SchemaEntity202012.tt"
 
             if (HasPatternProperties)
             {
@@ -13230,7 +13518,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4485 "SchemaEntity202012.tt"
+        #line 4566 "SchemaEntity202012.tt"
         this.Write(@"                foreach (System.Collections.Generic.KeyValuePair<Regex, PatternPropertyValidator> patternProperty in __CorvusPatternProperties)
                 {
                     if (patternProperty.Key.IsMatch(propertyName))
@@ -13249,7 +13537,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4498 "SchemaEntity202012.tt"
+        #line 4579 "SchemaEntity202012.tt"
 
             }
             
@@ -13257,13 +13545,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4501 "SchemaEntity202012.tt"
+        #line 4582 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4501 "SchemaEntity202012.tt"
+        #line 4582 "SchemaEntity202012.tt"
 
         }
         
@@ -13271,13 +13559,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4504 "SchemaEntity202012.tt"
+        #line 4585 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4505 "SchemaEntity202012.tt"
+        #line 4586 "SchemaEntity202012.tt"
 
         if (AllowsAdditionalProperties && HasAdditionalProperties)
         {
@@ -13286,20 +13574,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4509 "SchemaEntity202012.tt"
+        #line 4590 "SchemaEntity202012.tt"
         this.Write("                if (!result.HasEvaluatedLocalProperty(propertyCount))\r\n          " +
                 "      {\r\n                    result = property.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 4511 "SchemaEntity202012.tt"
+        #line 4592 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( AdditionalPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4511 "SchemaEntity202012.tt"
+        #line 4592 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
                     if (level == ValidationLevel.Flag && !result.IsValid)
                     {
@@ -13312,7 +13600,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4518 "SchemaEntity202012.tt"
+        #line 4599 "SchemaEntity202012.tt"
 
         }
         
@@ -13320,13 +13608,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4521 "SchemaEntity202012.tt"
+        #line 4602 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4522 "SchemaEntity202012.tt"
+        #line 4603 "SchemaEntity202012.tt"
 
         if (AllowsAdditionalProperties && HasUnevaluatedProperties)
         {
@@ -13335,20 +13623,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4526 "SchemaEntity202012.tt"
+        #line 4607 "SchemaEntity202012.tt"
         this.Write("        \r\n                if (!result.HasEvaluatedLocalOrAppliedProperty(property" +
                 "Count))\r\n                {\r\n\r\n                    result = property.ValueAs<");
         
         #line default
         #line hidden
         
-        #line 4530 "SchemaEntity202012.tt"
+        #line 4611 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( UnevaluatedPropertiesDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4530 "SchemaEntity202012.tt"
+        #line 4611 "SchemaEntity202012.tt"
         this.Write(@">().Validate(result, level);
                     if (level == ValidationLevel.Flag && !result.IsValid)
                     {
@@ -13362,7 +13650,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4538 "SchemaEntity202012.tt"
+        #line 4619 "SchemaEntity202012.tt"
 
         }
         
@@ -13370,13 +13658,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4541 "SchemaEntity202012.tt"
+        #line 4622 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4542 "SchemaEntity202012.tt"
+        #line 4623 "SchemaEntity202012.tt"
 
         if (!AllowsAdditionalProperties)
         {
@@ -13385,7 +13673,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4546 "SchemaEntity202012.tt"
+        #line 4627 "SchemaEntity202012.tt"
         this.Write(@"        
                 if (!result.HasEvaluatedLocalProperty(propertyCount))
                 {
@@ -13408,7 +13696,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4563 "SchemaEntity202012.tt"
+        #line 4644 "SchemaEntity202012.tt"
 
         }
         
@@ -13416,13 +13704,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4566 "SchemaEntity202012.tt"
+        #line 4647 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4567 "SchemaEntity202012.tt"
+        #line 4648 "SchemaEntity202012.tt"
 
         if (HasMaxProperties || HasMinProperties || HasLocalProperties || HasRequired || HasDependentSchemas || HasPatternProperties || HasAdditionalProperties || HasUnevaluatedProperties)
         {
@@ -13431,13 +13719,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4571 "SchemaEntity202012.tt"
+        #line 4652 "SchemaEntity202012.tt"
         this.Write("        \r\n                propertyCount++;\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4574 "SchemaEntity202012.tt"
+        #line 4655 "SchemaEntity202012.tt"
 
         }
         
@@ -13445,13 +13733,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4577 "SchemaEntity202012.tt"
+        #line 4658 "SchemaEntity202012.tt"
         this.Write("            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4579 "SchemaEntity202012.tt"
+        #line 4660 "SchemaEntity202012.tt"
 
         if (HasRequired)
         {
@@ -13460,13 +13748,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4583 "SchemaEntity202012.tt"
+        #line 4664 "SchemaEntity202012.tt"
         this.Write("\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4584 "SchemaEntity202012.tt"
+        #line 4665 "SchemaEntity202012.tt"
 
             foreach (var property in RequiredProperties)
             {
@@ -13477,19 +13765,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4590 "SchemaEntity202012.tt"
+        #line 4671 "SchemaEntity202012.tt"
         this.Write("            if (!found");
         
         #line default
         #line hidden
         
-        #line 4590 "SchemaEntity202012.tt"
+        #line 4671 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    property.DotnetPropertyName ));
         
         #line default
         #line hidden
         
-        #line 4590 "SchemaEntity202012.tt"
+        #line 4671 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".3. required - required property \\\"");
@@ -13497,13 +13785,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4594 "SchemaEntity202012.tt"
+        #line 4675 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    Formatting.FormatLiteralOrNull(property.JsonPropertyName, true).Trim('"') ));
         
         #line default
         #line hidden
         
-        #line 4594 "SchemaEntity202012.tt"
+        #line 4675 "SchemaEntity202012.tt"
         this.Write(@"\"" not present."");
                 }
                 else if (level >= ValidationLevel.Basic)
@@ -13520,7 +13808,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4605 "SchemaEntity202012.tt"
+        #line 4686 "SchemaEntity202012.tt"
 
                 }
             }
@@ -13529,13 +13817,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4609 "SchemaEntity202012.tt"
+        #line 4690 "SchemaEntity202012.tt"
         this.Write("        ");
         
         #line default
         #line hidden
         
-        #line 4609 "SchemaEntity202012.tt"
+        #line 4690 "SchemaEntity202012.tt"
 
         }
         
@@ -13543,13 +13831,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4612 "SchemaEntity202012.tt"
+        #line 4693 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4613 "SchemaEntity202012.tt"
+        #line 4694 "SchemaEntity202012.tt"
 
         if (HasMaxProperties)
         {
@@ -13558,19 +13846,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4617 "SchemaEntity202012.tt"
+        #line 4698 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (propertyCount > ");
         
         #line default
         #line hidden
         
-        #line 4618 "SchemaEntity202012.tt"
+        #line 4699 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4618 "SchemaEntity202012.tt"
+        #line 4699 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".1. maxProperties - property count of {propertyCount} is greater than ");
@@ -13578,13 +13866,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4622 "SchemaEntity202012.tt"
+        #line 4703 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4622 "SchemaEntity202012.tt"
+        #line 4703 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.5.1. maxProperties - property count greater than ");
@@ -13592,13 +13880,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4626 "SchemaEntity202012.tt"
+        #line 4707 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MaxProperties ));
         
         #line default
         #line hidden
         
-        #line 4626 "SchemaEntity202012.tt"
+        #line 4707 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n        ");
@@ -13606,7 +13894,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4633 "SchemaEntity202012.tt"
+        #line 4714 "SchemaEntity202012.tt"
 
         }
         
@@ -13614,13 +13902,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4636 "SchemaEntity202012.tt"
+        #line 4717 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4637 "SchemaEntity202012.tt"
+        #line 4718 "SchemaEntity202012.tt"
 
         if (HasMinProperties)
         {
@@ -13629,19 +13917,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4641 "SchemaEntity202012.tt"
+        #line 4722 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (propertyCount < ");
         
         #line default
         #line hidden
         
-        #line 4642 "SchemaEntity202012.tt"
+        #line 4723 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4642 "SchemaEntity202012.tt"
+        #line 4723 "SchemaEntity202012.tt"
         this.Write(")\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r\n       " +
                 "         {\r\n                    result = result.WithResult(isValid: false, $\"6.5" +
                 ".2. minProperties - property count of {propertyCount} is lezs than ");
@@ -13649,13 +13937,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4646 "SchemaEntity202012.tt"
+        #line 4727 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4646 "SchemaEntity202012.tt"
+        #line 4727 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)" +
                 "\r\n                {\r\n                    result = result.WithResult(isValid: fal" +
                 "se, \"6.5.2. minProperties - property count less than ");
@@ -13663,13 +13951,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4650 "SchemaEntity202012.tt"
+        #line 4731 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( MinProperties ));
         
         #line default
         #line hidden
         
-        #line 4650 "SchemaEntity202012.tt"
+        #line 4731 "SchemaEntity202012.tt"
         this.Write(".\");\r\n                }\r\n                else\r\n                {\r\n               " +
                 "     return result.WithResult(isValid: false);\r\n                }\r\n            }" +
                 "\r\n\r\n        ");
@@ -13677,7 +13965,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4658 "SchemaEntity202012.tt"
+        #line 4739 "SchemaEntity202012.tt"
 
         }
         
@@ -13685,13 +13973,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4661 "SchemaEntity202012.tt"
+        #line 4742 "SchemaEntity202012.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4665 "SchemaEntity202012.tt"
+        #line 4746 "SchemaEntity202012.tt"
 
     }
     
@@ -13699,13 +13987,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4668 "SchemaEntity202012.tt"
+        #line 4749 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4669 "SchemaEntity202012.tt"
+        #line 4750 "SchemaEntity202012.tt"
 
     if (HasOneOf)
     {
@@ -13714,7 +14002,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4673 "SchemaEntity202012.tt"
+        #line 4754 "SchemaEntity202012.tt"
         this.Write("        \r\n        private ValidationContext ValidateOneOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n            int oneOfCount = 0;\r\n\r\n        ");
@@ -13722,7 +14010,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4680 "SchemaEntity202012.tt"
+        #line 4761 "SchemaEntity202012.tt"
 
         int oneOfIndex = 0;
         foreach (var oneOf in OneOf)
@@ -13732,64 +14020,64 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4685 "SchemaEntity202012.tt"
+        #line 4766 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n            ValidationContext oneOfResult");
         
         #line default
         #line hidden
         
-        #line 4687 "SchemaEntity202012.tt"
+        #line 4768 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex));
         
         #line default
         #line hidden
         
-        #line 4687 "SchemaEntity202012.tt"
+        #line 4768 "SchemaEntity202012.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 4687 "SchemaEntity202012.tt"
+        #line 4768 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOf ));
         
         #line default
         #line hidden
         
-        #line 4687 "SchemaEntity202012.tt"
+        #line 4768 "SchemaEntity202012.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (o" +
                 "neOfResult");
         
         #line default
         #line hidden
         
-        #line 4689 "SchemaEntity202012.tt"
+        #line 4770 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4689 "SchemaEntity202012.tt"
+        #line 4770 "SchemaEntity202012.tt"
         this.Write(".IsValid)\r\n            {\r\n                result = result.MergeChildContext(oneOf" +
                 "Result");
         
         #line default
         #line hidden
         
-        #line 4691 "SchemaEntity202012.tt"
+        #line 4772 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4691 "SchemaEntity202012.tt"
+        #line 4772 "SchemaEntity202012.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n                oneOfCount += 1;\r\n        " +
                 "                    ");
         
         #line default
         #line hidden
         
-        #line 4693 "SchemaEntity202012.tt"
+        #line 4774 "SchemaEntity202012.tt"
 
             if (!HasUnevaluatedItems && !HasUnevaluatedProperties)
             {
@@ -13798,7 +14086,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4697 "SchemaEntity202012.tt"
+        #line 4778 "SchemaEntity202012.tt"
         this.Write("                if (oneOfCount > 1 && level == ValidationLevel.Flag)\r\n           " +
                 "     {\r\n                    result = result.WithResult(isValid: false);\r\n       " +
                 "             return result;\r\n                }\r\n            ");
@@ -13806,7 +14094,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4702 "SchemaEntity202012.tt"
+        #line 4783 "SchemaEntity202012.tt"
 
             }
             
@@ -13814,7 +14102,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4705 "SchemaEntity202012.tt"
+        #line 4786 "SchemaEntity202012.tt"
         this.Write("            }\r\n            else\r\n            {\r\n                if (level >= Vali" +
                 "dationLevel.Detailed)\r\n                {\r\n                    result = result.Me" +
                 "rgeResults(result.IsValid, level, oneOfResult");
@@ -13822,13 +14110,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4710 "SchemaEntity202012.tt"
+        #line 4791 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4710 "SchemaEntity202012.tt"
+        #line 4791 "SchemaEntity202012.tt"
         this.Write(");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)\r\n" +
                 "                {\r\n                    result = result.MergeResults(result.IsVal" +
                 "id, level, oneOfResult");
@@ -13836,32 +14124,32 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4714 "SchemaEntity202012.tt"
+        #line 4795 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4714 "SchemaEntity202012.tt"
+        #line 4795 "SchemaEntity202012.tt"
         this.Write(");\r\n                }\r\n                else\r\n                {\r\n                 " +
                 "   result = result.MergeResults(result.IsValid, level, oneOfResult");
         
         #line default
         #line hidden
         
-        #line 4718 "SchemaEntity202012.tt"
+        #line 4799 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( oneOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4718 "SchemaEntity202012.tt"
+        #line 4799 "SchemaEntity202012.tt"
         this.Write(");\r\n                }\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4722 "SchemaEntity202012.tt"
+        #line 4803 "SchemaEntity202012.tt"
 
             oneOfIndex++;
         }
@@ -13870,7 +14158,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4726 "SchemaEntity202012.tt"
+        #line 4807 "SchemaEntity202012.tt"
         this.Write("\r\n            if (oneOfCount == 1)\r\n            {\r\n                if (level >= V" +
                 "alidationLevel.Detailed)\r\n                {\r\n                    result = result" +
                 ".WithResult(isValid: true, \"Validation 10.2.1.3. onef - validated against the on" +
@@ -13897,7 +14185,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4768 "SchemaEntity202012.tt"
+        #line 4849 "SchemaEntity202012.tt"
 
     }
     
@@ -13905,13 +14193,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4771 "SchemaEntity202012.tt"
+        #line 4852 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4773 "SchemaEntity202012.tt"
+        #line 4854 "SchemaEntity202012.tt"
 
     if (HasAnyOf)
     {
@@ -13920,7 +14208,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4777 "SchemaEntity202012.tt"
+        #line 4858 "SchemaEntity202012.tt"
         this.Write("        \r\n        private ValidationContext ValidateAnyOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n            bool foundValid = false;\r\n\r\n       " +
@@ -13929,7 +14217,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4784 "SchemaEntity202012.tt"
+        #line 4865 "SchemaEntity202012.tt"
 
         int anyOfIndex = 0;
         foreach (var anyOf in AnyOf)
@@ -13939,63 +14227,63 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4789 "SchemaEntity202012.tt"
+        #line 4870 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n            ValidationContext anyOfResult");
         
         #line default
         #line hidden
         
-        #line 4791 "SchemaEntity202012.tt"
+        #line 4872 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4791 "SchemaEntity202012.tt"
+        #line 4872 "SchemaEntity202012.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 4791 "SchemaEntity202012.tt"
+        #line 4872 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOf ));
         
         #line default
         #line hidden
         
-        #line 4791 "SchemaEntity202012.tt"
+        #line 4872 "SchemaEntity202012.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (a" +
                 "nyOfResult");
         
         #line default
         #line hidden
         
-        #line 4793 "SchemaEntity202012.tt"
+        #line 4874 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4793 "SchemaEntity202012.tt"
+        #line 4874 "SchemaEntity202012.tt"
         this.Write(".IsValid)\r\n            {\r\n                result = result.MergeChildContext(anyOf" +
                 "Result");
         
         #line default
         #line hidden
         
-        #line 4795 "SchemaEntity202012.tt"
+        #line 4876 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4795 "SchemaEntity202012.tt"
+        #line 4876 "SchemaEntity202012.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4796 "SchemaEntity202012.tt"
+        #line 4877 "SchemaEntity202012.tt"
 
             if (!HasUnevaluatedItems && !HasUnevaluatedProperties)
             {
@@ -14004,7 +14292,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4800 "SchemaEntity202012.tt"
+        #line 4881 "SchemaEntity202012.tt"
         this.Write("                if (level == ValidationLevel.Flag)\r\n                {\r\n          " +
                 "          return result;\r\n                }\r\n                else\r\n             " +
                 "   {\r\n                    foundValid = true;\r\n                }\r\n            ");
@@ -14012,7 +14300,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4808 "SchemaEntity202012.tt"
+        #line 4889 "SchemaEntity202012.tt"
 
             }
             else
@@ -14022,13 +14310,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4813 "SchemaEntity202012.tt"
+        #line 4894 "SchemaEntity202012.tt"
         this.Write("                    foundValid = true;\r\n            ");
         
         #line default
         #line hidden
         
-        #line 4814 "SchemaEntity202012.tt"
+        #line 4895 "SchemaEntity202012.tt"
 
             }
             
@@ -14036,7 +14324,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4817 "SchemaEntity202012.tt"
+        #line 4898 "SchemaEntity202012.tt"
         this.Write("            }\r\n            else\r\n            {\r\n                if (level >= Vali" +
                 "dationLevel.Detailed)\r\n                {\r\n                    result = result.Me" +
                 "rgeResults(result.IsValid, level, anyOfResult");
@@ -14044,13 +14332,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4822 "SchemaEntity202012.tt"
+        #line 4903 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4822 "SchemaEntity202012.tt"
+        #line 4903 "SchemaEntity202012.tt"
         this.Write(");\r\n                }\r\n                else if (level >= ValidationLevel.Basic)\r\n" +
                 "                {\r\n                    result = result.MergeResults(result.IsVal" +
                 "id, level, anyOfResult");
@@ -14058,19 +14346,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4826 "SchemaEntity202012.tt"
+        #line 4907 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( anyOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4826 "SchemaEntity202012.tt"
+        #line 4907 "SchemaEntity202012.tt"
         this.Write(");\r\n                }\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4830 "SchemaEntity202012.tt"
+        #line 4911 "SchemaEntity202012.tt"
 
             anyOfIndex++;
         }
@@ -14079,7 +14367,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4834 "SchemaEntity202012.tt"
+        #line 4915 "SchemaEntity202012.tt"
         this.Write(@"
             if (foundValid)
             {
@@ -14112,7 +14400,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4861 "SchemaEntity202012.tt"
+        #line 4942 "SchemaEntity202012.tt"
 
     }
     
@@ -14120,13 +14408,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4864 "SchemaEntity202012.tt"
+        #line 4945 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4866 "SchemaEntity202012.tt"
+        #line 4947 "SchemaEntity202012.tt"
 
     if (HasAllOf)
     {
@@ -14135,7 +14423,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4870 "SchemaEntity202012.tt"
+        #line 4951 "SchemaEntity202012.tt"
         this.Write("        \r\n        private ValidationContext ValidateAllOf(in ValidationContext va" +
                 "lidationContext, ValidationLevel level)\r\n        {\r\n            ValidationContex" +
                 "t result = validationContext;\r\n\r\n        ");
@@ -14143,7 +14431,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4875 "SchemaEntity202012.tt"
+        #line 4956 "SchemaEntity202012.tt"
 
         int allOfIndex = 0;
         foreach (var allOf in AllOf)
@@ -14153,44 +14441,44 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4880 "SchemaEntity202012.tt"
+        #line 4961 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n            ValidationContext allOfResult");
         
         #line default
         #line hidden
         
-        #line 4882 "SchemaEntity202012.tt"
+        #line 4963 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4882 "SchemaEntity202012.tt"
+        #line 4963 "SchemaEntity202012.tt"
         this.Write(" = this.As<");
         
         #line default
         #line hidden
         
-        #line 4882 "SchemaEntity202012.tt"
+        #line 4963 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOf ));
         
         #line default
         #line hidden
         
-        #line 4882 "SchemaEntity202012.tt"
+        #line 4963 "SchemaEntity202012.tt"
         this.Write(">().Validate(validationContext.CreateChildContext(), level);\r\n\r\n            if (!" +
                 "allOfResult");
         
         #line default
         #line hidden
         
-        #line 4884 "SchemaEntity202012.tt"
+        #line 4965 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4884 "SchemaEntity202012.tt"
+        #line 4965 "SchemaEntity202012.tt"
         this.Write(".IsValid)\r\n            {\r\n                if (level >= ValidationLevel.Detailed)\r" +
                 "\n                {\r\n                    result = result.MergeChildContext(allOfR" +
                 "esult");
@@ -14198,13 +14486,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4888 "SchemaEntity202012.tt"
+        #line 4969 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4888 "SchemaEntity202012.tt"
+        #line 4969 "SchemaEntity202012.tt"
         this.Write(@", true).WithResult(isValid: false, ""Validation 10.2.1.1. allOf - failed to validate against the allOf schema."");
                 }
                 else if (level >= ValidationLevel.Basic)
@@ -14214,13 +14502,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4892 "SchemaEntity202012.tt"
+        #line 4973 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4892 "SchemaEntity202012.tt"
+        #line 4973 "SchemaEntity202012.tt"
         this.Write(", true).WithResult(isValid: false, \"Validation 10.2.1.1. allOf - failed to valida" +
                 "te against the allOf schema.\");\r\n                }\r\n                else\r\n      " +
                 "          {\r\n                    result = result.MergeChildContext(allOfResult");
@@ -14228,13 +14516,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4896 "SchemaEntity202012.tt"
+        #line 4977 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4896 "SchemaEntity202012.tt"
+        #line 4977 "SchemaEntity202012.tt"
         this.Write(", false).WithResult(isValid: false);\r\n                    return result;\r\n       " +
                 "         }\r\n            }\r\n            else\r\n            {\r\n                resu" +
                 "lt = result.MergeChildContext(allOfResult");
@@ -14242,19 +14530,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4902 "SchemaEntity202012.tt"
+        #line 4983 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( allOfIndex ));
         
         #line default
         #line hidden
         
-        #line 4902 "SchemaEntity202012.tt"
+        #line 4983 "SchemaEntity202012.tt"
         this.Write(", level >= ValidationLevel.Detailed);\r\n            }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 4905 "SchemaEntity202012.tt"
+        #line 4986 "SchemaEntity202012.tt"
 
             allOfIndex++;
         }
@@ -14263,13 +14551,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4909 "SchemaEntity202012.tt"
+        #line 4990 "SchemaEntity202012.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4913 "SchemaEntity202012.tt"
+        #line 4994 "SchemaEntity202012.tt"
 
     }
     
@@ -14277,13 +14565,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4916 "SchemaEntity202012.tt"
+        #line 4997 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4918 "SchemaEntity202012.tt"
+        #line 4999 "SchemaEntity202012.tt"
 
     if (HasNot)
     {
@@ -14292,7 +14580,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4922 "SchemaEntity202012.tt"
+        #line 5003 "SchemaEntity202012.tt"
         this.Write("        \r\n        private ValidationContext ValidateNot(ValidationContext validat" +
                 "ionContext, ValidationLevel level)\r\n        {\r\n            ValidationContext res" +
                 "ult = validationContext;\r\n\r\n            ValidationContext notResult = this.As<");
@@ -14300,13 +14588,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4927 "SchemaEntity202012.tt"
+        #line 5008 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( NotDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4927 "SchemaEntity202012.tt"
+        #line 5008 "SchemaEntity202012.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
             if (notResult.IsValid)
             {
@@ -14336,7 +14624,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4951 "SchemaEntity202012.tt"
+        #line 5032 "SchemaEntity202012.tt"
 
     }
     
@@ -14344,13 +14632,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4954 "SchemaEntity202012.tt"
+        #line 5035 "SchemaEntity202012.tt"
         this.Write("        \r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 4956 "SchemaEntity202012.tt"
+        #line 5037 "SchemaEntity202012.tt"
 
     if (HasIfThenElse)
     {
@@ -14359,7 +14647,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4960 "SchemaEntity202012.tt"
+        #line 5041 "SchemaEntity202012.tt"
         this.Write("        \r\n        private ValidationContext ValidateIfThenElse(in ValidationConte" +
                 "xt validationContext, ValidationLevel level)\r\n        {\r\n            ValidationC" +
                 "ontext result = validationContext;\r\n\r\n            ValidationContext ifResult = t" +
@@ -14368,13 +14656,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4965 "SchemaEntity202012.tt"
+        #line 5046 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( IfFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4965 "SchemaEntity202012.tt"
+        #line 5046 "SchemaEntity202012.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
             if (!ifResult.IsValid)
@@ -14404,7 +14692,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4989 "SchemaEntity202012.tt"
+        #line 5070 "SchemaEntity202012.tt"
 
         if (HasThen)
         {
@@ -14413,20 +14701,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 4993 "SchemaEntity202012.tt"
+        #line 5074 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (ifResult.IsValid)\r\n            {\r\n                Valid" +
                 "ationContext thenResult = this.As<");
         
         #line default
         #line hidden
         
-        #line 4996 "SchemaEntity202012.tt"
+        #line 5077 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ThenFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 4996 "SchemaEntity202012.tt"
+        #line 5077 "SchemaEntity202012.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
                 if (!thenResult.IsValid)
@@ -14460,7 +14748,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5024 "SchemaEntity202012.tt"
+        #line 5105 "SchemaEntity202012.tt"
 
         }
         
@@ -14468,13 +14756,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5027 "SchemaEntity202012.tt"
+        #line 5108 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5028 "SchemaEntity202012.tt"
+        #line 5109 "SchemaEntity202012.tt"
 
         if (HasElse)
         {
@@ -14483,20 +14771,20 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5032 "SchemaEntity202012.tt"
+        #line 5113 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (!ifResult.IsValid)\r\n            {\r\n                Vali" +
                 "dationContext elseResult = this.As<");
         
         #line default
         #line hidden
         
-        #line 5035 "SchemaEntity202012.tt"
+        #line 5116 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( ElseFullyQualifiedDotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5035 "SchemaEntity202012.tt"
+        #line 5116 "SchemaEntity202012.tt"
         this.Write(@">().Validate(validationContext.CreateChildContext(), level);
 
                 if (!elseResult.IsValid)
@@ -14530,7 +14818,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5063 "SchemaEntity202012.tt"
+        #line 5144 "SchemaEntity202012.tt"
 
         }
         
@@ -14538,13 +14826,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5066 "SchemaEntity202012.tt"
+        #line 5147 "SchemaEntity202012.tt"
         this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5070 "SchemaEntity202012.tt"
+        #line 5151 "SchemaEntity202012.tt"
 
     }
     
@@ -14552,13 +14840,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5073 "SchemaEntity202012.tt"
+        #line 5154 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5074 "SchemaEntity202012.tt"
+        #line 5155 "SchemaEntity202012.tt"
 
     if (HasMediaTypeOrEncoding)
     {
@@ -14567,14 +14855,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5078 "SchemaEntity202012.tt"
+        #line 5159 "SchemaEntity202012.tt"
         this.Write("        private ValidationContext ValidateMediaTypeAndEncoding(JsonValueKind valu" +
                 "eKind, ValidationContext result, ValidationLevel level)\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5080 "SchemaEntity202012.tt"
+        #line 5161 "SchemaEntity202012.tt"
 
         if (IsJsonBase64Content)
         {
@@ -14583,195 +14871,10 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5084 "SchemaEntity202012.tt"
+        #line 5165 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return this.As<JsonBase64Content>().Validate(result, level);\r\n      " +
                 "      }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5089 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5092 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5093 "SchemaEntity202012.tt"
-
-        if (IsJsonBase64String)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5097 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return this.As<JsonBase64String>().Validate(result, level);\r\n       " +
-                "     }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5103 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5106 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5107 "SchemaEntity202012.tt"
-
-        if (IsJsonContent)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5111 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return this.As<JsonContent>().Validate(result, level);\r\n            " +
-                "}\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5116 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5119 "SchemaEntity202012.tt"
-        this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 5123 "SchemaEntity202012.tt"
-
-    }
-    
-        
-        #line default
-        #line hidden
-        
-        #line 5126 "SchemaEntity202012.tt"
-        this.Write("\r\n    ");
-        
-        #line default
-        #line hidden
-        
-        #line 5127 "SchemaEntity202012.tt"
-
-    if (HasFormat)
-    {
-    
-        
-        #line default
-        #line hidden
-        
-        #line 5131 "SchemaEntity202012.tt"
-        this.Write("        \r\n        private ValidationContext ValidateFormat(JsonValueKind valueKin" +
-                "d, ValidationContext result, ValidationLevel level)\r\n        {\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5134 "SchemaEntity202012.tt"
-
-        if (IsJsonRelativePointer)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5138 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
-                "vel);\r\n            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5143 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5146 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5147 "SchemaEntity202012.tt"
-
-        if (IsJsonDate)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5151 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeDate(this, result, level);\r\n        " +
-                "    }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5157 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5160 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5161 "SchemaEntity202012.tt"
-
-        if (IsJsonDateTime)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5165 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeDateTime(this, result, level);\r\n    " +
-                "        }\r\n        ");
         
         #line default
         #line hidden
@@ -14792,7 +14895,7 @@ namespace ");
         
         #line 5174 "SchemaEntity202012.tt"
 
-        if (IsJsonDuration)
+        if (IsJsonBase64String)
         {
         
         
@@ -14801,13 +14904,13 @@ namespace ");
         
         #line 5178 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeDuration(this, result, level);\r\n    " +
-                "        }\r\n        ");
+                "            return this.As<JsonBase64String>().Validate(result, level);\r\n       " +
+                "     }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5183 "SchemaEntity202012.tt"
+        #line 5184 "SchemaEntity202012.tt"
 
         }
         
@@ -14815,13 +14918,198 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5186 "SchemaEntity202012.tt"
+        #line 5187 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5187 "SchemaEntity202012.tt"
+        #line 5188 "SchemaEntity202012.tt"
+
+        if (IsJsonContent)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5192 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return this.As<JsonContent>().Validate(result, level);\r\n            " +
+                "}\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5197 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5200 "SchemaEntity202012.tt"
+        this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 5204 "SchemaEntity202012.tt"
+
+    }
+    
+        
+        #line default
+        #line hidden
+        
+        #line 5207 "SchemaEntity202012.tt"
+        this.Write("\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 5208 "SchemaEntity202012.tt"
+
+    if (HasFormat)
+    {
+    
+        
+        #line default
+        #line hidden
+        
+        #line 5212 "SchemaEntity202012.tt"
+        this.Write("        \r\n        private ValidationContext ValidateFormat(JsonValueKind valueKin" +
+                "d, ValidationContext result, ValidationLevel level)\r\n        {\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5215 "SchemaEntity202012.tt"
+
+        if (IsJsonRelativePointer)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5219 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
+                "vel);\r\n            }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5224 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5227 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5228 "SchemaEntity202012.tt"
+
+        if (IsJsonDate)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5232 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeDate(this, result, level);\r\n        " +
+                "    }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5238 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5241 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5242 "SchemaEntity202012.tt"
+
+        if (IsJsonDateTime)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5246 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeDateTime(this, result, level);\r\n    " +
+                "        }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5251 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5254 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5255 "SchemaEntity202012.tt"
+
+        if (IsJsonDuration)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5259 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeDuration(this, result, level);\r\n    " +
+                "        }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5264 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5267 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5268 "SchemaEntity202012.tt"
 
         if (IsJsonTime)
         {
@@ -14830,7 +15118,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5191 "SchemaEntity202012.tt"
+        #line 5272 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeTime(this, result, level);\r\n        " +
                 "    }\r\n        ");
@@ -14838,7 +15126,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5196 "SchemaEntity202012.tt"
+        #line 5277 "SchemaEntity202012.tt"
 
         }
         
@@ -14846,13 +15134,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5199 "SchemaEntity202012.tt"
+        #line 5280 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5200 "SchemaEntity202012.tt"
+        #line 5281 "SchemaEntity202012.tt"
 
         if (IsJsonEmail)
         {
@@ -14861,196 +15149,10 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5204 "SchemaEntity202012.tt"
+        #line 5285 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeEmail(this, result, level);\r\n       " +
                 "     }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5209 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5212 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5213 "SchemaEntity202012.tt"
-
-        if (IsJsonHostname)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5217 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeHostname(this, result, level);\r\n    " +
-                "        }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5222 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5225 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5226 "SchemaEntity202012.tt"
-
-        if (IsJsonIdnEmail)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5230 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIdnEmail(this, result, level);\r\n    " +
-                "        }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5236 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5239 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5240 "SchemaEntity202012.tt"
-
-        if (IsJsonIdnHostname)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5244 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIdnHostname(this, result, level);\r\n " +
-                "           }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5249 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5252 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5253 "SchemaEntity202012.tt"
-
-        if (IsJsonInteger)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5257 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.Number)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeInteger(this, result, level);\r\n     " +
-                "       }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5262 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5265 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5266 "SchemaEntity202012.tt"
-
-        if (IsJsonIpV4)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5270 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIpV4(this, result, level);\r\n        " +
-                "    }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5276 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5279 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5280 "SchemaEntity202012.tt"
-
-        if (IsJsonIpV6)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5284 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIpV6(this, result, level);\r\n        " +
-                "    }\r\n\r\n        ");
         
         #line default
         #line hidden
@@ -15071,7 +15173,7 @@ namespace ");
         
         #line 5294 "SchemaEntity202012.tt"
 
-        if (IsJsonIri)
+        if (IsJsonHostname)
         {
         
         
@@ -15080,8 +15182,8 @@ namespace ");
         
         #line 5298 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIri(this, result, level);\r\n         " +
-                "   }\r\n        ");
+                "            return Corvus.Json.Validate.TypeHostname(this, result, level);\r\n    " +
+                "        }\r\n        ");
         
         #line default
         #line hidden
@@ -15102,7 +15204,7 @@ namespace ");
         
         #line 5307 "SchemaEntity202012.tt"
 
-        if (IsJsonIriReference)
+        if (IsJsonIdnEmail)
         {
         
         
@@ -15111,13 +15213,13 @@ namespace ");
         
         #line 5311 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeIriReference(this, result, level);\r\n" +
-                "            }\r\n        ");
+                "            return Corvus.Json.Validate.TypeIdnEmail(this, result, level);\r\n    " +
+                "        }\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5316 "SchemaEntity202012.tt"
+        #line 5317 "SchemaEntity202012.tt"
 
         }
         
@@ -15125,13 +15227,199 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5319 "SchemaEntity202012.tt"
+        #line 5320 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5320 "SchemaEntity202012.tt"
+        #line 5321 "SchemaEntity202012.tt"
+
+        if (IsJsonIdnHostname)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5325 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeIdnHostname(this, result, level);\r\n " +
+                "           }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5330 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5333 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5334 "SchemaEntity202012.tt"
+
+        if (IsJsonInteger)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5338 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.Number)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeInteger(this, result, level);\r\n     " +
+                "       }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5343 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5346 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5347 "SchemaEntity202012.tt"
+
+        if (IsJsonIpV4)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5351 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeIpV4(this, result, level);\r\n        " +
+                "    }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5357 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5360 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5361 "SchemaEntity202012.tt"
+
+        if (IsJsonIpV6)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5365 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeIpV6(this, result, level);\r\n        " +
+                "    }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5371 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5374 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5375 "SchemaEntity202012.tt"
+
+        if (IsJsonIri)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5379 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeIri(this, result, level);\r\n         " +
+                "   }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5384 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5387 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5388 "SchemaEntity202012.tt"
+
+        if (IsJsonIriReference)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5392 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeIriReference(this, result, level);\r\n" +
+                "            }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5397 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5400 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5401 "SchemaEntity202012.tt"
 
         if (IsJsonPointer)
         {
@@ -15140,196 +15428,10 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5324 "SchemaEntity202012.tt"
+        #line 5405 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
                 "            return Corvus.Json.Validate.TypeJsonPointer(this, result, level);\r\n " +
                 "           }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5329 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5332 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5333 "SchemaEntity202012.tt"
-
-        if (IsJsonRegex)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5337 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeRegex(this, result, level);\r\n       " +
-                "     }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5342 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5345 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5346 "SchemaEntity202012.tt"
-
-        if (IsJsonRelativePointer)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5350 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
-                "vel);\r\n            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5355 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5358 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5359 "SchemaEntity202012.tt"
-
-        if (IsJsonTime)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5363 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeTime(this, result, level);\r\n        " +
-                "    }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5369 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5372 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5373 "SchemaEntity202012.tt"
-
-        if (IsJsonUri)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5377 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeUri(this, result, level);\r\n         " +
-                "   }\r\n\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5383 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5386 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5387 "SchemaEntity202012.tt"
-
-        if (IsJsonUriReference)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5391 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeUriReference(this, result, level);\r\n" +
-                "            }\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5396 "SchemaEntity202012.tt"
-
-        }
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5399 "SchemaEntity202012.tt"
-        this.Write("\r\n        ");
-        
-        #line default
-        #line hidden
-        
-        #line 5400 "SchemaEntity202012.tt"
-
-        if (IsJsonUriTemplate)
-        {
-        
-        
-        #line default
-        #line hidden
-        
-        #line 5404 "SchemaEntity202012.tt"
-        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeUriTemplate(this, result, level);\r\n " +
-                "           }\r\n\r\n        ");
         
         #line default
         #line hidden
@@ -15350,7 +15452,7 @@ namespace ");
         
         #line 5414 "SchemaEntity202012.tt"
 
-        if (IsJsonUuid)
+        if (IsJsonRegex)
         {
         
         
@@ -15359,13 +15461,13 @@ namespace ");
         
         #line 5418 "SchemaEntity202012.tt"
         this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
-                "            return Corvus.Json.Validate.TypeUuid(this, result, level);\r\n        " +
-                "    }\r\n\r\n        ");
+                "            return Corvus.Json.Validate.TypeRegex(this, result, level);\r\n       " +
+                "     }\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5424 "SchemaEntity202012.tt"
+        #line 5423 "SchemaEntity202012.tt"
 
         }
         
@@ -15373,13 +15475,199 @@ namespace ");
         #line default
         #line hidden
         
+        #line 5426 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
         #line 5427 "SchemaEntity202012.tt"
-        this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
+
+        if (IsJsonRelativePointer)
+        {
+        
         
         #line default
         #line hidden
         
         #line 5431 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeRelativeJsonPointer(this, result, le" +
+                "vel);\r\n            }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5436 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5439 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5440 "SchemaEntity202012.tt"
+
+        if (IsJsonTime)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5444 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeTime(this, result, level);\r\n        " +
+                "    }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5450 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5453 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5454 "SchemaEntity202012.tt"
+
+        if (IsJsonUri)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5458 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeUri(this, result, level);\r\n         " +
+                "   }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5464 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5467 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5468 "SchemaEntity202012.tt"
+
+        if (IsJsonUriReference)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5472 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeUriReference(this, result, level);\r\n" +
+                "            }\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5477 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5480 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5481 "SchemaEntity202012.tt"
+
+        if (IsJsonUriTemplate)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5485 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeUriTemplate(this, result, level);\r\n " +
+                "           }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5491 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5494 "SchemaEntity202012.tt"
+        this.Write("\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5495 "SchemaEntity202012.tt"
+
+        if (IsJsonUuid)
+        {
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5499 "SchemaEntity202012.tt"
+        this.Write("        \r\n            if (valueKind == JsonValueKind.String)\r\n            {\r\n    " +
+                "            return Corvus.Json.Validate.TypeUuid(this, result, level);\r\n        " +
+                "    }\r\n\r\n        ");
+        
+        #line default
+        #line hidden
+        
+        #line 5505 "SchemaEntity202012.tt"
+
+        }
+        
+        
+        #line default
+        #line hidden
+        
+        #line 5508 "SchemaEntity202012.tt"
+        this.Write("\r\n            return result;\r\n        }\r\n\r\n    ");
+        
+        #line default
+        #line hidden
+        
+        #line 5512 "SchemaEntity202012.tt"
 
     }
     
@@ -15387,13 +15675,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5434 "SchemaEntity202012.tt"
+        #line 5515 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5435 "SchemaEntity202012.tt"
+        #line 5516 "SchemaEntity202012.tt"
 
     if (HasType)
     {
@@ -15402,7 +15690,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5439 "SchemaEntity202012.tt"
+        #line 5520 "SchemaEntity202012.tt"
         this.Write(@"        
         private ValidationContext ValidateType(JsonValueKind valueKind, in ValidationContext validationContext, ValidationLevel level)
         {
@@ -15414,7 +15702,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5445 "SchemaEntity202012.tt"
+        #line 5526 "SchemaEntity202012.tt"
 
         if (HasStringType)
         {
@@ -15423,7 +15711,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5449 "SchemaEntity202012.tt"
+        #line 5530 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultString = Corvus.Json.Validate.TypeString(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultString.IsValid)
@@ -15441,7 +15729,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5461 "SchemaEntity202012.tt"
+        #line 5542 "SchemaEntity202012.tt"
 
         }
         
@@ -15449,13 +15737,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5464 "SchemaEntity202012.tt"
+        #line 5545 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5465 "SchemaEntity202012.tt"
+        #line 5546 "SchemaEntity202012.tt"
 
         if (HasObjectType)
         {
@@ -15464,7 +15752,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5469 "SchemaEntity202012.tt"
+        #line 5550 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultObject = Corvus.Json.Validate.TypeObject(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultObject.IsValid)
@@ -15482,7 +15770,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5481 "SchemaEntity202012.tt"
+        #line 5562 "SchemaEntity202012.tt"
 
         }
         
@@ -15490,13 +15778,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5484 "SchemaEntity202012.tt"
+        #line 5565 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5485 "SchemaEntity202012.tt"
+        #line 5566 "SchemaEntity202012.tt"
 
         if (HasArrayType)
         {
@@ -15505,7 +15793,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5489 "SchemaEntity202012.tt"
+        #line 5570 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultArray = Corvus.Json.Validate.TypeArray(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultArray.IsValid)
@@ -15523,7 +15811,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5501 "SchemaEntity202012.tt"
+        #line 5582 "SchemaEntity202012.tt"
 
         }
         
@@ -15531,13 +15819,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5504 "SchemaEntity202012.tt"
+        #line 5585 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5505 "SchemaEntity202012.tt"
+        #line 5586 "SchemaEntity202012.tt"
 
         if (HasNumberType)
         {
@@ -15546,7 +15834,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5509 "SchemaEntity202012.tt"
+        #line 5590 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultNumber = Corvus.Json.Validate.TypeNumber(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultNumber.IsValid)
@@ -15564,7 +15852,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5521 "SchemaEntity202012.tt"
+        #line 5602 "SchemaEntity202012.tt"
 
         }
         
@@ -15572,13 +15860,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5524 "SchemaEntity202012.tt"
+        #line 5605 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5525 "SchemaEntity202012.tt"
+        #line 5606 "SchemaEntity202012.tt"
 
         if (HasIntegerType)
         {
@@ -15587,7 +15875,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5529 "SchemaEntity202012.tt"
+        #line 5610 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultInteger = Corvus.Json.Validate.TypeInteger(this, result, level);
             if (level == ValidationLevel.Flag && localResultInteger.IsValid)
@@ -15605,7 +15893,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5541 "SchemaEntity202012.tt"
+        #line 5622 "SchemaEntity202012.tt"
 
         }
         
@@ -15613,13 +15901,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5544 "SchemaEntity202012.tt"
+        #line 5625 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5545 "SchemaEntity202012.tt"
+        #line 5626 "SchemaEntity202012.tt"
 
         if (HasBooleanType)
         {
@@ -15628,7 +15916,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5549 "SchemaEntity202012.tt"
+        #line 5630 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultBoolean = Corvus.Json.Validate.TypeBoolean(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultBoolean.IsValid)
@@ -15646,7 +15934,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5561 "SchemaEntity202012.tt"
+        #line 5642 "SchemaEntity202012.tt"
 
         }
         
@@ -15654,13 +15942,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5564 "SchemaEntity202012.tt"
+        #line 5645 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5565 "SchemaEntity202012.tt"
+        #line 5646 "SchemaEntity202012.tt"
 
         if (HasNullType)
         {
@@ -15669,7 +15957,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5569 "SchemaEntity202012.tt"
+        #line 5650 "SchemaEntity202012.tt"
         this.Write(@"        
             ValidationContext localResultNull = Corvus.Json.Validate.TypeNull(valueKind, result, level);
             if (level == ValidationLevel.Flag && localResultNull.IsValid)
@@ -15687,7 +15975,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5581 "SchemaEntity202012.tt"
+        #line 5662 "SchemaEntity202012.tt"
 
         }
         
@@ -15695,14 +15983,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5584 "SchemaEntity202012.tt"
+        #line 5665 "SchemaEntity202012.tt"
         this.Write("\r\n            result = result.MergeResults(\r\n                isValid,\r\n          " +
                 "      level\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5588 "SchemaEntity202012.tt"
+        #line 5669 "SchemaEntity202012.tt"
 
         if (HasStringType)
         {
@@ -15711,13 +15999,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5592 "SchemaEntity202012.tt"
+        #line 5673 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultString\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5594 "SchemaEntity202012.tt"
+        #line 5675 "SchemaEntity202012.tt"
 
         }
         
@@ -15725,13 +16013,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5597 "SchemaEntity202012.tt"
+        #line 5678 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5598 "SchemaEntity202012.tt"
+        #line 5679 "SchemaEntity202012.tt"
 
         if (HasObjectType)
         {
@@ -15740,13 +16028,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5602 "SchemaEntity202012.tt"
+        #line 5683 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultObject\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5604 "SchemaEntity202012.tt"
+        #line 5685 "SchemaEntity202012.tt"
 
         }
         
@@ -15754,13 +16042,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5607 "SchemaEntity202012.tt"
+        #line 5688 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5608 "SchemaEntity202012.tt"
+        #line 5689 "SchemaEntity202012.tt"
 
         if (HasArrayType)
         {
@@ -15769,13 +16057,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5612 "SchemaEntity202012.tt"
+        #line 5693 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultArray\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5614 "SchemaEntity202012.tt"
+        #line 5695 "SchemaEntity202012.tt"
 
         }
         
@@ -15783,13 +16071,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5617 "SchemaEntity202012.tt"
+        #line 5698 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5618 "SchemaEntity202012.tt"
+        #line 5699 "SchemaEntity202012.tt"
 
         if (HasNumberType)
         {
@@ -15798,13 +16086,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5622 "SchemaEntity202012.tt"
+        #line 5703 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultNumber\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5624 "SchemaEntity202012.tt"
+        #line 5705 "SchemaEntity202012.tt"
 
         }
         
@@ -15812,13 +16100,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5627 "SchemaEntity202012.tt"
+        #line 5708 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5628 "SchemaEntity202012.tt"
+        #line 5709 "SchemaEntity202012.tt"
 
         if (HasIntegerType)
         {
@@ -15827,13 +16115,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5632 "SchemaEntity202012.tt"
+        #line 5713 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultInteger\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5634 "SchemaEntity202012.tt"
+        #line 5715 "SchemaEntity202012.tt"
 
         }
         
@@ -15841,13 +16129,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5637 "SchemaEntity202012.tt"
+        #line 5718 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5638 "SchemaEntity202012.tt"
+        #line 5719 "SchemaEntity202012.tt"
 
         if (HasBooleanType)
         {
@@ -15856,13 +16144,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5642 "SchemaEntity202012.tt"
+        #line 5723 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultBoolean\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5644 "SchemaEntity202012.tt"
+        #line 5725 "SchemaEntity202012.tt"
 
         }
         
@@ -15870,13 +16158,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5647 "SchemaEntity202012.tt"
+        #line 5728 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5648 "SchemaEntity202012.tt"
+        #line 5729 "SchemaEntity202012.tt"
 
         if (HasNullType)
         {
@@ -15885,13 +16173,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5652 "SchemaEntity202012.tt"
+        #line 5733 "SchemaEntity202012.tt"
         this.Write("        \r\n                , localResultNull\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5654 "SchemaEntity202012.tt"
+        #line 5735 "SchemaEntity202012.tt"
 
         }
         
@@ -15899,13 +16187,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5657 "SchemaEntity202012.tt"
+        #line 5738 "SchemaEntity202012.tt"
         this.Write("                );\r\n\r\n            return result;\r\n        }\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5662 "SchemaEntity202012.tt"
+        #line 5743 "SchemaEntity202012.tt"
 
     }
     
@@ -15913,13 +16201,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5665 "SchemaEntity202012.tt"
+        #line 5746 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5666 "SchemaEntity202012.tt"
+        #line 5747 "SchemaEntity202012.tt"
 
     if (HasEnum)
     {
@@ -15928,14 +16216,14 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5670 "SchemaEntity202012.tt"
+        #line 5751 "SchemaEntity202012.tt"
         this.Write("        \r\n        /// <summary>\r\n        /// Permitted values.\r\n        /// </sum" +
                 "mary>\r\n        public static class EnumValues\r\n        {\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5676 "SchemaEntity202012.tt"
+        #line 5757 "SchemaEntity202012.tt"
 
         int enumItemIndex = 0;
         foreach (var enumValue in EnumValues)
@@ -15945,13 +16233,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5681 "SchemaEntity202012.tt"
+        #line 5762 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 5681 "SchemaEntity202012.tt"
+        #line 5762 "SchemaEntity202012.tt"
 
             if (enumValue.IsString)
             {
@@ -15960,7 +16248,7 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5685 "SchemaEntity202012.tt"
+        #line 5766 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// enumValue.AsPropertyName.\r\n           " +
                 " /// </summary>\r\n            /// <remarks>\r\n            /// {Description}.\r\n    " +
                 "        /// </remarks>\r\n            public static readonly ");
@@ -15968,43 +16256,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5691 "SchemaEntity202012.tt"
+        #line 5772 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5691 "SchemaEntity202012.tt"
+        #line 5772 "SchemaEntity202012.tt"
         this.Write(" ");
         
         #line default
         #line hidden
         
-        #line 5691 "SchemaEntity202012.tt"
+        #line 5772 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    enumValue.AsPropertyName));
         
         #line default
         #line hidden
         
-        #line 5691 "SchemaEntity202012.tt"
+        #line 5772 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5691 "SchemaEntity202012.tt"
+        #line 5772 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(                    enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5691 "SchemaEntity202012.tt"
+        #line 5772 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5692 "SchemaEntity202012.tt"
+        #line 5773 "SchemaEntity202012.tt"
 
             }
             else if (enumValue.IsBoolean)
@@ -16014,19 +16302,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5697 "SchemaEntity202012.tt"
+        #line 5778 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5698 "SchemaEntity202012.tt"
+        #line 5779 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5698 "SchemaEntity202012.tt"
+        #line 5779 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16034,43 +16322,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5703 "SchemaEntity202012.tt"
+        #line 5784 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5703 "SchemaEntity202012.tt"
+        #line 5784 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5703 "SchemaEntity202012.tt"
+        #line 5784 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5703 "SchemaEntity202012.tt"
+        #line 5784 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5703 "SchemaEntity202012.tt"
+        #line 5784 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5703 "SchemaEntity202012.tt"
+        #line 5784 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5704 "SchemaEntity202012.tt"
+        #line 5785 "SchemaEntity202012.tt"
 
             }
             else if (enumValue.IsNumber)
@@ -16080,19 +16368,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5709 "SchemaEntity202012.tt"
+        #line 5790 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5710 "SchemaEntity202012.tt"
+        #line 5791 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5710 "SchemaEntity202012.tt"
+        #line 5791 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16100,43 +16388,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5715 "SchemaEntity202012.tt"
+        #line 5796 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5715 "SchemaEntity202012.tt"
+        #line 5796 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5715 "SchemaEntity202012.tt"
+        #line 5796 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5715 "SchemaEntity202012.tt"
+        #line 5796 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5715 "SchemaEntity202012.tt"
+        #line 5796 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5715 "SchemaEntity202012.tt"
+        #line 5796 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5716 "SchemaEntity202012.tt"
+        #line 5797 "SchemaEntity202012.tt"
 
             }
             else if (enumValue.IsObject)
@@ -16146,19 +16434,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5721 "SchemaEntity202012.tt"
+        #line 5802 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5722 "SchemaEntity202012.tt"
+        #line 5803 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5722 "SchemaEntity202012.tt"
+        #line 5803 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16166,43 +16454,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5727 "SchemaEntity202012.tt"
+        #line 5808 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5727 "SchemaEntity202012.tt"
+        #line 5808 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5727 "SchemaEntity202012.tt"
+        #line 5808 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5727 "SchemaEntity202012.tt"
+        #line 5808 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5727 "SchemaEntity202012.tt"
+        #line 5808 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5727 "SchemaEntity202012.tt"
+        #line 5808 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5728 "SchemaEntity202012.tt"
+        #line 5809 "SchemaEntity202012.tt"
 
             }
             else if (enumValue.IsArray)
@@ -16212,19 +16500,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5733 "SchemaEntity202012.tt"
+        #line 5814 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5734 "SchemaEntity202012.tt"
+        #line 5815 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5734 "SchemaEntity202012.tt"
+        #line 5815 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16232,43 +16520,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5739 "SchemaEntity202012.tt"
+        #line 5820 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5739 "SchemaEntity202012.tt"
+        #line 5820 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5739 "SchemaEntity202012.tt"
+        #line 5820 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5739 "SchemaEntity202012.tt"
+        #line 5820 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5739 "SchemaEntity202012.tt"
+        #line 5820 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5739 "SchemaEntity202012.tt"
+        #line 5820 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5740 "SchemaEntity202012.tt"
+        #line 5821 "SchemaEntity202012.tt"
 
             }
             else if (enumValue.IsNull)
@@ -16278,19 +16566,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5745 "SchemaEntity202012.tt"
+        #line 5826 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5746 "SchemaEntity202012.tt"
+        #line 5827 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5746 "SchemaEntity202012.tt"
+        #line 5827 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            publ" +
                 "ic static readonly ");
@@ -16298,31 +16586,31 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5751 "SchemaEntity202012.tt"
+        #line 5832 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5751 "SchemaEntity202012.tt"
+        #line 5832 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5751 "SchemaEntity202012.tt"
+        #line 5832 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5751 "SchemaEntity202012.tt"
+        #line 5832 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(\"null\");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5752 "SchemaEntity202012.tt"
+        #line 5833 "SchemaEntity202012.tt"
 
             }
             
@@ -16330,13 +16618,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5755 "SchemaEntity202012.tt"
+        #line 5836 "SchemaEntity202012.tt"
         this.Write("\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5756 "SchemaEntity202012.tt"
+        #line 5837 "SchemaEntity202012.tt"
 
             ++enumItemIndex;
         }
@@ -16345,13 +16633,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5760 "SchemaEntity202012.tt"
+        #line 5841 "SchemaEntity202012.tt"
         this.Write("\r\n\r\n        ");
         
         #line default
         #line hidden
         
-        #line 5762 "SchemaEntity202012.tt"
+        #line 5843 "SchemaEntity202012.tt"
 
         enumItemIndex = 0;
         foreach (var enumValue in EnumValues)
@@ -16361,13 +16649,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5767 "SchemaEntity202012.tt"
+        #line 5848 "SchemaEntity202012.tt"
         this.Write("            ");
         
         #line default
         #line hidden
         
-        #line 5767 "SchemaEntity202012.tt"
+        #line 5848 "SchemaEntity202012.tt"
 
             if (enumValue.IsString)
             {
@@ -16376,19 +16664,19 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5771 "SchemaEntity202012.tt"
+        #line 5852 "SchemaEntity202012.tt"
         this.Write("            /// <summary>\r\n            /// [{Title} || Item ");
         
         #line default
         #line hidden
         
-        #line 5772 "SchemaEntity202012.tt"
+        #line 5853 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5772 "SchemaEntity202012.tt"
+        #line 5853 "SchemaEntity202012.tt"
         this.Write("] (with predictable naming).\r\n            /// </summary>\r\n            /// <remark" +
                 "s>\r\n            /// {Description}.\r\n            /// </remarks>\r\n            inte" +
                 "rnal static readonly ");
@@ -16396,43 +16684,43 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5777 "SchemaEntity202012.tt"
+        #line 5858 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     TypeDeclaration.DotnetTypeName ));
         
         #line default
         #line hidden
         
-        #line 5777 "SchemaEntity202012.tt"
+        #line 5858 "SchemaEntity202012.tt"
         this.Write(" Item");
         
         #line default
         #line hidden
         
-        #line 5777 "SchemaEntity202012.tt"
+        #line 5858 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumItemIndex));
         
         #line default
         #line hidden
         
-        #line 5777 "SchemaEntity202012.tt"
+        #line 5858 "SchemaEntity202012.tt"
         this.Write(" = JsonAny.Parse(");
         
         #line default
         #line hidden
         
-        #line 5777 "SchemaEntity202012.tt"
+        #line 5858 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture(     enumValue.SerializedValue ));
         
         #line default
         #line hidden
         
-        #line 5777 "SchemaEntity202012.tt"
+        #line 5858 "SchemaEntity202012.tt"
         this.Write(");\r\n            ");
         
         #line default
         #line hidden
         
-        #line 5778 "SchemaEntity202012.tt"
+        #line 5859 "SchemaEntity202012.tt"
 
             }
             enumItemIndex++;
@@ -16442,13 +16730,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5783 "SchemaEntity202012.tt"
+        #line 5864 "SchemaEntity202012.tt"
         this.Write("        }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5784 "SchemaEntity202012.tt"
+        #line 5865 "SchemaEntity202012.tt"
 
     }
     
@@ -16456,13 +16744,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5787 "SchemaEntity202012.tt"
+        #line 5868 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5788 "SchemaEntity202012.tt"
+        #line 5869 "SchemaEntity202012.tt"
 
     foreach(var nestedType in NestedTypes)
     {
@@ -16471,25 +16759,25 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5792 "SchemaEntity202012.tt"
+        #line 5873 "SchemaEntity202012.tt"
         this.Write("\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5793 "SchemaEntity202012.tt"
+        #line 5874 "SchemaEntity202012.tt"
         this.Write(this.ToStringHelper.ToStringWithCulture( WriteNestedType(nestedType) ));
         
         #line default
         #line hidden
         
-        #line 5793 "SchemaEntity202012.tt"
+        #line 5874 "SchemaEntity202012.tt"
         this.Write("\r\n\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5795 "SchemaEntity202012.tt"
+        #line 5876 "SchemaEntity202012.tt"
 
     }
     
@@ -16497,13 +16785,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5798 "SchemaEntity202012.tt"
+        #line 5879 "SchemaEntity202012.tt"
         this.Write("\r\n    }\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5800 "SchemaEntity202012.tt"
+        #line 5881 "SchemaEntity202012.tt"
 
     if (!IsNested)
     {
@@ -16512,13 +16800,13 @@ namespace ");
         #line default
         #line hidden
         
-        #line 5804 "SchemaEntity202012.tt"
+        #line 5885 "SchemaEntity202012.tt"
         this.Write("}\r\n    ");
         
         #line default
         #line hidden
         
-        #line 5805 "SchemaEntity202012.tt"
+        #line 5886 "SchemaEntity202012.tt"
 
     }
     

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntity202012.tt
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntity202012.tt
@@ -2427,15 +2427,6 @@ namespace <#= Namespace #>
                 builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, <#= property.DotnetParameterName #>__);
             }            
         <#
-            if (IsConst(property.Type))
-            {
-        #>
-            else
-            {
-                builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, new <#= property.Type.FullyQualifiedDotnetTypeName #>());
-            }
-        <#
-            }
         }
         #>
             return builder.ToImmutable();

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntity202012.tt
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntity202012.tt
@@ -252,6 +252,62 @@ namespace <#= Namespace #>
     }
     #>
 
+    <#
+    if (HasConst)
+    {
+    #>
+        /// <summary>
+        /// Initializes a new instance of the <see cref="<#= TypeDeclaration.DotnetTypeName #>"/> struct.
+        /// </summary>
+        public <#= TypeDeclaration.DotnetTypeName #>()
+        {
+            this.jsonElementBacking = __CorvusConstValue.jsonElementBacking;
+    <#
+    if(IsImplicitObject)
+    {
+    #>
+            this.objectBacking = __CorvusConstValue.objectBacking;
+    <#
+    }
+    #>
+    <#
+    if(IsImplicitArray)
+    {
+    #>
+            this.arrayBacking = __CorvusConstValue.arrayBacking;
+    <#
+    }
+    #>
+    <#
+    if(IsImplicitNumber)
+    {
+    #>
+            this.numberBacking = __CorvusConstValue.numberBacking;
+    <#
+    }
+    #>
+    <#
+    if(IsImplicitString)
+    {
+    #>
+            this.stringBacking = __CorvusConstValue.stringBacking;
+    <#
+    }
+    #>
+    <#
+    if(IsImplicitBoolean)
+    {
+    #>
+            this.booleanBacking = __CorvusConstValue.booleanBacking;
+    <#
+    }
+    #>
+        }
+
+    <#
+    }
+    #>
+
         /// <summary>
         /// Initializes a new instance of the <see cref="<#= TypeDeclaration.DotnetTypeName #>"/> struct.
         /// </summary>
@@ -2309,17 +2365,20 @@ namespace <#= Namespace #>
         bool isFirstCreateParameter = true;
         foreach(var property in RequiredAllOfAndRefProperties)
         {
-            if (isFirstCreateParameter)
-            {
-                isFirstCreateParameter = false;
-            }
-            else
-            {
+            if (!IsConst(property.Type))
+            {           
+                if (isFirstCreateParameter)
+                {
+                    isFirstCreateParameter = false;
+                }
+                else
+                {
         #>, <#
-            }
+                }
         #>
            <#= property.Type.FullyQualifiedDotnetTypeName #> <#= property.DotnetParameterName #>
         <#
+            }
         }
         #>
         <#
@@ -2345,9 +2404,18 @@ namespace <#= Namespace #>
         <#
         foreach(var property in RequiredAllOfAndRefProperties)
         {
+            if (IsConst(property.Type))
+            {
+        #>
+            builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, new <#= property.Type.FullyQualifiedDotnetTypeName #>());
+        <#
+            }
+            else
+            {
         #>
             builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, <#= property.DotnetParameterName #>);
         <#
+            }
         }
         #>
         <#
@@ -2357,8 +2425,17 @@ namespace <#= Namespace #>
             if (<#= property.DotnetParameterName #> is <#= property.Type.FullyQualifiedDotnetTypeName #> <#= property.DotnetParameterName #>__)
             {
                 builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, <#= property.DotnetParameterName #>__);
+            }            
+        <#
+            if (IsConst(property.Type))
+            {
+        #>
+            else
+            {
+                builder.Add(<#= property.DotnetPropertyName#>JsonPropertyName, new <#= property.Type.FullyQualifiedDotnetTypeName #>());
             }
         <#
+            }
         }
         #>
             return builder.ToImmutable();
@@ -2367,6 +2444,10 @@ namespace <#= Namespace #>
         <#
         foreach(var property in Properties)
         {
+            if (IsConst(property.Type))
+            {
+                continue;
+            }
         #>
 
         /// <summary>

--- a/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntityPartial202012.cs
+++ b/Solutions/Corvus.Json.Walker.JsonSchema/Corvus.Json.JsonSchema.TypeBuilder/Draft202012/SchemaEntityPartial202012.cs
@@ -1959,6 +1959,16 @@ public partial class SchemaEntity202012
     }
 
     /// <summary>
+    /// Determines whether a particular child type declaration is a constant value.
+    /// </summary>
+    /// <param name="typeDeclaration">The type declaration to check.</param>
+    /// <returns><c>True</c> if the type declaration represents a const value.</returns>
+    public static bool IsConst(TypeDeclaration typeDeclaration)
+    {
+        return typeDeclaration.Schema.Const.IsNotUndefined();
+    }
+
+    /// <summary>
     /// Writes a nested type.
     /// </summary>
     /// <param name="child">The child type to write.</param>


### PR DESCRIPTION
Added support in both draft 2019-09 and 2020-12 for culling required `const` properties from  the `Create()` method.

It also adds an additional parameterless constructor which initializes the value to the default.

Testing uncovered an issue with percolating the "required" status when merging properties into dotnet types from multiple applicable schema.  This has been fixed as part of this PR. 

I also discovered a missing ToString() override on JsonPointer.