### PR TITLE
Feature/162 do not write properties with explicit undefined value

### DIFF
--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/JsonValueHelpers.Writers.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/JsonValueHelpers.Writers.cs
@@ -40,8 +40,11 @@ public static partial class JsonValueHelpers
 
         foreach (KeyValuePair<JsonPropertyName, JsonAny> property in properties)
         {
-            writer.WritePropertyName(property.Key.Name);
-            property.Value.WriteTo(writer);
+            if (property.Value.IsNotUndefined())
+            {
+                writer.WritePropertyName(property.Key.Name);
+                property.Value.WriteTo(writer);
+            }
         }
 
         writer.WriteEndObject();

--- a/Solutions/Corvus.Json.Specs/Features/JsonModel/JsonSerialization.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonModel/JsonSerialization.feature
@@ -1,6 +1,12 @@
 ﻿Feature: JsonSerialization
 	Writing entities
 
+Scenario: Serialize an object with an undefined property value
+	Given the dotnet backed JsonAny { "foo": 3, "bar": "<undefined>" }
+	When the json value is round-trip serialized via a string
+	Then the round-tripped result should be an Object
+	And the round-tripped result should be equal to the JsonAny { "foo": 3 }
+
 Scenario Outline: Serialize a jsonelement-backed JsonAny to a string
 	Given the JsonElement backed JsonAny <jsonValue>
 	When the json value is round-trip serialized via a string

--- a/Solutions/Corvus.Json.Specs/Steps/JsonValueSteps.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/JsonValueSteps.cs
@@ -290,7 +290,17 @@ public class JsonValueSteps
         }
         else
         {
-            this.scenarioContext.Set(JsonAny.Parse(value).AsDotnetBackedValue(), SubjectUnderTest);
+            JsonAny result = JsonAny.Parse(value).AsDotnetBackedValue();
+            foreach (JsonObjectProperty property in result.EnumerateObject())
+            {
+                if (property.Value.ValueKind == JsonValueKind.String &&
+                    property.Value.Equals("\u003cundefined\u003e"))
+                {
+                    result = result.SetProperty(property.Name, JsonString.Undefined);
+                }
+            }
+
+            this.scenarioContext.Set(result, SubjectUnderTest);
         }
     }
 

--- a/Solutions/Corvus.Json.Specs/Steps/JsonValueSteps.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/JsonValueSteps.cs
@@ -291,12 +291,15 @@ public class JsonValueSteps
         else
         {
             JsonAny result = JsonAny.Parse(value).AsDotnetBackedValue();
-            foreach (JsonObjectProperty property in result.EnumerateObject())
+            if (result.ValueKind == JsonValueKind.Object)
             {
-                if (property.Value.ValueKind == JsonValueKind.String &&
-                    property.Value.Equals("\u003cundefined\u003e"))
+                foreach (JsonObjectProperty property in result.EnumerateObject())
                 {
-                    result = result.SetProperty(property.Name, JsonString.Undefined);
+                    if (property.Value.ValueKind == JsonValueKind.String &&
+                        property.Value.Equals("\u003cundefined\u003e"))
+                    {
+                        result = result.SetProperty(property.Name, JsonString.Undefined);
+                    }
                 }
             }
 


### PR DESCRIPTION
The standard dotnet-backed object property writer incorrectly attempted to write properties that were explicitly undefined.

This change ensures that it will (correctly) omit those properties from the output.

A spec has been added to validate the round-trip behaviour. 