### PR TITLE
Support JsonElement-like TryGetValue() over JsonString

### DIFF
--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonValueExtensions.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonValueExtensions.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Buffers;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
@@ -162,24 +163,24 @@ public static class JsonValueExtensions
     public static T AsDotnetBackedValue<T>(this T value)
         where T : struct, IJsonValue<T>
     {
-            if (value.HasJsonElementBacking)
+        if (value.HasJsonElementBacking)
+        {
+            JsonValueKind valueKind = value.ValueKind;
+
+            return valueKind switch
             {
-                JsonValueKind valueKind = value.ValueKind;
+                JsonValueKind.Object => T.FromObject(new JsonObject(value.AsObject.AsImmutableDictionary())),
+                JsonValueKind.Array => T.FromArray(new JsonArray(value.AsArray.AsImmutableList())),
+                JsonValueKind.Number => T.FromNumber(new JsonNumber((double)value.AsNumber)),
+                JsonValueKind.String => T.FromString(new JsonString((string)value.AsString)),
+                JsonValueKind.True => T.FromBoolean(new JsonBoolean(true)),
+                JsonValueKind.False => T.FromBoolean(new JsonBoolean(false)),
+                JsonValueKind.Null => T.Null,
+                _ => value,
+            };
+        }
 
-                return valueKind switch
-                {
-                    JsonValueKind.Object => T.FromObject(new JsonObject(value.AsObject.AsImmutableDictionary())),
-                    JsonValueKind.Array => T.FromArray(new JsonArray(value.AsArray.AsImmutableList())),
-                    JsonValueKind.Number => T.FromNumber(new JsonNumber((double)value.AsNumber)),
-                    JsonValueKind.String => T.FromString(new JsonString((string)value.AsString)),
-                    JsonValueKind.True => T.FromBoolean(new JsonBoolean(true)),
-                    JsonValueKind.False => T.FromBoolean(new JsonBoolean(false)),
-                    JsonValueKind.Null => T.Null,
-                    _ => value,
-                };
-            }
-
-            return value;
+        return value;
     }
 
     /// <summary>
@@ -197,5 +198,89 @@ public static class JsonValueExtensions
         }
 
         return value;
