### PR TITLE
Added support for detecting the schema variant in the source document.

### DIFF
--- a/Solutions/Corvus.Json.SchemaGenerator/Program.cs
+++ b/Solutions/Corvus.Json.SchemaGenerator/Program.cs
@@ -106,16 +106,19 @@
                 JsonReference reference = new JsonReference(schemaFile).Apply(new JsonReference(rootPath));
                 string resolvedReference = await walker.TryRebaseDocumentToPropertyValue(reference, "$id").ConfigureAwait(false);
 
-                if (await TryGetSchemaFrom(walker, resolvedReference).ConfigureAwait(false) is SchemaVariant variant)
+                if (schemaVariant == SchemaVariant.NotSpecified)
                 {
-                    schemaVariant = variant;
+                    if (await TryGetSchemaFrom(walker, resolvedReference).ConfigureAwait(false) is SchemaVariant variant)
+                    {
+                        schemaVariant = variant;
+                    }
                 }
 
                 IJsonSchemaBuilder builder =
                     schemaVariant switch
                     {
-                        SchemaVariant.Draft201909 => new JsonSchema.TypeBuilder.Draft201909.JsonSchemaBuilder(walker),
-                        _ => new JsonSchema.TypeBuilder.Draft202012.JsonSchemaBuilder(walker)
+                        SchemaVariant.Draft202012 => new JsonSchema.TypeBuilder.Draft202012.JsonSchemaBuilder(walker),
+                        _ => new JsonSchema.TypeBuilder.Draft201909.JsonSchemaBuilder(walker)
                     };
 
                 (_, ImmutableDictionary<string, (string, string)> generatedTypes) = await builder.BuildTypesFor(resolvedReference, rootNamespace, rebaseToRootPath, rootTypeName: rootTypeName).ConfigureAwait(false);

--- a/Solutions/Corvus.Json.SchemaGenerator/Program.cs
+++ b/Solutions/Corvus.Json.SchemaGenerator/Program.cs
@@ -25,8 +25,8 @@
                                 description: "The path in the document for the root type.");
             var useSchema = new Option<SchemaVariant>(
                                 "--useSchema",
-                                getDefaultValue: () => SchemaVariant.Draft201909,
-                                description: "The schema variant to use.");
+                                getDefaultValue: () => SchemaVariant.NotSpecified,
+                                description: "Override the schema variant to use. This will default to draft2019-09 if it cannot be picked up from the schema itself.");
             var outputMapFile = new Option<string>(
                                 "--outputMapFile",
                                 description: "The name to use for a map file which includes details of the files that were written.");
@@ -91,15 +91,8 @@
             try
             {
                 var walker = new JsonWalker(new CompoundDocumentResolver(new FileSystemDocumentResolver(), new HttpClientDocumentResolver(new HttpClient())));
-                IJsonSchemaBuilder builder =
-                    schemaVariant switch
-                    {
-                        SchemaVariant.Draft201909 => new JsonSchema.TypeBuilder.Draft201909.JsonSchemaBuilder(walker),
-                        _ => new JsonSchema.TypeBuilder.Draft202012.JsonSchemaBuilder(walker)
-                    };
 
-                var uri = new JsonUri(schemaFile);
-                if (!uri.IsValid() || uri.GetUri().IsFile)
+                if (!new JsonUri(schemaFile).IsValid())
                 {
                     // If this is, in fact, a local file path, not a uri, then convert to a fullpath and URI-style separators.
                     if (!Path.IsPathFullyQualified(schemaFile))
@@ -112,6 +105,18 @@
 
                 JsonReference reference = new JsonReference(schemaFile).Apply(new JsonReference(rootPath));
                 string resolvedReference = await walker.TryRebaseDocumentToPropertyValue(reference, "$id").ConfigureAwait(false);
+
+                if (await TryGetSchemaFrom(walker, resolvedReference).ConfigureAwait(false) is SchemaVariant variant)
+                {
+                    schemaVariant = variant;
+                }
+
+                IJsonSchemaBuilder builder =
+                    schemaVariant switch
+                    {
+                        SchemaVariant.Draft201909 => new JsonSchema.TypeBuilder.Draft201909.JsonSchemaBuilder(walker),
+                        _ => new JsonSchema.TypeBuilder.Draft202012.JsonSchemaBuilder(walker)
+                    };
 
                 (_, ImmutableDictionary<string, (string, string)> generatedTypes) = await builder.BuildTypesFor(resolvedReference, rootNamespace, rebaseToRootPath, rootTypeName: rootTypeName).ConfigureAwait(false);
 
@@ -178,6 +183,32 @@
             }
 
             return 0;
+        }
+
+        private static async Task<SchemaVariant?> TryGetSchemaFrom(JsonWalker walker, string resolvedReference)
+        {
+            JsonElement? rootElement = await walker.GetDocumentElement(resolvedReference).ConfigureAwait(false);
+            if (rootElement is JsonElement re && re.TryGetProperty("$schema", out JsonElement schema))
+            {
+                if (schema.ValueKind == JsonValueKind.String)
+                {
+                    string? schemaValue = schema.GetString();
+                    if (schemaValue is string sv)
+                    {
+                        if (sv == "https://json-schema.org/draft/2019-09/schema")
+                        {
+                            return SchemaVariant.Draft201909;
+                        }
+
+                        if (sv == "https://json-schema.org/draft/2020-12/schema")
+                        {
+                            return SchemaVariant.Draft202012;
+                        }
+                    }
+                }
+            }
+
+            return null;
         }
     }
 }