+    }
+
+    /// <summary>
+    /// Parses a value from a JsonString type.
+    /// </summary>
+    /// <typeparam name="T">The type of the <see cref="IJsonString{T}"/> to parse.</typeparam>
+    /// <typeparam name="TState">The state passed in to the parser.</typeparam>
+    /// <typeparam name="TResult">The result of parsing the string.</typeparam>
+    /// <param name="jsonValue">The instance of the <see cref="IJsonString{T}"/> to parse.</param>
+    /// <param name="parser">The parser to perform the conversion.</param>
+    /// <param name="state">The state to be passed to the parser.</param>
+    /// <param name="result">The result of the parsing.</param>
+    /// <returns><see langword="true"/> if the result was parsed successfully, otherwise <see langword="false"/>.</returns>
+    public static bool TryGetValue<T, TState, TResult>(this T jsonValue, Parser<TState, TResult> parser, in TState state, [NotNullWhen(true)] out TResult? result)
+        where T : struct, IJsonString<T>
+    {
+        if (jsonValue.HasJsonElementBacking)
+        {
+            return jsonValue.AsJsonElement.TryGetValue(parser, state, out result);
+        }
+
+        return parser(jsonValue.AsSpan(), state, out result);
+    }
+
+    /// <summary>
+    /// Parses a value from a JsonString type.
+    /// </summary>
+    /// <typeparam name="T">The type of the <see cref="IJsonString{T}"/> to parse.</typeparam>
+    /// <typeparam name="TState">The state passed in to the parser.</typeparam>
+    /// <typeparam name="TResult">The result of parsing the string.</typeparam>
+    /// <param name="jsonValue">The instance of the <see cref="IJsonString{T}"/> to parse.</param>
+    /// <param name="parser">The parser to perform the conversion.</param>
+    /// <param name="state">The state to be passed to the parser.</param>
+    /// <param name="result">The result of the parsing.</param>
+    /// <returns><see langword="true"/> if the result was parsed successfully, otherwise <see langword="false"/>.</returns>
+    public static bool TryGetValue<T, TState, TResult>(this T jsonValue, Utf8Parser<TState, TResult> parser, in TState state, [NotNullWhen(true)] out TResult? result)
+        where T : struct, IJsonString<T>
+    {
+        return TryGetValue(jsonValue, parser, state, true, out result);
+    }
+
+    /// <summary>
+    /// Parses a value from a JsonString type.
+    /// </summary>
+    /// <typeparam name="T">The type of the <see cref="IJsonString{T}"/> to parse.</typeparam>
+    /// <typeparam name="TState">The state passed in to the parser.</typeparam>
+    /// <typeparam name="TResult">The result of parsing the string.</typeparam>
+    /// <param name="jsonValue">The instance of the <see cref="IJsonString{T}"/> to parse.</param>
+    /// <param name="parser">The parser to perform the conversion.</param>
+    /// <param name="state">The state to be passed to the parser.</param>
+    /// <param name="decode">Determines whether to decode the UTF8 bytes.</param>
+    /// <param name="result">The result of the parsing.</param>
+    /// <returns><see langword="true"/> if the result was parsed successfully, otherwise <see langword="false"/>.</returns>
+    public static bool TryGetValue<T, TState, TResult>(this T jsonValue, Utf8Parser<TState, TResult> parser, in TState state, bool decode, [NotNullWhen(true)] out TResult? result)
+        where T : struct, IJsonString<T>
+    {
+        if (jsonValue.HasJsonElementBacking)
+        {
+            return jsonValue.AsJsonElement.TryGetValue(parser, state, decode, out result);
+        }
+
+        if (!jsonValue.TryGetString(out string? value))
+        {
+            result = default;
+            return false;
+        }
+
+        int maxByteCount = Encoding.UTF8.GetMaxByteCount(value.Length);
+        byte[]? pooledBytes = null;
+
+        Span<byte> bytes = maxByteCount <= JsonConstants.StackallocThreshold ?
+            stackalloc byte[maxByteCount] :
+            (pooledBytes = ArrayPool<byte>.Shared.Rent(maxByteCount));
+
+        int written = Encoding.UTF8.GetBytes(value, bytes);
+
+        bool success = parser(bytes[..written], state, out result);
+
+        if (pooledBytes is byte[] pb)
+        {
+            ArrayPool<byte>.Shared.Return(pb);
+        }
+
+        return success;
     }
 }

--- a/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
+++ b/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
@@ -70,6 +70,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
+	  <Folder Include="Features\JsonModel\JsonStringTryGetValue\" />
 	  <Folder Include="Features\JsonSchema\Draft6\" />
 	</ItemGroup>
 

--- a/Solutions/Corvus.Json.Specs/Features/JsonModel/JsonStringTryGetValue/StringTryGetValue.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonModel/JsonStringTryGetValue/StringTryGetValue.feature
@@ -1,0 +1,50 @@
+Feature: JsonStringTryGetValue
+	Optimize parsing a value from a JSON string
+
+Scenario: Get a numeric value from a dotnet-backed string using a char parser
+	Given the dotnet backed JsonString "2"
+	When you try get an integer from the json value using a char parser with the multiplier 3
+	Then the parse result should be true
+	And the parsed value should be equal to the number 6
+
+Scenario: Get a numeric value from a jsonelement-backed string using a char parser
+	Given the JsonElement backed JsonString "2"
+	When you try get an integer from the json value using a char parser with the multiplier 3
+	Then the parse result should be true
+	And the parsed value should be equal to the number 6
+
+Scenario: Get a numeric value from a dotnet-backed string which does not support the format using a char parser
+	Given the dotnet backed JsonString "Hello"
+	When you try get an integer from the json value using a char parser with the multiplier 3
+	Then the parse result should be false
+	And the parsed value should be null
+
+Scenario: Get a numeric value from a jsonelement-backed string which does not support the format using a char parser
+	Given the JsonElement backed JsonString "Hello"
+	When you try get an integer from the json value using a char parser with the multiplier 3
+	Then the parse result should be false
+	And the parsed value should be null
+
+Scenario: Get a numeric value from a dotnet-backed string using a utf8 parser
+	Given the dotnet backed JsonString "2"
+	When you try get an integer from the json value using a utf8 parser with the multiplier 3
+	Then the parse result should be true
+	And the parsed value should be equal to the number 6
+
+Scenario: Get a numeric value from a jsonelement-backed string using a utf8 parser
+	Given the JsonElement backed JsonString "2"
+	When you try get an integer from the json value using a utf8 parser with the multiplier 3
+	Then the parse result should be true
+	And the parsed value should be equal to the number 6
+
+Scenario: Get a numeric value from a dotnet-backed string which does not support the format using a utf8 parser
+	Given the dotnet backed JsonString "Hello"
+	When you try get an integer from the json value using a utf8 parser with the multiplier 3
+	Then the parse result should be false
+	And the parsed value should be null
+
+Scenario: Get a numeric value from a jsonelement-backed string which does not support the format using a utf8 parser
+	Given the JsonElement backed JsonString "Hello"
+	When you try get an integer from the json value using a utf8 parser with the multiplier 3
+	Then the parse result should be false
+	And the parsed value should be null

--- a/Solutions/Corvus.Json.Specs/Steps/JsonStringTryGetValueSteps.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/JsonStringTryGetValueSteps.cs
@@ -29,7 +29,7 @@ public class JsonStringTryGetValueSteps
         this.scenarioContext = scenarioContext;
     }
 
-    [When(@"you try get an integer from the json value using a char parser with the multiplier (.*)")]
+    [When("you try get an integer from the json value using a char parser with the multiplier (.*)")]
     public void WhenYouTryGetAnIntegerFromTheJsonValueUsingACharParser(int multiplier)
     {
         JsonString subjectUnderTest = this.scenarioContext.Get<JsonString>(JsonValueSteps.SubjectUnderTest);
@@ -51,7 +51,7 @@ public class JsonStringTryGetValueSteps
         }
     }
 
-    [When(@"you try get an integer from the json value using a utf8 parser with the multiplier (.*)")]
+    [When("you try get an integer from the json value using a utf8 parser with the multiplier (.*)")]
     public void WhenYouTryGetAnIntegerFromTheJsonValueUsingAUtf8Parser(int multiplier)
     {
         JsonString subjectUnderTest = this.scenarioContext.Get<JsonString>(JsonValueSteps.SubjectUnderTest);
@@ -73,28 +73,28 @@ public class JsonStringTryGetValueSteps
         }
     }
 
-    [Then(@"the parse result should be true")]
+    [Then("the parse result should be true")]
     public void ThenTheParseResultShouldBeTrue()
     {
         ParseResult result = this.scenarioContext.Get<ParseResult>(TryParseResult);
         Assert.IsTrue(result.Success);
     }
 
-    [Then(@"the parse result should be false")]
+    [Then("the parse result should be false")]
     public void ThenTheParseResultShouldBeFalse()
     {
         ParseResult result = this.scenarioContext.Get<ParseResult>(TryParseResult);
         Assert.IsFalse(result.Success);
     }
 
-    [Then(@"the parsed value should be equal to the number (.*)")]
+    [Then("the parsed value should be equal to the number (.*)")]
     public void ThenTheParsedValueShouldBeEqualToTheNumber(int expected)
     {
         ParseResult result = this.scenarioContext.Get<ParseResult>(TryParseResult);
         Assert.AreEqual(expected, result.Value);
     }
 