--- a/Solutions/Corvus.Json.SchemaGenerator/Program.cs
+++ b/Solutions/Corvus.Json.SchemaGenerator/Program.cs
@@ -91,8 +91,8 @@
             try
             {
                 var walker = new JsonWalker(new CompoundDocumentResolver(new FileSystemDocumentResolver(), new HttpClientDocumentResolver(new HttpClient())));
-
-                if (!new JsonUri(schemaFile).IsValid())
+                var uri = new JsonUri(schemaFile);
+                if (!uri.IsValid() || uri.GetUri().IsFile)
                 {
                     // If this is, in fact, a local file path, not a uri, then convert to a fullpath and URI-style separators.
                     if (!Path.IsPathFullyQualified(schemaFile))

--- a/Solutions/Corvus.Json.SchemaGenerator/SchemaVariant.cs
+++ b/Solutions/Corvus.Json.SchemaGenerator/SchemaVariant.cs
@@ -5,6 +5,7 @@
     /// </summary>
     public enum SchemaVariant
     {
+        NotSpecified,
         Draft201909,
         Draft202012
     }

--- a/Solutions/Corvus.Json.Walker/Corvus.Json/JsonWalker.cs
+++ b/Solutions/Corvus.Json.Walker/Corvus.Json/JsonWalker.cs
@@ -20,17 +20,19 @@ namespace Corvus.Json
         /// </summary>
         public const string DefaultContent = "application/vnd.Corvus.element-default";
 
-        private readonly List<Func<JsonWalker, JsonElement, Task<bool>>> handlers = new ();
-        private readonly List<Func<JsonWalker, JsonReference, bool, bool, Func<Task<LocatedElement?>>, Task<LocatedElement?>>> resolvers = new ();
+#pragma warning disable SA1000 // Keywords should be spaced correctly
+        private readonly List<Func<JsonWalker, JsonElement, Task<bool>>> handlers = new();
+        private readonly List<Func<JsonWalker, JsonReference, bool, bool, Func<Task<LocatedElement?>>, Task<LocatedElement?>>> resolvers = new();
 
-        private readonly Dictionary<string, LocatedElement> locatedElements = new ();
+        private readonly Dictionary<string, LocatedElement> locatedElements = new();
 
         private readonly IDocumentResolver documentResolver;
         private readonly string baseLocation;
 
-        private readonly List<(string, bool, bool, List<string>, Action<JsonWalker, LocatedElement>)> unresolvedReferences = new ();
+        private readonly List<(string, bool, bool, List<string>, Action<JsonWalker, LocatedElement>)> unresolvedReferences = new();
 
-        private Stack<string> scopedLocationStack = new ();
+        private Stack<string> scopedLocationStack = new();
+#pragma warning restore SA1000 // Keywords should be spaced correctly
 
         /// <summary>
         /// Initializes a new instance of the <see cref="JsonWalker"/> class.
@@ -106,6 +108,16 @@ namespace Corvus.Json
         }
 
         /// <summary>
+        /// Resolves element.
+        /// </summary>
+        /// <param name="reference">The document reference for which to provide the element.</param>
+        /// <returns>A <see cref="Task{T}"/> which, when complete, provides the root element of the document.</returns>
+        public async Task<JsonElement?> GetDocumentElement(string reference)
+        {
+            return await this.documentResolver.TryResolve(new JsonReference(reference).WithFragment(string.Empty)).ConfigureAwait(false);
+        }
+
+        /// <summary>
         /// Rebases a reference to a canonical URI contained in a given property..
         /// </summary>
         /// <param name="reference">The reference to rebase as a root document.</param>
@@ -120,7 +132,9 @@ namespace Corvus.Json
             {
                 if (e.TryGetProperty(propertyName, out JsonElement uri) && uri.ValueKind == JsonValueKind.String)
                 {
-                    string outputUri = uri.GetString() !;
+#pragma warning disable SA1009 // Closing parenthesis should be spaced correctly
+                    string outputUri = uri.GetString()!;
+#pragma warning restore SA1009 // Closing parenthesis should be spaced correctly
                     var outputUriRef = new JsonReference(outputUri);
                     if (!outputUriRef.HasFragment)
                     {


### PR DESCRIPTION
This will respect the rebasing of a document fragment as a virtual root.

You no longer need to specify the `--useSchema` option if your schema document contains a `$schema` property with the appropriate draft identifier.