-    [Then(@"the parsed value should be null")]
+    [Then("the parsed value should be null")]
     public void ThenTheParsedValueShouldBeNull()
     {
         ParseResult result = this.scenarioContext.Get<ParseResult>(TryParseResult);

--- a/Solutions/Corvus.Json.Specs/Steps/JsonStringTryGetValueSteps.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/JsonStringTryGetValueSteps.cs
@@ -1,0 +1,110 @@
+// <copyright file="JsonStringTryGetValueSteps.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using Corvus.Json;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+
+namespace Steps;
+
+[Binding]
+public class JsonStringTryGetValueSteps
+{
+    /// <summary>
+    /// The key for a parse result.
+    /// </summary>
+    internal const string TryParseResult = "TryParseResult";
+
+    private readonly ScenarioContext scenarioContext;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonValueCastSteps"/> class.
+    /// </summary>
+    /// <param name="scenarioContext">The scenario context.</param>
+    public JsonStringTryGetValueSteps(ScenarioContext scenarioContext)
+    {
+        this.scenarioContext = scenarioContext;
+    }
+
+    [When(@"you try get an integer from the json value using a char parser with the multiplier (.*)")]
+    public void WhenYouTryGetAnIntegerFromTheJsonValueUsingACharParser(int multiplier)
+    {
+        JsonString subjectUnderTest = this.scenarioContext.Get<JsonString>(JsonValueSteps.SubjectUnderTest);
+
+        bool success = subjectUnderTest.TryGetValue(TryGetIntegerUsingChar, multiplier, out int? result);
+
+        this.scenarioContext.Set(new ParseResult(success, result), TryParseResult);
+
+        static bool TryGetIntegerUsingChar(ReadOnlySpan<char> span, in int state, [NotNullWhen(true)] out int? value)
+        {
+            if (int.TryParse(span, out int baseValue))
+            {
+                value = baseValue * state;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+    }
+
+    [When(@"you try get an integer from the json value using a utf8 parser with the multiplier (.*)")]
+    public void WhenYouTryGetAnIntegerFromTheJsonValueUsingAUtf8Parser(int multiplier)
+    {
+        JsonString subjectUnderTest = this.scenarioContext.Get<JsonString>(JsonValueSteps.SubjectUnderTest);
+
+        bool success = subjectUnderTest.TryGetValue(TryGetIntegerUsingUtf8, multiplier, out int? result);
+
+        this.scenarioContext.Set(new ParseResult(success, result), TryParseResult);
+
+        static bool TryGetIntegerUsingUtf8(ReadOnlySpan<byte> span, in int state, [NotNullWhen(true)] out int? value)
+        {
+            if (int.TryParse(Encoding.UTF8.GetString(span), out int baseValue))
+            {
+                value = baseValue * state;
+                return true;
+            }
+
+            value = default;
+            return false;
+        }
+    }
+
+    [Then(@"the parse result should be true")]
+    public void ThenTheParseResultShouldBeTrue()
+    {
+        ParseResult result = this.scenarioContext.Get<ParseResult>(TryParseResult);
+        Assert.IsTrue(result.Success);
+    }
+
+    [Then(@"the parse result should be false")]
+    public void ThenTheParseResultShouldBeFalse()
+    {
+        ParseResult result = this.scenarioContext.Get<ParseResult>(TryParseResult);
+        Assert.IsFalse(result.Success);
+    }
+
+    [Then(@"the parsed value should be equal to the number (.*)")]
+    public void ThenTheParsedValueShouldBeEqualToTheNumber(int expected)
+    {
+        ParseResult result = this.scenarioContext.Get<ParseResult>(TryParseResult);
+        Assert.AreEqual(expected, result.Value);
+    }
+
+    [Then(@"the parsed value should be null")]
+    public void ThenTheParsedValueShouldBeNull()
+    {
+        ParseResult result = this.scenarioContext.Get<ParseResult>(TryParseResult);
+        Assert.IsNull(result.Value);
+    }
+
+    /// <summary>
+    /// The result of a TryParse() operation.
+    /// </summary>
+    /// <param name="Success">Captures the return value of TryParse().</param>
+    /// <param name="Value">Captures the value produced by TryParse().</param>
+    internal readonly record struct ParseResult(bool Success, int? Value);
+}


### PR DESCRIPTION
Added extension methods to support TryGetValue() semantics over an `IJsonString{T}`.

It automatically converts to the relevant underlying string format (i.e. `ReadOnlySpan<char>` or `ReadOnlySpan<byte>`), using as optimal a mechanism as possible given the 