### PR TITLE
Support concatenation of JSON values to a JSON string. 

### DIFF
--- a/Solutions/Corvus.Json.Benchmarking/Corvus.Json.Benchmarking.csproj
+++ b/Solutions/Corvus.Json.Benchmarking/Corvus.Json.Benchmarking.csproj
@@ -14,15 +14,15 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.3" />
-		<PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.3" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
+		<PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
 		<PackageReference Include="Endjin.RecommendedPractices.GitHub" Version="2.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="JsonSchema.Net" Version="3.3.2" />
+		<PackageReference Include="JsonSchema.Net" Version="4.1.3" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-		<PackageReference Include="JsonPatch.Net" Version="2.0.4" />
+		<PackageReference Include="JsonPatch.Net" Version="2.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Solutions/Corvus.Json.Benchmarking/ValidateLargeDocument.cs
+++ b/Solutions/Corvus.Json.Benchmarking/ValidateLargeDocument.cs
@@ -26,7 +26,7 @@ public class ValidateLargeDocument
     ""dateOfBirth"": ""1944-07-14""
 }";
 
-    private static readonly JsonEverything.ValidationOptions Options = new JsonEverything.ValidationOptions() { OutputFormat = JsonEverything.OutputFormat.Flag };
+    private static readonly JsonEverything.EvaluationOptions Options = new JsonEverything.EvaluationOptions() { OutputFormat = JsonEverything.OutputFormat.Flag };
 
     private JsonDocument? objectDocument;
     private Person person;
@@ -100,7 +100,7 @@ public class ValidateLargeDocument
     [Benchmark(Baseline = true)]
     public void ValidateLargeArrayJsonEveything()
     {
-        JsonEverything.ValidationResults result = this.schema!.Validate(this.node, Options);
+        JsonEverything.EvaluationResults result = this.schema!.Evaluate(this.node, Options);
         if (!result.IsValid)
         {
             throw new InvalidOperationException();

--- a/Solutions/Corvus.Json.Benchmarking/ValidateLargeDocumentWithAnnotationCollection.cs
+++ b/Solutions/Corvus.Json.Benchmarking/ValidateLargeDocumentWithAnnotationCollection.cs
@@ -26,7 +26,7 @@ public class ValidateLargeDocumentWithAnnotationCollection
     ""dateOfBirth"": ""1944-07-14""
 }";
 
-    private static readonly JsonEverything.ValidationOptions Options = new JsonEverything.ValidationOptions() { OutputFormat = JsonEverything.OutputFormat.Basic };
+    private static readonly JsonEverything.EvaluationOptions Options = new JsonEverything.EvaluationOptions() { OutputFormat = JsonEverything.OutputFormat.List };
 
     private JsonDocument? objectDocument;
     private Person person;
@@ -58,9 +58,9 @@ public class ValidateLargeDocumentWithAnnotationCollection
     }
 
     /// <summary>
-    /// Global cleanup.
+    /// Global clean-up.
     /// </summary>
-    /// <returns>A <see cref="Task"/> which completes once cleanup is complete.</returns>
+    /// <returns>A <see cref="Task"/> which completes once clean-up is complete.</returns>
     [GlobalCleanup]
     public Task GlobalCleanup()
     {
@@ -100,7 +100,7 @@ public class ValidateLargeDocumentWithAnnotationCollection
     [Benchmark(Baseline = true)]
     public void ValidateLargeArrayJsonEveything()
     {
-        JsonEverything.ValidationResults result = this.schema!.Validate(this.node, Options);
+        JsonEverything.EvaluationResults result = this.schema!.Evaluate(this.node, Options);
         if (!result.IsValid)
         {
             throw new InvalidOperationException();

--- a/Solutions/Corvus.Json.Benchmarking/ValidateSmallDocument.cs
+++ b/Solutions/Corvus.Json.Benchmarking/ValidateSmallDocument.cs
@@ -25,7 +25,7 @@ public class ValidateSmallDocument
     ""dateOfBirth"": ""1944-07-14""
 }";
 
-    private static readonly JsonEverything.ValidationOptions Options = new() { OutputFormat = JsonEverything.OutputFormat.Flag };
+    private static readonly JsonEverything.EvaluationOptions Options = new() { OutputFormat = JsonEverything.OutputFormat.Flag };
 
     private JsonDocument? objectDocument;
     private Person person;
@@ -78,9 +78,9 @@ public class ValidateSmallDocument
     /// Validates using the JsonEverything types.
     /// </summary>
     [Benchmark(Baseline = true)]
-    public void ValidateSmallDocumentJsonEveything()
+    public void ValidateSmallDocumentJsonEverything()
     {
-        JsonEverything.ValidationResults result = this.schema!.Validate(this.node, Options);
+        JsonEverything.EvaluationResults result = this.schema!.Evaluate(this.node, Options);
         if (!result.IsValid)
         {
             throw new InvalidOperationException();

--- a/Solutions/Corvus.Json.Benchmarking/packages.lock.json
+++ b/Solutions/Corvus.Json.Benchmarking/packages.lock.json
@@ -4,11 +4,11 @@
     "net7.0": {
       "BenchmarkDotNet": {
         "type": "Direct",
-        "requested": "[0.13.3, )",
-        "resolved": "0.13.3",
-        "contentHash": "Y0aNdOZ9LdcwVniiAmQEcdYnpR8qe+BOSmqMBukJ1+ez7PiyqpwJHbppOJ1ibHKh28qdq781l8hsPIld5lvsIw==",
+        "requested": "[0.13.5, )",
+        "resolved": "0.13.5",
+        "contentHash": "PiwINqvreKV7L+BQlaZ2qcJ90s88LbLqZoUWbKnEPzvmsWd4pUH58Yjp+mFn311n8Jz0Y0JsD+jWa+Kh67IG3A==",
         "dependencies": {
-          "BenchmarkDotNet.Annotations": "0.13.3",
+          "BenchmarkDotNet.Annotations": "0.13.5",
           "CommandLineParser": "2.4.3",
           "Gee.External.Capstone": "2.3.0",
           "Iced": "1.17.0",
@@ -22,42 +22,42 @@
       },
       "BenchmarkDotNet.Diagnostics.Windows": {
         "type": "Direct",
-        "requested": "[0.13.3, )",
-        "resolved": "0.13.3",
-        "contentHash": "mlVmyFBcgrnOsupN7BvADjYaTxqlMbGjx6WTPV0ponFwupU1r2z5Vv27QF8guGvYViM8RjNFQvtNB8is/jyGdw==",
+        "requested": "[0.13.5, )",
+        "resolved": "0.13.5",
+        "contentHash": "bNKJlIgUvEMBotiiHrEzw2xyCFlNiEfE14/EcBOEDSgYg+spzByVVv+totq9baxKUk5MhfAFhyzguBMiuoho3Q==",
         "dependencies": {
-          "BenchmarkDotNet": "0.13.3",
+          "BenchmarkDotNet": "0.13.5",
           "Microsoft.Diagnostics.Tracing.TraceEvent": "3.0.2"
         }
       },
       "Endjin.RecommendedPractices.GitHub": {
         "type": "Direct",
-        "requested": "[2.1.4, )",
-        "resolved": "2.1.4",
-        "contentHash": "SUBvnwWuKtklIv9NWqY9PI/J1nONyvcOlitIhUTq5Hk8K0QnBoISc1xTZTe0C0tOtUW1JIAZeEYwAAeuzQwtYg==",
+        "requested": "[2.1.5, )",
+        "resolved": "2.1.5",
+        "contentHash": "PoZqxrp7iYbSF0Vi2Wtj2sepxwZA3i4Yq9CGueralFhLYcHE60E3bQOwHLwWsv4oNf60FYJrr3RjFPa7pv1HyA==",
         "dependencies": {
-          "Endjin.RecommendedPractices": "2.1.4",
+          "Endjin.RecommendedPractices": "2.1.5",
           "Microsoft.SourceLink.GitHub": "1.1.1"
         }
       },
       "JsonPatch.Net": {
         "type": "Direct",
-        "requested": "[2.0.4, )",
-        "resolved": "2.0.4",
-        "contentHash": "Pr0lHxEYOpa2r6cEJaji9HTamKrp3pIey8Cxg0sV7EovGFf/e24TemwLPHjJD/zZ2q2YDFf/53VQCbPoDh3kPw==",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "iTTUYeOk6tLGCwKTnqC/w28vkxaP8pO5BgIODpvwU3MM63XqZJ/p+iWZXhSvyRBUxqo3l+VHw49TnsxBZGTW9Q==",
         "dependencies": {
-          "JsonPointer.Net": "2.2.1"
+          "JsonPointer.Net": "3.0.1"
         }
       },
       "JsonSchema.Net": {
         "type": "Direct",
-        "requested": "[3.3.2, )",
-        "resolved": "3.3.2",
-        "contentHash": "1HXsDZyrDoq7kYKYkxxLQzUaq7URHFB6EynoAOSPYZaSUdpDA4M/lu/8mm6M4KM4KuWGdwsyKAawpQUtFpC1+Q==",
+        "requested": "[4.1.3, )",
+        "resolved": "4.1.3",
+        "contentHash": "9QdyGdSMR9fJ5APSwZU2Ws1/P6uQMbEoxXwG/BAWCEMAMGt7v1/41lM3cxnhfc8RijG6n+IL3L5khth0pccxAw==",
         "dependencies": {
           "JetBrains.Annotations": "2021.2.0",
-          "Json.More.Net": "1.7.0",
-          "JsonPointer.Net": "2.2.1"
+          "Json.More.Net": "1.8.0",
+          "JsonPointer.Net": "3.0.1"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
@@ -75,9 +75,9 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.2.0, )",
-        "resolved": "4.2.0",
-        "contentHash": "3N8CNx1Q/Q5VDDL7qgfZRgTURyMqzHAkAB59AZKRnsOXoh2n9xRzhiBMIbJaUtBATmieECBx68GcjRn2xoNDug=="
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "NZNaV9DAYGHKZ753WfhtBj8eoP40LLJsA6JQXdzhF87iTZAdbKCgp32mI3cnQF4TMXz7bk+CgzF/kDG+m+9bCg=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -90,8 +90,8 @@
       },
       "BenchmarkDotNet.Annotations": {
         "type": "Transitive",
-        "resolved": "0.13.3",
-        "contentHash": "p0ur0mig3KCtyqs88V33ciTGH+iKr3u2bzJWwkm11/4u5EZs47dDgAq1VuZBj076E3QLjEYpe0utjttCwcGMdw=="
+        "resolved": "0.13.5",
+        "contentHash": "ORcRi9/fnjRfINKiAnAgIsRlQ15Gj2Lki7AluHnAVMk/lTyQ2nwaa+F+ezW8f3tElBDoZql02+J2lIwHbu1eoA=="
       },
       "CommandLineParser": {
         "type": "Transitive",
@@ -100,32 +100,32 @@
       },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "S5Iv1d5UJZNJLJbe/xzJmLqYJ2mhefbLAvhXCZEh3G4sFadUBuQZhQioE4oJG4enY69QMuJX3AX9+6P9rH1bMw=="
+        "resolved": "8.2.0",
+        "contentHash": "iKzsPiSnXoQUN5AoApYmdfnLn9osNb+YCLWRr5PFmrDEQVIu7OeOyf4DPvNBvbqbYLZCfvHozPkulyv6zBQsFw=="
       },
       "Corvus.Extensions": {
         "type": "Transitive",
-        "resolved": "1.1.10",
-        "contentHash": "F43KpxsKXQhdxYPV6DRgHy2GfOJiB6/Jlg4gZzE/IQN/G1tasxWaqwUWVj+fk9HKNiDOJkcVRgxactkwD6/E3w==",
+        "resolved": "1.1.11",
+        "contentHash": "HYRd2hg8OkhejLs6ywYaGi/xuP71B3ffBeRQkZ5kywlyhxXxfQzyNuE7mvZqwP0ASFCpNLnkZwa3n3BgC59uQg==",
         "dependencies": {
           "System.Interactive": "3.2.0"
         }
       },
       "Corvus.UriTemplates": {
         "type": "Transitive",
-        "resolved": "1.0.1",
-        "contentHash": "ExxU69vHUVBvhIOy65+8V1Vpp3tl/WxiEn0R1UmqSXGTD7MVaWsQCZM4dQ98QSn86BHmmn6irCedmrdHkQ8Glw==",
+        "resolved": "1.2.0",
+        "contentHash": "Mt8dz6chvHNaVrOSrMQJPqk4EMBMA74R/LsYgq+fy5H1om88INKXHrcRaRSBMesJlmbugAowaQ7vTlNLbbn9vw==",
         "dependencies": {
-          "CommunityToolkit.HighPerformance": "8.0.0",
-          "Microsoft.Extensions.ObjectPool": "7.0.0",
+          "CommunityToolkit.HighPerformance": "8.2.0",
+          "Microsoft.Extensions.ObjectPool": "7.0.5",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "7.0.0"
         }
       },
       "Endjin.RecommendedPractices": {
         "type": "Transitive",
-        "resolved": "2.1.4",
-        "contentHash": "3B8zpRU3LEwHNZvEU8NHhzFZKZDpVaI4sMhv8bXcEoLQhRvJiBKQ90hibZIz7veX1Zi9PXrsH11HzdZBQMmntQ==",
+        "resolved": "2.1.5",
+        "contentHash": "iEFt7iG7gaBi24xSkEPFywEkZkC4yoE61PEkh2Nspqe8zbwKifSn/05jRlvRnYnanXdON+AzTKxLZf28vgCOsA==",
         "dependencies": {
           "Microsoft.Build.Tasks.Git": "1.1.1"
         }
@@ -147,18 +147,18 @@
       },
       "Json.More.Net": {
         "type": "Transitive",
-        "resolved": "1.7.0",
-        "contentHash": "+c+VvrowC36hANAihpa9uIQj4+hLmQza37d/+FCjj5Yea7QFp7l3MH7VFvJpXiEiIxWHSL5tNHXRvQu+svVUvg==",
+        "resolved": "1.8.0",
+        "contentHash": "JWxlYwCSYXZIWezmrvRgaxhI/vEEpQlZVm6/lskuS7p/uPrNJzQxbe2CPjzkF3UUz4RI8WkmObs6ycpxoE9T7w==",
         "dependencies": {
           "System.Text.Json": "6.0.2"
         }
       },
       "JsonPointer.Net": {
         "type": "Transitive",
-        "resolved": "2.2.1",
-        "contentHash": "yiofs6GG1rwwMecQeuzaY9SCXsCStAXZgU7Ek2IA5TFTUfNbzYKClmfaSl1ZB9PKyTjEj/mcp9fNHzP2ZkdQTA==",
+        "resolved": "3.0.1",
+        "contentHash": "TtUFnAp/0wK4v16quNKAbtAngXV7NrTBe3t70beTxiBU9VRhHFnLqjjU+MKWFMbM3AK++oiI2b4abgK2/7WNJA==",
         "dependencies": {
-          "Json.More.Net": "1.6.0"
+          "Json.More.Net": "1.8.0"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -324,8 +324,8 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "dDFItid/TGJljAnqbUQ0PkAl6ShIG0htwRR8J0cG/5Il6lIZPfkIZMwrZTWiF23AiQcqt6suPaUy2ih6dsCB9Q=="
+        "resolved": "7.0.5",
+        "contentHash": "uylNo8wuzAeqAJDyLDUM2JWSpTdCHTp11BXCsCO68LXnDjxwDM4PL6mJmho/+fJesWKdcJV5XB/Oa80wAJXnvQ=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -362,8 +362,8 @@
       },
       "NodaTime": {
         "type": "Transitive",
-        "resolved": "3.1.6",
-        "contentHash": "0ZGOyyLldBHYhFpDi22YcXDuAjj3bI33ChGJyp4/dP2gbhpIIVAKaIgU0h+1oUlh/LgA/UKeyJkWOCW2wHYfIg==",
+        "resolved": "3.1.9",
+        "contentHash": "EzjwDOtsETlXWBDE6qvTQqc3guP+9xrAOf9j1mHL++UD4VeZay+dbCPNnXyZhoQMkKAOZ/+hIOtz7STl0Rkknw==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "4.7.1"
         }
@@ -440,8 +440,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "OtDEmCCiNl8JAduFKZ/r0Sw6XZNHwIicUYy/mXgMDGeOsZLshH37qi3oPRzFYiryVktiMoQLByMGPtRCEMYbeQ==",
+        "resolved": "7.0.2",
+        "contentHash": "/LZf/JrGyilojqwpaywb+sSz8Tew7ij4K/Sk+UW8AKfAK7KRhR6mKpKtTm06cYA7bCpGTWfYksIW+mVsdxPegQ==",
         "dependencies": {
           "System.Text.Encodings.Web": "7.0.0"
         }
@@ -454,15 +454,15 @@
       "corvus.json.extendedtypes": {
         "type": "Project",
         "dependencies": {
-          "CommunityToolkit.HighPerformance": "[8.0.0, )",
-          "Corvus.Extensions": "[1.1.10, )",
-          "Corvus.UriTemplates": "[1.0.1, )",
+          "CommunityToolkit.HighPerformance": "[8.2.0, )",
+          "Corvus.Extensions": "[1.1.11, )",
+          "Corvus.UriTemplates": "[1.2.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.1, )",
-          "NodaTime": "[3.1.6, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.5, )",
+          "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
-          "System.Text.Json": "[7.0.1, )"
+          "System.Text.Json": "[7.0.2, )"
         }
       }
     }

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json.CodeGeneration.Abstractions.csproj
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json.CodeGeneration.Abstractions.csproj
@@ -22,7 +22,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
 		<PackageReference Include="System.CodeDom" Version="7.0.0" />
 	</ItemGroup>
 

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/SharedTemplates/CodeGenerator.String.tt
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/SharedTemplates/CodeGenerator.String.tt
@@ -201,6 +201,188 @@ public readonly partial struct <#= TypeDeclaration.DotnetTypeName #> : IJsonStri
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/SharedTemplates/CodeGenerator.tt
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/SharedTemplates/CodeGenerator.tt
@@ -761,6 +761,26 @@ public readonly partial struct <#= TypeDeclaration.DotnetTypeName #>
     }
 
     /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    static <#= TypeDeclaration.DotnetTypeName #> ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        return IJsonValue<<#= TypeDeclaration.DotnetTypeName #>>.ParseValue(buffer);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    static <#= TypeDeclaration.DotnetTypeName #> ParseValue(ref Utf8JsonReader reader)
+    {
+        return IJsonValue<<#= TypeDeclaration.DotnetTypeName #>>.ParseValue(reader);
+    }
+
+    /// <summary>
     /// Gets the value as the target value.
     /// </summary>
     /// <typeparam name="TTarget">The type of the target.</typeparam>

--- a/Solutions/Corvus.Json.CodeGenerator/Corvus.Json.CodeGenerator.csproj
+++ b/Solutions/Corvus.Json.CodeGenerator/Corvus.Json.CodeGenerator.csproj
@@ -16,7 +16,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-	  <PackageReference Include="Spectre.Console.Cli" Version="0.45.0" />
+	  <PackageReference Include="Spectre.Console.Cli" Version="0.47.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json.ExtendedTypes.csproj
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json.ExtendedTypes.csproj
@@ -18,7 +18,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="CommunityToolkit.HighPerformance" Version="8.0.0" />
+		<PackageReference Include="CommunityToolkit.HighPerformance" Version="8.2.0" />
 		<PackageReference Include="Corvus.Extensions" Version="1.1.11" />
 		<PackageReference Include="Corvus.UriTemplates" Version="1.2.0" />
 		<PackageReference Include="Endjin.RecommendedPractices.GitHub" Version="2.1.5">
@@ -26,8 +26,8 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.4" />
-		<PackageReference Include="NodaTime" Version="3.1.6" />
+		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.5" />
+		<PackageReference Include="NodaTime" Version="3.1.9" />
 		<PackageReference Include="System.Buffers" Version="4.5.1" />
 		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
 		<PackageReference Include="System.Text.Json" Version="7.0.2" />

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonAny.Core.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonAny.Core.cs
@@ -557,6 +557,26 @@ public readonly partial struct JsonAny
     }
 
     /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonAny ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        return IJsonValue<JsonAny>.ParseValue(buffer);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonAny ParseValue(ref Utf8JsonReader reader)
+    {
+        return IJsonValue<JsonAny>.ParseValue(ref reader);
+    }
+
+    /// <summary>
     /// Gets the value as the target value.
     /// </summary>
     /// <typeparam name="TTarget">The type of the target.</typeparam>

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonAny.String.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonAny.String.cs
@@ -123,6 +123,188 @@ public readonly partial struct JsonAny : IJsonString<JsonAny>
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonAny Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonAny Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonAny Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonAny Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonAny Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonAny Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonAny Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonBase64Content.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonBase64Content.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonBase64Content
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonBase64Content.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64Content Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonBase64Content>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonBase64Content.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64Content Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonBase64Content>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonBase64Content.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64Content Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonBase64Content>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonBase64Content.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64Content Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonBase64Content>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonBase64Content.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64Content Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonBase64Content>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonBase64Content.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64Content Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonBase64Content>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonBase64Content.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64Content Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonBase64Content>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonBase64ContentPre201909.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonBase64ContentPre201909.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonBase64ContentPre201909
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonBase64ContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64ContentPre201909 Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonBase64ContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonBase64ContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64ContentPre201909 Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonBase64ContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonBase64ContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64ContentPre201909 Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonBase64ContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonBase64ContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64ContentPre201909 Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonBase64ContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonBase64ContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64ContentPre201909 Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonBase64ContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonBase64ContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64ContentPre201909 Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonBase64ContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonBase64ContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64ContentPre201909 Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonBase64ContentPre201909>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonBase64String.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonBase64String.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonBase64String
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonBase64String.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64String Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonBase64String>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonBase64String.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64String Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonBase64String>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonBase64String.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64String Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonBase64String>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonBase64String.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64String Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonBase64String>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonBase64String.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64String Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonBase64String>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonBase64String.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64String Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonBase64String>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonBase64String.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64String Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonBase64String>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonBase64StringPre201909.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonBase64StringPre201909.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonBase64StringPre201909
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonBase64StringPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64StringPre201909 Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonBase64StringPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonBase64StringPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64StringPre201909 Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonBase64StringPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonBase64StringPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64StringPre201909 Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonBase64StringPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonBase64StringPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64StringPre201909 Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonBase64StringPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonBase64StringPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64StringPre201909 Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonBase64StringPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonBase64StringPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64StringPre201909 Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonBase64StringPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonBase64StringPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonBase64StringPre201909 Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonBase64StringPre201909>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonContent.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonContent.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonContent
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonContent.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContent Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonContent>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonContent.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContent Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonContent>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonContent.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContent Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonContent>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonContent.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContent Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonContent>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonContent.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContent Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonContent>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonContent.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContent Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonContent>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonContent.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContent Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonContent>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonContentPre201909.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonContentPre201909.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonContentPre201909
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContentPre201909 Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContentPre201909 Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContentPre201909 Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContentPre201909 Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContentPre201909 Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContentPre201909 Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonContentPre201909>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonContentPre201909.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonContentPre201909 Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonContentPre201909>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonDate.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonDate.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonDate
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonDate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDate Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonDate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonDate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDate Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonDate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonDate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDate Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonDate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonDate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDate Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonDate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonDate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDate Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonDate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonDate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDate Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonDate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonDate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDate Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonDate>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonDateTime.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonDateTime.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonDateTime
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonDateTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDateTime Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonDateTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonDateTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDateTime Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonDateTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonDateTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDateTime Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonDateTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonDateTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDateTime Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonDateTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonDateTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDateTime Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonDateTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonDateTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDateTime Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonDateTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonDateTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDateTime Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonDateTime>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonDuration.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonDuration.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonDuration
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonDuration.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDuration Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonDuration>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonDuration.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDuration Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonDuration>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonDuration.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDuration Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonDuration>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonDuration.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDuration Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonDuration>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonDuration.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDuration Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonDuration>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonDuration.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDuration Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonDuration>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonDuration.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonDuration Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonDuration>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonEmail.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonEmail.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonEmail
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonEmail Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonEmail Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonEmail Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonEmail Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonEmail Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonEmail Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonEmail Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonEmail>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonHostname.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonHostname.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonHostname
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonHostname Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonHostname Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonHostname Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonHostname Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonHostname Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonHostname Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonHostname Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonHostname>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIdnEmail.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIdnEmail.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonIdnEmail
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonIdnEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnEmail Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonIdnEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonIdnEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnEmail Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonIdnEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonIdnEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnEmail Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonIdnEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonIdnEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnEmail Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonIdnEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonIdnEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnEmail Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonIdnEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonIdnEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnEmail Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonIdnEmail>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonIdnEmail.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnEmail Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonIdnEmail>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIdnHostname.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIdnHostname.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonIdnHostname
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonIdnHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnHostname Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonIdnHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonIdnHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnHostname Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonIdnHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonIdnHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnHostname Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonIdnHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonIdnHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnHostname Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonIdnHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonIdnHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnHostname Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonIdnHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonIdnHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnHostname Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonIdnHostname>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonIdnHostname.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIdnHostname Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonIdnHostname>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonInteger.Core.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonInteger.Core.cs
@@ -452,6 +452,26 @@ public readonly partial struct JsonInteger : IJsonNumber<JsonInteger>
     }
 
     /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonInteger ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        return IJsonValue<JsonInteger>.ParseValue(buffer);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonInteger ParseValue(ref Utf8JsonReader reader)
+    {
+        return IJsonValue<JsonInteger>.ParseValue(ref reader);
+    }
+
+    /// <summary>
     /// Gets the value as the target value.
     /// </summary>
     /// <typeparam name="TTarget">The type of the target.</typeparam>

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIpV4.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIpV4.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonIpV4
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonIpV4.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV4 Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonIpV4>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonIpV4.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV4 Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonIpV4>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonIpV4.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV4 Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonIpV4>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonIpV4.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV4 Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonIpV4>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonIpV4.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV4 Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonIpV4>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonIpV4.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV4 Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonIpV4>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonIpV4.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV4 Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonIpV4>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIpV6.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIpV6.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonIpV6
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonIpV6.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV6 Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonIpV6>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonIpV6.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV6 Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonIpV6>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonIpV6.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV6 Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonIpV6>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonIpV6.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV6 Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonIpV6>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonIpV6.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV6 Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonIpV6>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonIpV6.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV6 Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonIpV6>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonIpV6.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIpV6 Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonIpV6>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIri.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIri.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonIri
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonIri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIri Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonIri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonIri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIri Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonIri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonIri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIri Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonIri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonIri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIri Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonIri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonIri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIri Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonIri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonIri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIri Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonIri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonIri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIri Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonIri>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIriReference.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonIriReference.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonIriReference
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonIriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIriReference Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonIriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonIriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIriReference Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonIriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonIriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIriReference Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonIriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonIriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIriReference Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonIriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonIriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIriReference Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonIriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonIriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIriReference Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonIriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonIriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonIriReference Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonIriReference>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonNotAny.Core.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonNotAny.Core.cs
@@ -715,6 +715,26 @@ public readonly partial struct JsonNotAny
     }
 
     /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonNotAny ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        return IJsonValue<JsonNotAny>.ParseValue(buffer);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonNotAny ParseValue(ref Utf8JsonReader reader)
+    {
+        return IJsonValue<JsonNotAny>.ParseValue(ref reader);
+    }
+
+    /// <summary>
     /// Gets the value as the target value.
     /// </summary>
     /// <typeparam name="TTarget">The type of the target.</typeparam>

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonNotAny.String.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonNotAny.String.cs
@@ -123,6 +123,188 @@ public readonly partial struct JsonNotAny : IJsonString<JsonNotAny>
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonNotAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonNotAny Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonNotAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonNotAny Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonNotAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonNotAny Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonNotAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonNotAny Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonNotAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonNotAny Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonNotAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonNotAny Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonNotAny.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonNotAny Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonPointer.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonPointer.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonPointer
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonPointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonPointer Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonPointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonPointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonPointer Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonPointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonPointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonPointer Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonPointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonPointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonPointer Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonPointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonPointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonPointer Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonPointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonPointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonPointer Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonPointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonPointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonPointer Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonPointer>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonRegex.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonRegex.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonRegex
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonRegex.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRegex Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonRegex>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonRegex.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRegex Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonRegex>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonRegex.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRegex Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonRegex>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonRegex.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRegex Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonRegex>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonRegex.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRegex Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonRegex>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonRegex.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRegex Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonRegex>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonRegex.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRegex Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonRegex>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonRelativePointer.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonRelativePointer.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonRelativePointer
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonRelativePointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRelativePointer Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonRelativePointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonRelativePointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRelativePointer Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonRelativePointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonRelativePointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRelativePointer Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonRelativePointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonRelativePointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRelativePointer Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonRelativePointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonRelativePointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRelativePointer Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonRelativePointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonRelativePointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRelativePointer Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonRelativePointer>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonRelativePointer.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonRelativePointer Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonRelativePointer>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonTime.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonTime.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonTime
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonTime Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonTime Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonTime Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonTime Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonTime Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonTime Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonTime>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonTime.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonTime Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonTime>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonUri.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonUri.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonUri
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonUri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUri Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonUri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonUri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUri Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonUri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonUri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUri Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonUri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonUri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUri Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonUri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonUri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUri Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonUri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonUri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUri Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonUri>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonUri.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUri Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonUri>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonUriReference.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonUriReference.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonUriReference
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonUriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriReference Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonUriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonUriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriReference Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonUriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonUriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriReference Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonUriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonUriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriReference Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonUriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonUriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriReference Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonUriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonUriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriReference Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonUriReference>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonUriReference.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriReference Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonUriReference>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonUriTemplate.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonUriTemplate.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonUriTemplate
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonUriTemplate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriTemplate Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonUriTemplate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonUriTemplate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriTemplate Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonUriTemplate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonUriTemplate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriTemplate Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonUriTemplate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonUriTemplate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriTemplate Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonUriTemplate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonUriTemplate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriTemplate Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonUriTemplate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonUriTemplate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriTemplate Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonUriTemplate>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonUriTemplate.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUriTemplate Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonUriTemplate>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonUuid.Basics.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedFormatTypes/JsonUuid.Basics.cs
@@ -151,6 +151,188 @@ public readonly partial struct JsonUuid
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonUuid.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUuid Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonUuid>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonUuid.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUuid Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonUuid>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonUuid.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUuid Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonUuid>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonUuid.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUuid Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonUuid>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonUuid.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUuid Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonUuid>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonUuid.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUuid Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonUuid>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonUuid.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonUuid Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonUuid>.ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/IJsonString{T}.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/IJsonString{T}.cs
@@ -9,7 +9,7 @@ namespace Corvus.Json;
 /// <summary>
 /// A JSON string.
 /// </summary>
-/// <typeparam name="T">The type implementin the interface.</typeparam>
+/// <typeparam name="T">The type implementing the interface.</typeparam>
 public interface IJsonString<T> : IJsonValue<T>
     where T : struct, IJsonString<T>
 {
@@ -65,4 +65,186 @@ public interface IJsonString<T> : IJsonValue<T>
     /// </summary>
     /// <returns>If the value is a string, the value as a string. Otherwise <c>null</c>.</returns>
     string? AsOptionalString();
+
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>A count of the characters written.</returns>
+    static T Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>A count of the characters written.</returns>
+    static T Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>A count of the characters written.</returns>
+    static T Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>A count of the characters written.</returns>
+    static T Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>A count of the characters written.</returns>
+    static T Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>A count of the characters written.</returns>
+    static T Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type <typeparamref name="T"/>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>A count of the characters written.</returns>
+    static T Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return ParseValue(buffer[..written]);
+    }
 }

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/IJsonValue{T}.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/IJsonValue{T}.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Buffers;
+using System.Reflection.Metadata;
 using System.Text.Json;
 
 namespace Corvus.Json;
@@ -130,4 +131,25 @@ public interface IJsonValue<T> : IEquatable<T>, IJsonValue
     /// <param name="options">The (optional) JsonDocumentOptions.</param>
     /// <returns>An instance built from the JSON string.</returns>
     static abstract T Parse(ReadOnlySequence<byte> utf8Json, JsonDocumentOptions options = default);
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    static T ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        Utf8JsonReader reader = new(buffer);
+        return ParseValue(ref reader);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    static T ParseValue(ref Utf8JsonReader reader)
+    {
+        return T.FromJson(JsonElement.ParseValue(ref reader));
+    }
 }

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/JsonWriterHelper.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/JsonWriterHelper.cs
@@ -1,0 +1,179 @@
+﻿// <copyright file="JsonWriterHelper.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+// Derived from code:
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+#pragma warning disable
+
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+using System.Text.Encodings.Web;
+
+namespace Corvus.Json;
+
+internal static partial class JsonWriterHelper
+{
+    // Only allow ASCII characters between ' ' (0x20) and '~' (0x7E), inclusively,
+    // but exclude characters that need to be escaped as hex: '"', '\'', '&', '+', '<', '>', '`'
+    // and exclude characters that need to be escaped by adding a backslash: '\n', '\r', '\t', '\\', '\b', '\f'
+    //
+    // non-zero = allowed, 0 = disallowed
+    public const int LastAsciiCharacter = 0x7F;
+
+    private static ReadOnlySpan<byte> AllowList => new byte[byte.MaxValue + 1]
+    {
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U+0000..U+000F
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U+0010..U+001F
+        1, 1, 0, 1, 1, 1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 1, // U+0020..U+002F
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 0, 1, // U+0030..U+003F
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // U+0040..U+004F
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 1, // U+0050..U+005F
+        0, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, // U+0060..U+006F
+        1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 0, // U+0070..U+007F
+
+        // Also include the ranges from U+0080 to U+00FF for performance to avoid UTF8 code from checking boundary.
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+        0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, // U+00F0..U+00FF
+    };
+
+    private const string HexFormatString = "X4";
+
+    private static readonly StandardFormat s_hexStandardFormat = new StandardFormat('X', 4);
+
+    private static bool NeedsEscaping(byte value) => AllowList[value] == 0;
+
+    public static int NeedsEscaping(ReadOnlySpan<byte> value, JavaScriptEncoder? encoder)
+    {
+        return (encoder ?? JavaScriptEncoder.Default).FindFirstCharacterToEncodeUtf8(value);
+    }
+
+    public static int GetMaxEscapedLength(int textLength, int firstIndexToEscape)
+    {
+        Debug.Assert(textLength > 0);
+        Debug.Assert(firstIndexToEscape >= 0 && firstIndexToEscape < textLength);
+        return firstIndexToEscape + JsonConstants.MaxExpansionFactorWhileEscaping * (textLength - firstIndexToEscape);
+    }
+
+    private static void EscapeString(ReadOnlySpan<byte> value, Span<byte> destination, JavaScriptEncoder encoder, ref int written)
+    {
+        Debug.Assert(encoder != null);
+
+        OperationStatus result = encoder.EncodeUtf8(value, destination, out int encoderBytesConsumed, out int encoderBytesWritten);
+
+        Debug.Assert(result != OperationStatus.DestinationTooSmall);
+        Debug.Assert(result != OperationStatus.NeedMoreData);
+
+        if (result != OperationStatus.Done)
+        {
+            throw new InvalidOperationException($"Invalid UTF8 bytes at: {value.Slice(encoderBytesWritten).ToString()}");
+        }
+
+        Debug.Assert(encoderBytesConsumed == value.Length);
+
+        written += encoderBytesWritten;
+    }
+
+    public static void EscapeString(ReadOnlySpan<byte> value, Span<byte> destination, int indexOfFirstByteToEscape, JavaScriptEncoder? encoder, out int written)
+    {
+        Debug.Assert(indexOfFirstByteToEscape >= 0 && indexOfFirstByteToEscape < value.Length);
+
+        value.Slice(0, indexOfFirstByteToEscape).CopyTo(destination);
+        written = indexOfFirstByteToEscape;
+
+        if (encoder != null)
+        {
+            destination = destination.Slice(indexOfFirstByteToEscape);
+            value = value.Slice(indexOfFirstByteToEscape);
+            EscapeString(value, destination, encoder, ref written);
+        }
+        else
+        {
+            // For performance when no encoder is specified, perform escaping here for Ascii and on the
+            // first occurrence of a non-Ascii character, then call into the default encoder.
+            while (indexOfFirstByteToEscape < value.Length)
+            {
+                byte val = value[indexOfFirstByteToEscape];
+                if (IsAsciiValue(val))
+                {
+                    if (NeedsEscaping(val))
+                    {
+                        EscapeNextBytes(val, destination, ref written);
+                        indexOfFirstByteToEscape++;
+                    }
+                    else
+                    {
+                        destination[written] = val;
+                        written++;
+                        indexOfFirstByteToEscape++;
+                    }
+                }
+                else
+                {
+                    // Fall back to default encoder.
+                    destination = destination.Slice(written);
+                    value = value.Slice(indexOfFirstByteToEscape);
+                    EscapeString(value, destination, JavaScriptEncoder.Default, ref written);
+                    break;
+                }
+            }
+        }
+    }
+
+    private static void EscapeNextBytes(byte value, Span<byte> destination, ref int written)
+    {
+        destination[written++] = (byte)'\\';
+        switch (value)
+        {
+            case JsonConstants.Quote:
+                // Optimize for the common quote case.
+                destination[written++] = (byte)'u';
+                destination[written++] = (byte)'0';
+                destination[written++] = (byte)'0';
+                destination[written++] = (byte)'2';
+                destination[written++] = (byte)'2';
+                break;
+            case JsonConstants.LineFeed:
+                destination[written++] = (byte)'n';
+                break;
+            case JsonConstants.CarriageReturn:
+                destination[written++] = (byte)'r';
+                break;
+            case JsonConstants.Tab:
+                destination[written++] = (byte)'t';
+                break;
+            case JsonConstants.BackSlash:
+                destination[written++] = (byte)'\\';
+                break;
+            case JsonConstants.BackSpace:
+                destination[written++] = (byte)'b';
+                break;
+            case JsonConstants.FormFeed:
+                destination[written++] = (byte)'f';
+                break;
+            default:
+                destination[written++] = (byte)'u';
+
+                bool result = Utf8Formatter.TryFormat(value, destination.Slice(written), out int bytesWritten, format: s_hexStandardFormat);
+                Debug.Assert(result);
+                Debug.Assert(bytesWritten == 4);
+                written += bytesWritten;
+                break;
+        }
+    }
+
+    private static bool IsAsciiValue(byte value) => value <= LastAsciiCharacter;
+
+    private static bool IsAsciiValue(char value) => value <= LastAsciiCharacter;
+}

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/LowAllocJsonUtils.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/LowAllocJsonUtils.cs
@@ -11,7 +11,7 @@ using Microsoft.Extensions.ObjectPool;
 namespace Corvus.Json;
 
 /// <summary>
-/// Utilies for low allocation access to JSON values.
+/// Utilities for low allocation access to JSON values.
 /// </summary>
 /// <remarks>
 /// These adapters give access to the underlying UTF8 bytes of JSON string
@@ -126,6 +126,552 @@ internal static class LowAllocJsonUtils
                 WriterPool.Return(writerPair);
             }
         }
+    }
+
+    /// <summary>
+    /// Concatenate two JSON values, as a UTF8 JSON string (including quotes).
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>A count of the characters written.</returns>
+    public static int ConcatenateAsUtf8JsonString<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int offset = 0;
+        PooledWriter? writerPair = null;
+        try
+        {
+            writerPair = WriterPool.Get();
+            (Utf8JsonWriter w, ArrayPoolBufferWriter<byte> writer) = writerPair.Get();
+
+            offset = CopyToBufferWithLeadingQuote(buffer, firstValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            return CopyToBufferWithTrailingQuote(buffer, secondValue, offset, w, writer);
+        }
+        finally
+        {
+            if (writerPair is not null)
+            {
+                WriterPool.Return(writerPair);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, as a UTF8 JSON string (including quotes).
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>A count of the characters written.</returns>
+    public static int ConcatenateAsUtf8JsonString<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+    where T1 : struct, IJsonValue<T1>
+    where T2 : struct, IJsonValue<T2>
+    where T3 : struct, IJsonValue<T3>
+    {
+        int offset = 0;
+        PooledWriter? writerPair = null;
+        try
+        {
+            writerPair = WriterPool.Get();
+            (Utf8JsonWriter w, ArrayPoolBufferWriter<byte> writer) = writerPair.Get();
+
+            offset = CopyToBufferWithLeadingQuote(buffer, firstValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, secondValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            return CopyToBufferWithTrailingQuote(buffer, thirdValue, offset, w, writer);
+        }
+        finally
+        {
+            if (writerPair is not null)
+            {
+                WriterPool.Return(writerPair);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, as a UTF8 JSON string (including quotes).
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>A count of the characters written.</returns>
+    public static int ConcatenateAsUtf8JsonString<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int offset = 0;
+        PooledWriter? writerPair = null;
+        try
+        {
+            writerPair = WriterPool.Get();
+            (Utf8JsonWriter w, ArrayPoolBufferWriter<byte> writer) = writerPair.Get();
+
+            offset = CopyToBufferWithLeadingQuote(buffer, firstValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, secondValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, thirdValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            return CopyToBufferWithTrailingQuote(buffer, fourthValue, offset, w, writer);
+        }
+        finally
+        {
+            if (writerPair is not null)
+            {
+                WriterPool.Return(writerPair);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, as a UTF8 JSON string (including quotes).
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>A count of the characters written.</returns>
+    public static int ConcatenateAsUtf8JsonString<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int offset = 0;
+        PooledWriter? writerPair = null;
+        try
+        {
+            writerPair = WriterPool.Get();
+            (Utf8JsonWriter w, ArrayPoolBufferWriter<byte> writer) = writerPair.Get();
+
+            offset = CopyToBufferWithLeadingQuote(buffer, firstValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, secondValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, thirdValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, fourthValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            return CopyToBufferWithTrailingQuote(buffer, fifthValue, offset, w, writer);
+        }
+        finally
+        {
+            if (writerPair is not null)
+            {
+                WriterPool.Return(writerPair);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, as a UTF8 JSON string (including quotes).
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>A count of the characters written.</returns>
+    public static int ConcatenateAsUtf8JsonString<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int offset = 0;
+        PooledWriter? writerPair = null;
+        try
+        {
+            writerPair = WriterPool.Get();
+            (Utf8JsonWriter w, ArrayPoolBufferWriter<byte> writer) = writerPair.Get();
+
+            offset = CopyToBufferWithLeadingQuote(buffer, firstValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, secondValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, thirdValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, fourthValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, fifthValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            return CopyToBufferWithTrailingQuote(buffer, sixthValue, offset, w, writer);
+        }
+        finally
+        {
+            if (writerPair is not null)
+            {
+                WriterPool.Return(writerPair);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, as a UTF8 JSON string (including quotes).
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>A count of the characters written.</returns>
+    public static int ConcatenateAsUtf8JsonString<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int offset = 0;
+        PooledWriter? writerPair = null;
+        try
+        {
+            writerPair = WriterPool.Get();
+            (Utf8JsonWriter w, ArrayPoolBufferWriter<byte> writer) = writerPair.Get();
+
+            offset = CopyToBufferWithLeadingQuote(buffer, firstValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, secondValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, thirdValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, fourthValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, fifthValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, sixthValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            return CopyToBufferWithTrailingQuote(buffer, seventhValue, offset, w, writer);
+        }
+        finally
+        {
+            if (writerPair is not null)
+            {
+                WriterPool.Return(writerPair);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, as a UTF8 JSON string (including quotes).
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>A count of the characters written.</returns>
+    public static int ConcatenateAsUtf8JsonString<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int offset = 0;
+        PooledWriter? writerPair = null;
+        try
+        {
+            writerPair = WriterPool.Get();
+            (Utf8JsonWriter w, ArrayPoolBufferWriter<byte> writer) = writerPair.Get();
+
+            offset = CopyToBufferWithLeadingQuote(buffer, firstValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, secondValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, thirdValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, fourthValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, fifthValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, sixthValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            offset = CopyToBufferWithoutQuotes(buffer, seventhValue, offset, w, writer);
+
+            // Reset the writer (which resets the buffer) for reuse
+            w.Reset();
+            writer.Clear();
+
+            return CopyToBufferWithTrailingQuote(buffer, eighthValue, offset, w, writer);
+        }
+        finally
+        {
+            if (writerPair is not null)
+            {
+                WriterPool.Return(writerPair);
+            }
+        }
+    }
+
+    private static int CopyToBufferWithTrailingQuote<T>(Span<byte> buffer, in T value, int offset, Utf8JsonWriter jsonWriter, ArrayPoolBufferWriter<byte> writer)
+        where T : struct, IJsonValue<T>
+    {
+        value.WriteTo(jsonWriter);
+        jsonWriter.Flush();
+
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            // Ignore the open quote, but write the close quote
+            writer.WrittenSpan[1..].CopyTo(buffer[offset..]);
+            offset += writer.WrittenCount - 1;
+        }
+        else
+        {
+            int firstToEscape = JsonWriterHelper.NeedsEscaping(writer.WrittenSpan, null);
+            if (firstToEscape >= 0)
+            {
+                JsonWriterHelper.EscapeString(writer.WrittenSpan, buffer[offset..], firstToEscape, null, out int escapedWritten);
+                offset += escapedWritten;
+            }
+            else
+            {
+                writer.WrittenSpan.CopyTo(buffer[offset..]);
+                offset += writer.WrittenCount;
+            }
+
+            buffer[offset++] = 0x22; // '"'
+        }
+
+        return offset;
+    }
+
+    private static int CopyToBufferWithLeadingQuote<T>(Span<byte> buffer, in T value, int offset, Utf8JsonWriter jsonWriter, ArrayPoolBufferWriter<byte> writer)
+        where T : struct, IJsonValue<T>
+    {
+        value.WriteTo(jsonWriter);
+        jsonWriter.Flush();
+
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            // Don't copy the close quote
+            writer.WrittenSpan[..^1].CopyTo(buffer[offset..]);
+
+            // Ignore the closing quote
+            offset += writer.WrittenCount - 1;
+        }
+        else
+        {
+            buffer[offset++] = 0x22; // '"'
+
+            int firstToEscape = JsonWriterHelper.NeedsEscaping(writer.WrittenSpan, null);
+            if (firstToEscape >= 0)
+            {
+                JsonWriterHelper.EscapeString(writer.WrittenSpan, buffer[offset..], firstToEscape, null, out int escapedWritten);
+                offset += escapedWritten;
+            }
+            else
+            {
+                // Copy the value in after the open quote
+                writer.WrittenSpan.CopyTo(buffer[offset..]);
+                offset += writer.WrittenCount;
+            }
+        }
+
+        return offset;
+    }
+
+    private static int CopyToBufferWithoutQuotes<T>(Span<byte> buffer, in T value, int offset, Utf8JsonWriter jsonWriter, ArrayPoolBufferWriter<byte> writer)
+        where T : struct, IJsonValue<T>
+    {
+        value.WriteTo(jsonWriter);
+        jsonWriter.Flush();
+
+        if (value.ValueKind == JsonValueKind.String)
+        {
+            // Ignore the open and close quotes
+            writer.WrittenSpan[1..^1].CopyTo(buffer[offset..]);
+            offset += writer.WrittenCount - 2;
+        }
+        else
+        {
+            int firstToEscape = JsonWriterHelper.NeedsEscaping(writer.WrittenSpan, null);
+            if (firstToEscape >= 0)
+            {
+                JsonWriterHelper.EscapeString(writer.WrittenSpan, buffer[offset..], firstToEscape, null, out int escapedWritten);
+                offset += escapedWritten;
+            }
+            else
+            {
+                // Copy the value in after the open quote
+                writer.WrittenSpan.CopyTo(buffer[offset..]);
+                offset += writer.WrittenCount;
+            }
+        }
+
+        return offset;
     }
 
     private class PooledWriter : IDisposable

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonArray.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonArray.cs
@@ -421,6 +421,26 @@ public readonly partial struct JsonArray : IJsonArray<JsonArray>
     }
 
     /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonArray ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        return IJsonValue<JsonArray>.ParseValue(buffer);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonArray ParseValue(ref Utf8JsonReader reader)
+    {
+        return IJsonValue<JsonArray>.ParseValue(ref reader);
+    }
+
+    /// <summary>
     /// Gets the value as the target value.
     /// </summary>
     /// <typeparam name="TTarget">The type of the target.</typeparam>

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonBoolean.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonBoolean.cs
@@ -426,6 +426,26 @@ public readonly partial struct JsonBoolean : IJsonBoolean<JsonBoolean>
     }
 
     /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonBoolean ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        return IJsonValue<JsonBoolean>.ParseValue(buffer);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonBoolean ParseValue(ref Utf8JsonReader reader)
+    {
+        return IJsonValue<JsonBoolean>.ParseValue(ref reader);
+    }
+
+    /// <summary>
     /// Gets the value as the target value.
     /// </summary>
     /// <typeparam name="TTarget">The type of the target.</typeparam>

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonObject.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonObject.cs
@@ -412,6 +412,26 @@ public readonly partial struct JsonObject : IJsonObject<JsonObject>
     }
 
     /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonObject ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        return IJsonValue<JsonObject>.ParseValue(buffer);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonObject ParseValue(ref Utf8JsonReader reader)
+    {
+        return IJsonValue<JsonObject>.ParseValue(ref reader);
+    }
+
+    /// <summary>
     /// Gets the value as the target value.
     /// </summary>
     /// <typeparam name="TTarget">The type of the target.</typeparam>

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonString.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonString.cs
@@ -2,10 +2,12 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
+using System;
 using System.Buffers;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+using Corvus.Json;
 using Corvus.Json.Internal;
 
 namespace Corvus.Json;
@@ -420,13 +422,215 @@ public readonly partial struct JsonString : IJsonString<JsonString>
     }
 
     /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonString ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        return IJsonValue<JsonString>.ParseValue(buffer);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static JsonString ParseValue(ref Utf8JsonReader reader)
+    {
+        return IJsonValue<JsonString>.ParseValue(ref reader);
+    }
+
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type JsonString.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonString Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<JsonString>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type JsonString.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonString Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+            where T1 : struct, IJsonValue<T1>
+            where T2 : struct, IJsonValue<T2>
+            where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<JsonString>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type JsonString.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonString Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<JsonString>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type JsonString.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonString Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+            where T1 : struct, IJsonValue<T1>
+            where T2 : struct, IJsonValue<T2>
+            where T3 : struct, IJsonValue<T3>
+            where T4 : struct, IJsonValue<T4>
+            where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<JsonString>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type JsonString.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonString Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+            where T1 : struct, IJsonValue<T1>
+            where T2 : struct, IJsonValue<T2>
+            where T3 : struct, IJsonValue<T3>
+            where T4 : struct, IJsonValue<T4>
+            where T5 : struct, IJsonValue<T5>
+            where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<JsonString>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type JsonString.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonString Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+            where T1 : struct, IJsonValue<T1>
+            where T2 : struct, IJsonValue<T2>
+            where T3 : struct, IJsonValue<T3>
+            where T4 : struct, IJsonValue<T4>
+            where T5 : struct, IJsonValue<T5>
+            where T6 : struct, IJsonValue<T6>
+            where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<JsonString>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type JsonString.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static JsonString Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+            where T1 : struct, IJsonValue<T1>
+            where T2 : struct, IJsonValue<T2>
+            where T3 : struct, IJsonValue<T3>
+            where T4 : struct, IJsonValue<T4>
+            where T5 : struct, IJsonValue<T5>
+            where T6 : struct, IJsonValue<T6>
+            where T7 : struct, IJsonValue<T7>
+            where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<JsonString>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
     /// Gets the value as the target value.
     /// </summary>
     /// <typeparam name="TTarget">The type of the target.</typeparam>
     /// <returns>An instance of the target type.</returns>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public TTarget As<TTarget>()
-        where TTarget : struct, IJsonValue<TTarget>
+            where TTarget : struct, IJsonValue<TTarget>
     {
         if ((this.backing & Backing.JsonElement) != 0)
         {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Templates/CustomAny.Core.tt
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Templates/CustomAny.Core.tt
@@ -756,6 +756,26 @@ public readonly partial struct <#= TypeName #>
     }
 
     /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static <#= TypeName #> ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        return IJsonValue<<#= TypeName #>>.ParseValue(buffer);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static <#= TypeName #> ParseValue(ref Utf8JsonReader reader)
+    {
+        return IJsonValue<<#= TypeName #>>.ParseValue(ref reader);
+    }
+
+    /// <summary>
     /// Gets the value as the target value.
     /// </summary>
     /// <typeparam name="TTarget">The type of the target.</typeparam>

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Templates/CustomAny.String.tt
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Templates/CustomAny.String.tt
@@ -126,6 +126,188 @@ public readonly partial struct <#= TypeName #> : IJsonString<<#= TypeName #>>
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return ParseValue(buffer[..written]);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Templates/FormattedNumberType.Core.tt
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Templates/FormattedNumberType.Core.tt
@@ -463,6 +463,26 @@ public readonly partial struct <#= TypeName #> : IJsonNumber<<#= TypeName #>>
     }
 
     /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static <#= TypeName #> ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        return IJsonValue<<#= TypeName #>>.ParseValue(buffer);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static <#= TypeName #> ParseValue(ref Utf8JsonReader reader)
+    {
+        return IJsonValue<<#= TypeName #>>.ParseValue(ref reader);
+    }
+
+    /// <summary>
     /// Gets the value as the target value.
     /// </summary>
     /// <typeparam name="TTarget">The type of the target.</typeparam>

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Templates/FormattedStringType.Basics.tt
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Templates/FormattedStringType.Basics.tt
@@ -154,6 +154,208 @@ public readonly partial struct <#= TypeName #>
         return new(value);
     }
 
+    /// <summary>
+    /// Concatenate two JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2>(Span<byte> buffer, in T1 firstValue, in T2 secondValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue);
+        return IJsonValue<<#= TypeName #>>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate three JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue);
+        return IJsonValue<<#= TypeName #>>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate four JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue);
+        return IJsonValue<<#= TypeName #>>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate five JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue);
+        return IJsonValue<<#= TypeName #>>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate six JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5, T6>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue);
+        return IJsonValue<<#= TypeName #>>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate seven JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5, T6, T7>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue);
+        return IJsonValue<<#= TypeName #>>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Concatenate eight JSON values, producing an instance of the string type <#= TypeName #>.
+    /// </summary>
+    /// <typeparam name="T1">The type of the first value.</typeparam>
+    /// <typeparam name="T2">The type of the second value.</typeparam>
+    /// <typeparam name="T3">The type of the third value.</typeparam>
+    /// <typeparam name="T4">The type of the fourth value.</typeparam>
+    /// <typeparam name="T5">The type of the fifth value.</typeparam>
+    /// <typeparam name="T6">The type of the sixth value.</typeparam>
+    /// <typeparam name="T7">The type of the seventh value.</typeparam>
+    /// <typeparam name="T8">The type of the eighth value.</typeparam>
+    /// <param name="buffer">The buffer into which to concatenate the values.</param>
+    /// <param name="firstValue">The first value.</param>
+    /// <param name="secondValue">The second value.</param>
+    /// <param name="thirdValue">The third value.</param>
+    /// <param name="fourthValue">The fourth value.</param>
+    /// <param name="fifthValue">The fifth value.</param>
+    /// <param name="sixthValue">The sixth value.</param>
+    /// <param name="seventhValue">The seventh value.</param>
+    /// <param name="eighthValue">The eighth value.</param>
+    /// <returns>An instance of this string type.</returns>
+    public static <#= TypeName #> Concatenate<T1, T2, T3, T4, T5, T6, T7, T8>(Span<byte> buffer, in T1 firstValue, in T2 secondValue, in T3 thirdValue, in T4 fourthValue, in T5 fifthValue, in T6 sixthValue, in T7 seventhValue, in T8 eighthValue)
+        where T1 : struct, IJsonValue<T1>
+        where T2 : struct, IJsonValue<T2>
+        where T3 : struct, IJsonValue<T3>
+        where T4 : struct, IJsonValue<T4>
+        where T5 : struct, IJsonValue<T5>
+        where T6 : struct, IJsonValue<T6>
+        where T7 : struct, IJsonValue<T7>
+        where T8 : struct, IJsonValue<T8>
+    {
+        int written = LowAllocJsonUtils.ConcatenateAsUtf8JsonString(buffer, firstValue, secondValue, thirdValue, fourthValue, fifthValue, sixthValue, seventhValue, eighthValue);
+        return IJsonValue<<#= TypeName #>>.ParseValue(buffer[..written]);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="buffer">The buffer from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static <#= TypeName #> ParseValue(ReadOnlySpan<byte> buffer)
+    {
+        return IJsonValue<<#= TypeName #>>.ParseValue(buffer);
+    }
+
+    /// <summary>
+    /// Parses a JSON value from a buffer.
+    /// </summary>
+    /// <param name="reader">The reader from which to parse the value.</param>
+    /// <returns>The parsed value.</returns>
+    public static <#= TypeName #> ParseValue(ref Utf8JsonReader reader)
+    {
+        return IJsonValue<<#= TypeName #>>.ParseValue(ref reader);
+    }
+
     /// <inheritdoc/>
     public bool TryGetString([NotNullWhen(true)] out string? value)
     {

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema.csproj
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema.csproj
@@ -19,8 +19,8 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.4" />
-		<PackageReference Include="NodaTime" Version="3.1.6" />
+		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.5" />
+		<PackageReference Include="NodaTime" Version="3.1.9" />
 		<PackageReference Include="System.Buffers" Version="4.5.1" />
 		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
 		<PackageReference Include="System.Text.Json" Version="7.0.2" />

--- a/Solutions/Corvus.Json.Patch.SpecGenerator/Corvus.Json.Patch.SpecGenerator.csproj
+++ b/Solutions/Corvus.Json.Patch.SpecGenerator/Corvus.Json.Patch.SpecGenerator.csproj
@@ -16,7 +16,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
 		<PackageReference Include="Mono.TextTemplating" Version="2.3.1" />
 		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
 		<PackageReference Include="System.Text.Json" Version="7.0.2" />

--- a/Solutions/Corvus.Json.Patch.SpecGenerator/packages.lock.json
+++ b/Solutions/Corvus.Json.Patch.SpecGenerator/packages.lock.json
@@ -4,30 +4,30 @@
     "net7.0": {
       "Corvus.Extensions": {
         "type": "Direct",
-        "requested": "[1.1.10, )",
-        "resolved": "1.1.10",
-        "contentHash": "F43KpxsKXQhdxYPV6DRgHy2GfOJiB6/Jlg4gZzE/IQN/G1tasxWaqwUWVj+fk9HKNiDOJkcVRgxactkwD6/E3w==",
+        "requested": "[1.1.11, )",
+        "resolved": "1.1.11",
+        "contentHash": "HYRd2hg8OkhejLs6ywYaGi/xuP71B3ffBeRQkZ5kywlyhxXxfQzyNuE7mvZqwP0ASFCpNLnkZwa3n3BgC59uQg==",
         "dependencies": {
           "System.Interactive": "3.2.0"
         }
       },
       "Endjin.RecommendedPractices.GitHub": {
         "type": "Direct",
-        "requested": "[2.1.4, )",
-        "resolved": "2.1.4",
-        "contentHash": "SUBvnwWuKtklIv9NWqY9PI/J1nONyvcOlitIhUTq5Hk8K0QnBoISc1xTZTe0C0tOtUW1JIAZeEYwAAeuzQwtYg==",
+        "requested": "[2.1.5, )",
+        "resolved": "2.1.5",
+        "contentHash": "PoZqxrp7iYbSF0Vi2Wtj2sepxwZA3i4Yq9CGueralFhLYcHE60E3bQOwHLwWsv4oNf60FYJrr3RjFPa7pv1HyA==",
         "dependencies": {
-          "Endjin.RecommendedPractices": "2.1.4",
+          "Endjin.RecommendedPractices": "2.1.5",
           "Microsoft.SourceLink.GitHub": "1.1.1"
         }
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[4.4.0, )",
-        "resolved": "4.4.0",
-        "contentHash": "eD2w0xHRoaqK07hjlOKGR9eLNy3nimiGNeCClNax1NDgS/+DBtBqCjXelOa+TNy99kIB3nHhUqDmr46nDXy/RQ==",
+        "requested": "[4.6.0, )",
+        "resolved": "4.6.0",
+        "contentHash": "9pyFZUN2Lyu3C0Xfs49kezfH+CzQHMibGsQeQPu0P+GWyH2XXDwmyZ6jAaKQGNUXOJfC2OK01hWMJTJY315uDQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[4.4.0]"
+          "Microsoft.CodeAnalysis.Common": "[4.6.0]"
         }
       },
       "Mono.TextTemplating": {
@@ -41,9 +41,9 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.2.0, )",
-        "resolved": "4.2.0",
-        "contentHash": "3N8CNx1Q/Q5VDDL7qgfZRgTURyMqzHAkAB59AZKRnsOXoh2n9xRzhiBMIbJaUtBATmieECBx68GcjRn2xoNDug=="
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "NZNaV9DAYGHKZ753WfhtBj8eoP40LLJsA6JQXdzhF87iTZAdbKCgp32mI3cnQF4TMXz7bk+CgzF/kDG+m+9bCg=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -62,33 +62,33 @@
       },
       "System.Text.Json": {
         "type": "Direct",
-        "requested": "[7.0.1, )",
-        "resolved": "7.0.1",
-        "contentHash": "OtDEmCCiNl8JAduFKZ/r0Sw6XZNHwIicUYy/mXgMDGeOsZLshH37qi3oPRzFYiryVktiMoQLByMGPtRCEMYbeQ==",
+        "requested": "[7.0.2, )",
+        "resolved": "7.0.2",
+        "contentHash": "/LZf/JrGyilojqwpaywb+sSz8Tew7ij4K/Sk+UW8AKfAK7KRhR6mKpKtTm06cYA7bCpGTWfYksIW+mVsdxPegQ==",
         "dependencies": {
           "System.Text.Encodings.Web": "7.0.0"
         }
       },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "S5Iv1d5UJZNJLJbe/xzJmLqYJ2mhefbLAvhXCZEh3G4sFadUBuQZhQioE4oJG4enY69QMuJX3AX9+6P9rH1bMw=="
+        "resolved": "8.2.0",
+        "contentHash": "iKzsPiSnXoQUN5AoApYmdfnLn9osNb+YCLWRr5PFmrDEQVIu7OeOyf4DPvNBvbqbYLZCfvHozPkulyv6zBQsFw=="
       },
       "Corvus.UriTemplates": {
         "type": "Transitive",
-        "resolved": "1.0.1",
-        "contentHash": "ExxU69vHUVBvhIOy65+8V1Vpp3tl/WxiEn0R1UmqSXGTD7MVaWsQCZM4dQ98QSn86BHmmn6irCedmrdHkQ8Glw==",
+        "resolved": "1.2.0",
+        "contentHash": "Mt8dz6chvHNaVrOSrMQJPqk4EMBMA74R/LsYgq+fy5H1om88INKXHrcRaRSBMesJlmbugAowaQ7vTlNLbbn9vw==",
         "dependencies": {
-          "CommunityToolkit.HighPerformance": "8.0.0",
-          "Microsoft.Extensions.ObjectPool": "7.0.0",
+          "CommunityToolkit.HighPerformance": "8.2.0",
+          "Microsoft.Extensions.ObjectPool": "7.0.5",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "7.0.0"
         }
       },
       "Endjin.RecommendedPractices": {
         "type": "Transitive",
-        "resolved": "2.1.4",
-        "contentHash": "3B8zpRU3LEwHNZvEU8NHhzFZKZDpVaI4sMhv8bXcEoLQhRvJiBKQ90hibZIz7veX1Zi9PXrsH11HzdZBQMmntQ==",
+        "resolved": "2.1.5",
+        "contentHash": "iEFt7iG7gaBi24xSkEPFywEkZkC4yoE61PEkh2Nspqe8zbwKifSn/05jRlvRnYnanXdON+AzTKxLZf28vgCOsA==",
         "dependencies": {
           "Microsoft.Build.Tasks.Git": "1.1.1"
         }
@@ -100,21 +100,19 @@
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
-        "resolved": "3.3.3",
-        "contentHash": "j/rOZtLMVJjrfLRlAMckJLPW/1rze9MT1yfWqSIbUPGRu1m1P0fuo9PmqapwsmePfGB5PJrudQLvmUOAMF0DqQ=="
+        "resolved": "3.3.4",
+        "contentHash": "AxkxcPR+rheX0SmvpLVIGLhOUXAKG56a64kV9VQZ4y9gR9ZmPXnqZvHJnmwLSwzrEP6junUF11vuc+aqo5r68g=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "JfHupS/B7Jb5MZoYkFFABn3mux0wQgxi2D8F/rJYZeRBK2ZOyk7TjQ2Kq9rh6W/DCh0KNbbSbn5qoFar+ueHqw==",
+        "resolved": "4.6.0",
+        "contentHash": "N3uLvekc7DjvE1BX8YW7UH7ldjA4ps/Tun2YmOoSIItJrh1gnQIMKUbK1c3uQUx2NHbLibVZI4o/VB9xb4B7tA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.3.3",
-          "System.Collections.Immutable": "6.0.0",
-          "System.Memory": "4.5.5",
-          "System.Reflection.Metadata": "5.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.4",
+          "System.Collections.Immutable": "7.0.0",
+          "System.Reflection.Metadata": "7.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encoding.CodePages": "6.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Text.Encoding.CodePages": "7.0.0"
         }
       },
       "Microsoft.Extensions.DependencyInjection": {
@@ -159,8 +157,8 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "dDFItid/TGJljAnqbUQ0PkAl6ShIG0htwRR8J0cG/5Il6lIZPfkIZMwrZTWiF23AiQcqt6suPaUy2ih6dsCB9Q=="
+        "resolved": "7.0.5",
+        "contentHash": "uylNo8wuzAeqAJDyLDUM2JWSpTdCHTp11BXCsCO68LXnDjxwDM4PL6mJmho/+fJesWKdcJV5XB/Oa80wAJXnvQ=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -192,8 +190,8 @@
       },
       "NodaTime": {
         "type": "Transitive",
-        "resolved": "3.1.6",
-        "contentHash": "0ZGOyyLldBHYhFpDi22YcXDuAjj3bI33ChGJyp4/dP2gbhpIIVAKaIgU0h+1oUlh/LgA/UKeyJkWOCW2wHYfIg==",
+        "resolved": "3.1.9",
+        "contentHash": "EzjwDOtsETlXWBDE6qvTQqc3guP+9xrAOf9j1mHL++UD4VeZay+dbCPNnXyZhoQMkKAOZ/+hIOtz7STl0Rkknw==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "4.7.1"
         }
@@ -218,15 +216,13 @@
         "resolved": "3.2.0",
         "contentHash": "hoXiC7r+WvT/oQ/QcsCgIJMEcXKXyM26BvIcFVRgEMzXk9URu8oR2ADqrnHwIRiJmxQC/q8b3KTQSkdoFRO4TA=="
       },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.5",
-        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw=="
-      },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ=="
+        "resolved": "7.0.0",
+        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "dependencies": {
+          "System.Collections.Immutable": "7.0.0"
+        }
       },
       "System.Runtime.CompilerServices.Unsafe": {
         "type": "Transitive",
@@ -235,47 +231,39 @@
       },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "ZFCILZuOvtKPauZ/j/swhvw68ZRi9ATCfvGbk1QfydmcXBkIWecWKn/250UH7rahZ5OoDBaiAudJtPvLwzw85A==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "7.0.0",
+        "contentHash": "LSyCblMpvOe0N3E+8e0skHcrIhgV2huaNcjUUEa8hRtgEAm36aGkRoC8Jxlb6Ra6GSfF29ftduPNywin8XolzQ=="
       },
       "System.Text.Encodings.Web": {
         "type": "Transitive",
         "resolved": "7.0.0",
         "contentHash": "OP6umVGxc0Z0MvZQBVigj4/U31Pw72ITihDWP9WiWDm+q5aoe0GaJivsfYGq53o6dxH7DcXWiCTl7+0o2CGdmg=="
       },
-      "System.Threading.Tasks.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
-      },
       "corvus.json.extendedtypes": {
         "type": "Project",
         "dependencies": {
-          "CommunityToolkit.HighPerformance": "[8.0.0, )",
-          "Corvus.Extensions": "[1.1.10, )",
-          "Corvus.UriTemplates": "[1.0.1, )",
+          "CommunityToolkit.HighPerformance": "[8.2.0, )",
+          "Corvus.Extensions": "[1.1.11, )",
+          "Corvus.UriTemplates": "[1.2.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.1, )",
-          "NodaTime": "[3.1.6, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.5, )",
+          "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
-          "System.Text.Json": "[7.0.1, )"
+          "System.Text.Json": "[7.0.2, )"
         }
       },
       "corvus.json.patch": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Extensions": "[1.1.10, )",
+          "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.ExtendedTypes": "[1.0.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.1, )",
-          "NodaTime": "[3.1.6, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.5, )",
+          "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
-          "System.Text.Json": "[7.0.1, )"
+          "System.Text.Json": "[7.0.2, )"
         }
       }
     }

--- a/Solutions/Corvus.Json.Patch/Corvus.Json.Patch.csproj
+++ b/Solutions/Corvus.Json.Patch/Corvus.Json.Patch.csproj
@@ -19,8 +19,8 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.4" />
-		<PackageReference Include="NodaTime" Version="3.1.6" />
+		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.5" />
+		<PackageReference Include="NodaTime" Version="3.1.9" />
 		<PackageReference Include="System.Buffers" Version="4.5.1" />
 		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />
 		<PackageReference Include="System.Text.Json" Version="7.0.2" />

--- a/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
+++ b/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
@@ -71,6 +71,7 @@
 
 	<ItemGroup>
 	  <Folder Include="Features\JsonModel\JsonStringTryGetValue\" />
+	  <Folder Include="Features\JsonModel\JsonStringConcatenate\" />
 	  <Folder Include="Features\JsonSchema\Draft6\" />
 	</ItemGroup>
 

--- a/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
+++ b/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
@@ -18,9 +18,9 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="2.0.0" />
+		<PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="2.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0-preview-20221003-04" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
 		<PackageReference Include="SolidToken.SpecFlow.DependencyInjection" Version="3.9.3" />
 		<PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
 
@@ -28,16 +28,16 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.4.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.6.0" />
 
 
 		<PackageReference Include="SpecFlow.NUnit" Version="3.9.74" />
 		<PackageReference Include="nunit" Version="3.13.3" />
-		<PackageReference Include="NUnit3TestAdapter" Version="4.3.1" />
+		<PackageReference Include="NUnit3TestAdapter" Version="4.5.0" />
 		<!-- Required for publishing test results directly to Azure Pipelines -->
 		<PackageReference Include="azurepipelines.testlogger" Version="1.2.2" />
 
-		<PackageReference Include="FluentAssertions" Version="6.8.0" />
+		<PackageReference Include="FluentAssertions" Version="6.11.0" />
 
 		<PackageReference Include="System.Text.Json" Version="7.0.2" />
 

--- a/Solutions/Corvus.Json.Specs/Features/JsonModel/JsonStringConcatenate/StringConcatenate.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonModel/JsonStringConcatenate/StringConcatenate.feature
@@ -1,0 +1,92 @@
+Feature: JsonStringConcatenate
+	Concatenate multiple JSON values into a json string
+
+Scenario Outline: Concatenate multiple JSON values to a JSON string value
+	Given the JsonElement backed JsonArray <jsonValue>
+	When the values are concatenated to a JsonString
+	And the result should be equal to the JsonString <result>
+
+Examples:
+	| jsonValue                                                                                        | result                                                            |
+	| ["Hello", "world"]                                                                               | Helloworld                                                        |
+	| [true, "world"]                                                                                  | trueworld                                                         |
+	| ["Hello", true]                                                                                  | Hellotrue                                                         |
+	| [3.0, "world"]                                                                                   | 3.0world                                                          |
+	| ["Hello", 3.0]                                                                                   | Hello3.0                                                          |
+	| [null, "world"]                                                                                  | nullworld                                                         |
+	| ["Hello", null]                                                                                  | Hellonull                                                         |
+	| [[1,2,3], "world"]                                                                               | [1,2,3]world                                                      |
+	| ["Hello", [1,2,3]]                                                                               | Hello[1,2,3]                                                      |
+	| [{"foo": 3}, "world"]                                                                            | {"foo":3}world                                                    |
+	| ["Hello", {"foo": 3}]                                                                            | Hello{"foo":3}                                                    |
+	| ["Hello", "there", "world"]                                                                      | Hellothereworld                                                   |
+	| [true, "there", "world"]                                                                         | truethereworld                                                    |
+	| ["Hello", "there", true]                                                                         | Hellotheretrue                                                    |
+	| [3.0, "there", "world"]                                                                          | 3.0thereworld                                                     |
+	| ["Hello", "there", 3.0]                                                                          | Hellothere3.0                                                     |
+	| [null, "there", "world"]                                                                         | nullthereworld                                                    |
+	| ["Hello", "there", null]                                                                         | Hellotherenull                                                    |
+	| [[1,2,3], "there", "world"]                                                                      | [1,2,3]thereworld                                                 |
+	| ["Hello", "there", [1,2,3]]                                                                      | Hellothere[1,2,3]                                                 |
+	| [{"foo": 3}, "there", "world"]                                                                   | {"foo":3}thereworld                                               |
+	| ["Hello", "there", {"foo": 3}]                                                                   | Hellothere{"foo":3}                                               |
+	| ["Hello", "there", "again", "world"]                                                             | Hellothereagainworld                                              |
+	| [true, "there", "again", "world"]                                                                | truethereagainworld                                               |
+	| ["Hello", "there", "again", true]                                                                | Hellothereagaintrue                                               |
+	| [3.0, "there", "again", "world"]                                                                 | 3.0thereagainworld                                                |
+	| ["Hello", "there", "again", 3.0]                                                                 | Hellothereagain3.0                                                |
+	| [null, "there", "again", "world"]                                                                | nullthereagainworld                                               |
+	| ["Hello", "there", "again", null]                                                                | Hellothereagainnull                                               |
+	| [[1,2,3], "there", "again", "world"]                                                             | [1,2,3]thereagainworld                                            |
+	| ["Hello", "there", "again", [1,2,3]]                                                             | Hellothereagain[1,2,3]                                            |
+	| [{"foo": 3}, "there", "again", "world"]                                                          | {"foo":3}thereagainworld                                          |
+	| ["Hello", "there", "again", {"foo": 3}]                                                          | Hellothereagain{"foo":3}                                          |
+	| ["Hello", "there", "again", "beautiful", "world"]                                                | Hellothereagainbeautifulworld                                     |
+	| [true, "there", "again", "beautiful", "world"]                                                   | truethereagainbeautifulworld                                      |
+	| ["Hello", "there", "again", "beautiful", true]                                                   | Hellothereagainbeautifultrue                                      |
+	| [3.0, "there", "again", "beautiful", "world"]                                                    | 3.0thereagainbeautifulworld                                       |
+	| ["Hello", "there", "again", "beautiful", 3.0]                                                    | Hellothereagainbeautiful3.0                                       |
+	| [null, "there", "again", "beautiful", "world"]                                                   | nullthereagainbeautifulworld                                      |
+	| ["Hello", "there", "again", "beautiful", null]                                                   | Hellothereagainbeautifulnull                                      |
+	| [[1,2,3], "there", "again", "beautiful", "world"]                                                | [1,2,3]thereagainbeautifulworld                                   |
+	| ["Hello", "there", "again", "beautiful", [1,2,3]]                                                | Hellothereagainbeautiful[1,2,3]                                   |
+	| [{"foo": 3}, "there", "again", "beautiful", "world"]                                             | {"foo":3}thereagainbeautifulworld                                 |
+	| ["Hello", "there", "again", "beautiful", {"foo": 3}]                                             | Hellothereagainbeautiful{"foo":3}                                 |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "world"]                               | Hellothereagainbeautifulextraordinaryworld                        |
+	| [true, "there", "again", "beautiful", "extraordinary", "world"]                                  | truethereagainbeautifulextraordinaryworld                         |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", true]                                  | Hellothereagainbeautifulextraordinarytrue                         |
+	| [3.0, "there", "again", "beautiful", "extraordinary", "world"]                                   | 3.0thereagainbeautifulextraordinaryworld                          |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", 3.0]                                   | Hellothereagainbeautifulextraordinary3.0                          |
+	| [null, "there", "again", "beautiful", "extraordinary", "world"]                                  | nullthereagainbeautifulextraordinaryworld                         |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", null]                                  | Hellothereagainbeautifulextraordinarynull                         |
+	| [[1,2,3], "there", "again", "beautiful", "extraordinary", "world"]                               | [1,2,3]thereagainbeautifulextraordinaryworld                      |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", [1,2,3]]                               | Hellothereagainbeautifulextraordinary[1,2,3]                      |
+	| [{"foo": 3}, "there", "again", "beautiful", "extraordinary", "world"]                            | {"foo":3}thereagainbeautifulextraordinaryworld                    |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", {"foo": 3}]                            | Hellothereagainbeautifulextraordinary{"foo":3}                    |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", "world"]                | Hellothereagainbeautifulextraordinarymagnificentworld             |
+	| [true, "there", "again", "beautiful", "extraordinary", "magnificent", "world"]                   | truethereagainbeautifulextraordinarymagnificentworld              |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", true]                   | Hellothereagainbeautifulextraordinarymagnificenttrue              |
+	| [3.0, "there", "again", "beautiful", "extraordinary", "magnificent", "world"]                    | 3.0thereagainbeautifulextraordinarymagnificentworld               |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", 3.0]                    | Hellothereagainbeautifulextraordinarymagnificent3.0               |
+	| [null, "there", "again", "beautiful", "extraordinary", "magnificent", "world"]                   | nullthereagainbeautifulextraordinarymagnificentworld              |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", null]                   | Hellothereagainbeautifulextraordinarymagnificentnull              |
+	| [[1,2,3], "there", "again", "beautiful", "extraordinary", "magnificent", "world"]                | [1,2,3]thereagainbeautifulextraordinarymagnificentworld           |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", [1,2,3]]                | Hellothereagainbeautifulextraordinarymagnificent[1,2,3]           |
+	| [{"foo": 3}, "there", "again", "beautiful", "extraordinary", "magnificent", "world"]             | {"foo":3}thereagainbeautifulextraordinarymagnificentworld         |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", {"foo": 3}]             | Hellothereagainbeautifulextraordinarymagnificent{"foo":3}         |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", "glorious", "world"]    | Hellothereagainbeautifulextraordinarymagnificentgloriousworld     |
+	| [true, "there", "again", "beautiful", "extraordinary", "magnificent", "glorious", "world"]       | truethereagainbeautifulextraordinarymagnificentgloriousworld      |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", "glorious", true]       | Hellothereagainbeautifulextraordinarymagnificentglorioustrue      |
+	| [3.0, "there", "again", "beautiful", "extraordinary", "magnificent", "glorious", "world"]        | 3.0thereagainbeautifulextraordinarymagnificentgloriousworld       |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", "glorious", 3.0]        | Hellothereagainbeautifulextraordinarymagnificentglorious3.0       |
+	| [null, "there", "again", "beautiful", "extraordinary", "magnificent", "glorious", "world"]       | nullthereagainbeautifulextraordinarymagnificentgloriousworld      |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", "glorious", null]       | Hellothereagainbeautifulextraordinarymagnificentgloriousnull      |
+	| [[1,2,3], "there", "again", "beautiful", "extraordinary", "magnificent", "glorious", "world"]    | [1,2,3]thereagainbeautifulextraordinarymagnificentgloriousworld   |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", "glorious", [1,2,3]]    | Hellothereagainbeautifulextraordinarymagnificentglorious[1,2,3]   |
+	| [{"foo": 3}, "there", "again", "beautiful", "extraordinary", "magnificent", "glorious", "world"] | {"foo":3}thereagainbeautifulextraordinarymagnificentgloriousworld |
+	| ["Hello", "there", "again", "beautiful", "extraordinary", "magnificent", "glorious", {"foo": 3}] | Hellothereagainbeautifulextraordinarymagnificentglorious{"foo":3} |
+	| ["there", true, "world"]                                                                         | theretrueworld                                                    |
+	| ["there", 3.0, "world"]                                                                          | there3.0world                                                     |
+	| ["there", null, "world"]                                                                         | therenullworld                                                    |
+	| ["there", [1,2,3], "world"]                                                                      | there[1,2,3]world                                                 |
+	| ["there", {"foo": 3}, "world"]                                                                   | there{"foo":3}world                                               |	

--- a/Solutions/Corvus.Json.Specs/Steps/JsonStringConcatenateStepDefinitions.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/JsonStringConcatenateStepDefinitions.cs
@@ -1,0 +1,55 @@
+// <copyright file="JsonStringConcatenateStepDefinitions.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using Corvus.Json;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+
+namespace Steps;
+
+[Binding]
+public class JsonStringConcatenateStepDefinitions
+{
+    /// <summary>
+    /// The key for a concatenation result.
+    /// </summary>
+    internal const string ConcatenateResult = "ConcatenateResult";
+
+    private readonly ScenarioContext scenarioContext;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonStringConcatenateStepDefinitions"/> class.
+    /// </summary>
+    /// <param name="scenarioContext">The scenario context.</param>
+    public JsonStringConcatenateStepDefinitions(ScenarioContext scenarioContext)
+    {
+        this.scenarioContext = scenarioContext;
+    }
+
+    [When("the values are concatenated to a JsonString")]
+    public void WhenTheValuesAreConcatenatedToAJsonString()
+    {
+        JsonArray subjectUnderTest = this.scenarioContext.Get<JsonArray>(JsonValueSteps.SubjectUnderTest);
+        Span<byte> buffer = stackalloc byte[256];
+        JsonString result = subjectUnderTest.GetArrayLength() switch
+        {
+            2 => JsonString.Concatenate(buffer, subjectUnderTest[0], subjectUnderTest[1]),
+            3 => JsonString.Concatenate(buffer, subjectUnderTest[0], subjectUnderTest[1], subjectUnderTest[2]),
+            4 => JsonString.Concatenate(buffer, subjectUnderTest[0], subjectUnderTest[1], subjectUnderTest[2], subjectUnderTest[3]),
+            5 => JsonString.Concatenate(buffer, subjectUnderTest[0], subjectUnderTest[1], subjectUnderTest[2], subjectUnderTest[3], subjectUnderTest[4]),
+            6 => JsonString.Concatenate(buffer, subjectUnderTest[0], subjectUnderTest[1], subjectUnderTest[2], subjectUnderTest[3], subjectUnderTest[4], subjectUnderTest[5]),
+            7 => JsonString.Concatenate(buffer, subjectUnderTest[0], subjectUnderTest[1], subjectUnderTest[2], subjectUnderTest[3], subjectUnderTest[4], subjectUnderTest[5], subjectUnderTest[6]),
+            8 => JsonString.Concatenate(buffer, subjectUnderTest[0], subjectUnderTest[1], subjectUnderTest[2], subjectUnderTest[3], subjectUnderTest[4], subjectUnderTest[5], subjectUnderTest[6], subjectUnderTest[7]),
+            _ => throw new InvalidOperationException("Unsupported number of items"),
+        };
+        this.scenarioContext.Set(result, ConcatenateResult);
+    }
+
+    [When("the result should be equal to the JsonString (.*)")]
+    public void WhenTheResultShouldBeEqualToTheJsonString(string result)
+    {
+        var stringValue = new JsonString(result);
+        Assert.AreEqual(stringValue, this.scenarioContext.Get<JsonString>(ConcatenateResult));
+    }
+}

--- a/Solutions/Corvus.Json.Specs/packages.lock.json
+++ b/Solutions/Corvus.Json.Specs/packages.lock.json
@@ -13,43 +13,43 @@
       },
       "Corvus.Testing.SpecFlow.NUnit": {
         "type": "Direct",
-        "requested": "[2.0.0, )",
-        "resolved": "2.0.0",
-        "contentHash": "mutrleL9V2ftOzcrfBGSe8imboy+p4hxWO+ejNE6TWvBPBdjFlteST/vsHoQwMOVT1VUj4AfXtgSqk5SN+NH4A==",
+        "requested": "[2.0.1, )",
+        "resolved": "2.0.1",
+        "contentHash": "jRk9G0PMuotpgBJMpkp9wM+0Rd+QxG8Hs28nP+p3izctFPtaCNZfcWO1/0QdiQdeK1dTjQdHqWSB7n6oFsRuVQ==",
         "dependencies": {
-          "Corvus.Testing.SpecFlow": "2.0.0",
+          "Corvus.Testing.SpecFlow": "2.0.1",
           "Microsoft.NET.Test.Sdk": "17.4.0",
-          "Moq": "4.18.3",
+          "Moq": "4.18.4",
           "SpecFlow.NUnit.Runners": "3.9.74",
           "coverlet.msbuild": "3.2.0"
         }
       },
       "Endjin.RecommendedPractices.GitHub": {
         "type": "Direct",
-        "requested": "[2.1.4, )",
-        "resolved": "2.1.4",
-        "contentHash": "SUBvnwWuKtklIv9NWqY9PI/J1nONyvcOlitIhUTq5Hk8K0QnBoISc1xTZTe0C0tOtUW1JIAZeEYwAAeuzQwtYg==",
+        "requested": "[2.1.5, )",
+        "resolved": "2.1.5",
+        "contentHash": "PoZqxrp7iYbSF0Vi2Wtj2sepxwZA3i4Yq9CGueralFhLYcHE60E3bQOwHLwWsv4oNf60FYJrr3RjFPa7pv1HyA==",
         "dependencies": {
-          "Endjin.RecommendedPractices": "2.1.4",
+          "Endjin.RecommendedPractices": "2.1.5",
           "Microsoft.SourceLink.GitHub": "1.1.1"
         }
       },
       "FluentAssertions": {
         "type": "Direct",
-        "requested": "[6.8.0, )",
-        "resolved": "6.8.0",
-        "contentHash": "NfSlAG97wMxS48Ov+wQEhJITdn4bKrgtKrG4sCPrFBVKozpC57lQ2vzsPdxUOsPbfEgEQTMtvCDECxIlDBfgNA==",
+        "requested": "[6.11.0, )",
+        "resolved": "6.11.0",
+        "contentHash": "aBaagwdNtVKkug1F3imGXUlmoBd8ZUZX8oQ5niThaJhF79SpESe1Gzq7OFuZkQdKD5Pa4Mone+jrbas873AT4g==",
         "dependencies": {
           "System.Configuration.ConfigurationManager": "4.4.0"
         }
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[4.4.0, )",
-        "resolved": "4.4.0",
-        "contentHash": "eD2w0xHRoaqK07hjlOKGR9eLNy3nimiGNeCClNax1NDgS/+DBtBqCjXelOa+TNy99kIB3nHhUqDmr46nDXy/RQ==",
+        "requested": "[4.6.0, )",
+        "resolved": "4.6.0",
+        "contentHash": "9pyFZUN2Lyu3C0Xfs49kezfH+CzQHMibGsQeQPu0P+GWyH2XXDwmyZ6jAaKQGNUXOJfC2OK01hWMJTJY315uDQ==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Common": "[4.4.0]"
+          "Microsoft.CodeAnalysis.Common": "[4.6.0]"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
@@ -67,12 +67,12 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[17.5.0-preview-20221003-04, )",
-        "resolved": "17.5.0-preview-20221003-04",
-        "contentHash": "YpPrK2mVX9iMbXaq+uTl+sON2iis6bDyiuZnaw66LfAI6O3uBBstN6gjYlkNGfKxzIkA5XO7+UXPCCnXDQkbkA==",
+        "requested": "[17.6.2, )",
+        "resolved": "17.6.2",
+        "contentHash": "+WFxuoFVBG0aewD9Psw+1I90kaRToQgMIzK20xNVRO4QRWR9Bou3qGefrZvMZ/xTC+6bAmZppFbpPbiHDzrPyg==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "17.5.0-preview-20221003-04",
-          "Microsoft.TestPlatform.TestHost": "17.5.0-preview-20221003-04"
+          "Microsoft.CodeCoverage": "17.6.2",
+          "Microsoft.TestPlatform.TestHost": "17.6.2"
         }
       },
       "NUnit": {
@@ -86,15 +86,15 @@
       },
       "NUnit3TestAdapter": {
         "type": "Direct",
-        "requested": "[4.3.1, )",
-        "resolved": "4.3.1",
-        "contentHash": "R+bGFtsUpLWywjT1nb3xMmoVa2AIw6ClIGC+XjW9lYE8hwJeos+NdR/mtg4RXbBphmC9epALrnUc6MM7mUG8+Q=="
+        "requested": "[4.5.0, )",
+        "resolved": "4.5.0",
+        "contentHash": "s8JpqTe9bI2f49Pfr3dFRfoVSuFQyraTj68c3XXjIS/MRGvvkLnrg6RLqnTjdShX+AdFUCCU/4Xex58AdUfs6A=="
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.2.0, )",
-        "resolved": "4.2.0",
-        "contentHash": "3N8CNx1Q/Q5VDDL7qgfZRgTURyMqzHAkAB59AZKRnsOXoh2n9xRzhiBMIbJaUtBATmieECBx68GcjRn2xoNDug=="
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "NZNaV9DAYGHKZ753WfhtBj8eoP40LLJsA6JQXdzhF87iTZAdbKCgp32mI3cnQF4TMXz7bk+CgzF/kDG+m+9bCg=="
       },
       "SolidToken.SpecFlow.DependencyInjection": {
         "type": "Direct",
@@ -134,9 +134,9 @@
       },
       "System.Text.Json": {
         "type": "Direct",
-        "requested": "[7.0.1, )",
-        "resolved": "7.0.1",
-        "contentHash": "OtDEmCCiNl8JAduFKZ/r0Sw6XZNHwIicUYy/mXgMDGeOsZLshH37qi3oPRzFYiryVktiMoQLByMGPtRCEMYbeQ==",
+        "requested": "[7.0.2, )",
+        "resolved": "7.0.2",
+        "contentHash": "/LZf/JrGyilojqwpaywb+sSz8Tew7ij4K/Sk+UW8AKfAK7KRhR6mKpKtTm06cYA7bCpGTWfYksIW+mVsdxPegQ==",
         "dependencies": {
           "System.Text.Encodings.Web": "7.0.0"
         }
@@ -148,29 +148,29 @@
       },
       "Castle.Core": {
         "type": "Transitive",
-        "resolved": "5.1.0",
-        "contentHash": "31UJpTHOiWq95CDOHazE3Ub/hE/PydNWsJMwnEVTqFFP4WhAugwpaVGxzOxKgNeSUUeqS2W6lxV+q7u1pAOfXg==",
+        "resolved": "5.1.1",
+        "contentHash": "rpYtIczkzGpf+EkZgDr9CClTdemhsrwA/W5hMoPjLkRFnXzH44zDLoovXeKtmxb1ykXK9aJVODSpiJml8CTw2g==",
         "dependencies": {
           "System.Diagnostics.EventLog": "6.0.0"
         }
       },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "S5Iv1d5UJZNJLJbe/xzJmLqYJ2mhefbLAvhXCZEh3G4sFadUBuQZhQioE4oJG4enY69QMuJX3AX9+6P9rH1bMw=="
+        "resolved": "8.2.0",
+        "contentHash": "iKzsPiSnXoQUN5AoApYmdfnLn9osNb+YCLWRr5PFmrDEQVIu7OeOyf4DPvNBvbqbYLZCfvHozPkulyv6zBQsFw=="
       },
       "Corvus.Extensions": {
         "type": "Transitive",
-        "resolved": "1.1.10",
-        "contentHash": "F43KpxsKXQhdxYPV6DRgHy2GfOJiB6/Jlg4gZzE/IQN/G1tasxWaqwUWVj+fk9HKNiDOJkcVRgxactkwD6/E3w==",
+        "resolved": "1.1.11",
+        "contentHash": "HYRd2hg8OkhejLs6ywYaGi/xuP71B3ffBeRQkZ5kywlyhxXxfQzyNuE7mvZqwP0ASFCpNLnkZwa3n3BgC59uQg==",
         "dependencies": {
           "System.Interactive": "3.2.0"
         }
       },
       "Corvus.Testing.SpecFlow": {
         "type": "Transitive",
-        "resolved": "2.0.0",
-        "contentHash": "dNCAIMrssh6jG7HO8FlTRzdNIHcE/X8B6Zlsdfwi9LbI0EX2IZGiFZosp+XhFQDYZ5ttAzJjO2ZWUqhnpglWWQ==",
+        "resolved": "2.0.1",
+        "contentHash": "sVHvG/Zl7NLIYu02FM9yFbiCb6n4NKY8KjuApR1l21ZQ28UZfsRpgrNR/nKGM6zOWURqNKf/fI610P1EoP6pzQ==",
         "dependencies": {
           "Microsoft.Extensions.Configuration.Abstractions": "6.0.0",
           "Microsoft.Extensions.DependencyInjection": "6.0.1",
@@ -182,11 +182,11 @@
       },
       "Corvus.UriTemplates": {
         "type": "Transitive",
-        "resolved": "1.0.1",
-        "contentHash": "ExxU69vHUVBvhIOy65+8V1Vpp3tl/WxiEn0R1UmqSXGTD7MVaWsQCZM4dQ98QSn86BHmmn6irCedmrdHkQ8Glw==",
+        "resolved": "1.2.0",
+        "contentHash": "Mt8dz6chvHNaVrOSrMQJPqk4EMBMA74R/LsYgq+fy5H1om88INKXHrcRaRSBMesJlmbugAowaQ7vTlNLbbn9vw==",
         "dependencies": {
-          "CommunityToolkit.HighPerformance": "8.0.0",
-          "Microsoft.Extensions.ObjectPool": "7.0.0",
+          "CommunityToolkit.HighPerformance": "8.2.0",
+          "Microsoft.Extensions.ObjectPool": "7.0.5",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "7.0.0"
         }
@@ -198,8 +198,8 @@
       },
       "Endjin.RecommendedPractices": {
         "type": "Transitive",
-        "resolved": "2.1.4",
-        "contentHash": "3B8zpRU3LEwHNZvEU8NHhzFZKZDpVaI4sMhv8bXcEoLQhRvJiBKQ90hibZIz7veX1Zi9PXrsH11HzdZBQMmntQ==",
+        "resolved": "2.1.5",
+        "contentHash": "iEFt7iG7gaBi24xSkEPFywEkZkC4yoE61PEkh2Nspqe8zbwKifSn/05jRlvRnYnanXdON+AzTKxLZf28vgCOsA==",
         "dependencies": {
           "Microsoft.Build.Tasks.Git": "1.1.1"
         }
@@ -216,27 +216,25 @@
       },
       "Microsoft.CodeAnalysis.Analyzers": {
         "type": "Transitive",
-        "resolved": "3.3.3",
-        "contentHash": "j/rOZtLMVJjrfLRlAMckJLPW/1rze9MT1yfWqSIbUPGRu1m1P0fuo9PmqapwsmePfGB5PJrudQLvmUOAMF0DqQ=="
+        "resolved": "3.3.4",
+        "contentHash": "AxkxcPR+rheX0SmvpLVIGLhOUXAKG56a64kV9VQZ4y9gR9ZmPXnqZvHJnmwLSwzrEP6junUF11vuc+aqo5r68g=="
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "4.4.0",
-        "contentHash": "JfHupS/B7Jb5MZoYkFFABn3mux0wQgxi2D8F/rJYZeRBK2ZOyk7TjQ2Kq9rh6W/DCh0KNbbSbn5qoFar+ueHqw==",
+        "resolved": "4.6.0",
+        "contentHash": "N3uLvekc7DjvE1BX8YW7UH7ldjA4ps/Tun2YmOoSIItJrh1gnQIMKUbK1c3uQUx2NHbLibVZI4o/VB9xb4B7tA==",
         "dependencies": {
-          "Microsoft.CodeAnalysis.Analyzers": "3.3.3",
-          "System.Collections.Immutable": "6.0.0",
-          "System.Memory": "4.5.5",
-          "System.Reflection.Metadata": "5.0.0",
+          "Microsoft.CodeAnalysis.Analyzers": "3.3.4",
+          "System.Collections.Immutable": "7.0.0",
+          "System.Reflection.Metadata": "7.0.0",
           "System.Runtime.CompilerServices.Unsafe": "6.0.0",
-          "System.Text.Encoding.CodePages": "6.0.0",
-          "System.Threading.Tasks.Extensions": "4.5.4"
+          "System.Text.Encoding.CodePages": "7.0.0"
         }
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "17.5.0-preview-20221003-04",
-        "contentHash": "3xgt5Lf/XcEPxk4aclgJIYwwmt8fcTFmKmxSBoAPoQ5U5liQcsncrHhCg9twligVqfYT2PptBevpQLAR8WuUAg=="
+        "resolved": "17.6.2",
+        "contentHash": "t+DjPlq7GIxIkOK/jiTmNeiEMVkfVCynBEZyV+IMg2ro43NugKExng+7a04R1fBLi+d6voxjeDxL2ozdl+XyVg=="
       },
       "Microsoft.DotNet.PlatformAbstractions": {
         "type": "Transitive",
@@ -359,8 +357,8 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "dDFItid/TGJljAnqbUQ0PkAl6ShIG0htwRR8J0cG/5Il6lIZPfkIZMwrZTWiF23AiQcqt6suPaUy2ih6dsCB9Q=="
+        "resolved": "7.0.5",
+        "contentHash": "uylNo8wuzAeqAJDyLDUM2JWSpTdCHTp11BXCsCO68LXnDjxwDM4PL6mJmho/+fJesWKdcJV5XB/Oa80wAJXnvQ=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -402,19 +400,19 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "17.5.0-preview-20221003-04",
-        "contentHash": "Gou0FfdDd6MZMmh1m6AJF3KVIYHE+SxxDnv4Dksr0ZAh+TpRR48gN/W/x/qit1ePCzhiHE1wyXEiNpl1YtOJnA==",
+        "resolved": "17.6.2",
+        "contentHash": "I3S/oELDAe/ckFltBnPb0PV+gADbpc8n0yGTtYfTd7q1hd0cAZKn/FrYoegA/rGws8fEFyJD/2PB6uq+nIjWsg==",
         "dependencies": {
-          "NuGet.Frameworks": "5.11.0",
+          "NuGet.Frameworks": "6.5.0",
           "System.Reflection.Metadata": "1.6.0"
         }
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "17.5.0-preview-20221003-04",
-        "contentHash": "p0tQUCn9UupTaVqFdFWDcDV82QiVRFMPuJ2/zxoEf6DtmeKDjZzB3AXkhTRM+eVkR1fMiW3TehhMh0T3TiUs9w==",
+        "resolved": "17.6.2",
+        "contentHash": "WszrF1CoG+Y2bA4WJFxlaPADQCWUuNP6TCxVRuScmP6DQsNvDDuOO9XiUxCA+wPmNOSyWVh9EGrPu7JoUpf2gA==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "17.5.0-preview-20221003-04",
+          "Microsoft.TestPlatform.ObjectModel": "17.6.2",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -429,10 +427,10 @@
       },
       "Moq": {
         "type": "Transitive",
-        "resolved": "4.18.3",
-        "contentHash": "nmV2lludVOFmVi+Vtq9twX1/SDiEVyYDURzxW39gUBqjyoXmdyNwJSeOfSCJoJTXDXBVfFNfEljB5UWGj/cKnQ==",
+        "resolved": "4.18.4",
+        "contentHash": "IOo+W51+7Afnb0noltJrKxPBSfsgMzTKCw+Re5AMx8l/vBbAbMDOynLik4+lBYIWDJSO0uV7Zdqt7cNb6RZZ+A==",
         "dependencies": {
-          "Castle.Core": "5.1.0"
+          "Castle.Core": "5.1.1"
         }
       },
       "NETStandard.Library": {
@@ -450,16 +448,16 @@
       },
       "NodaTime": {
         "type": "Transitive",
-        "resolved": "3.1.6",
-        "contentHash": "0ZGOyyLldBHYhFpDi22YcXDuAjj3bI33ChGJyp4/dP2gbhpIIVAKaIgU0h+1oUlh/LgA/UKeyJkWOCW2wHYfIg==",
+        "resolved": "3.1.9",
+        "contentHash": "EzjwDOtsETlXWBDE6qvTQqc3guP+9xrAOf9j1mHL++UD4VeZay+dbCPNnXyZhoQMkKAOZ/+hIOtz7STl0Rkknw==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "4.7.1"
         }
       },
       "NuGet.Frameworks": {
         "type": "Transitive",
-        "resolved": "5.11.0",
-        "contentHash": "eaiXkUjC4NPcquGWzAGMXjuxvLwc6XGKMptSyOGQeT0X70BUZObuybJFZLA0OfTdueLd3US23NBPTBb6iF3V1Q=="
+        "resolved": "6.5.0",
+        "contentHash": "QWINE2x3MbTODsWT1Gh71GaGb5icBz4chS8VYvTgsBnsi8esgN6wtHhydd7fvToWECYGq7T4cgBBDiKD/363fg=="
       },
       "NUnit.Console": {
         "type": "Transitive",
@@ -890,11 +888,6 @@
           "System.CodeDom": "4.7.0"
         }
       },
-      "System.Memory": {
-        "type": "Transitive",
-        "resolved": "4.5.5",
-        "contentHash": "XIWiDvKPXaTveaB7HVganDlOCRoj03l+jrwNvcge/t8vhGYKvqV+dMv6G4SAX2NoNmN0wZfVPTAlFwZcZvVOUw=="
-      },
       "System.Net.Http": {
         "type": "Transitive",
         "resolved": "4.3.4",
@@ -1009,8 +1002,11 @@
       },
       "System.Reflection.Metadata": {
         "type": "Transitive",
-        "resolved": "5.0.0",
-        "contentHash": "5NecZgXktdGg34rh1OenY1rFNDCI8xSjFr+Z4OU4cU06AQHUdRnIIEeWENu3Wl4YowbzkymAIMvi3WyK9U53pQ=="
+        "resolved": "7.0.0",
+        "contentHash": "MclTG61lsD9sYdpNz9xsKBzjsmsfCtcMZYXz/IUr2zlhaTaABonlr1ESeompTgM+Xk+IwtGYU7/voh3YWB/fWw==",
+        "dependencies": {
+          "System.Collections.Immutable": "7.0.0"
+        }
       },
       "System.Reflection.Primitives": {
         "type": "Transitive",
@@ -1308,11 +1304,8 @@
       },
       "System.Text.Encoding.CodePages": {
         "type": "Transitive",
-        "resolved": "6.0.0",
-        "contentHash": "ZFCILZuOvtKPauZ/j/swhvw68ZRi9ATCfvGbk1QfydmcXBkIWecWKn/250UH7rahZ5OoDBaiAudJtPvLwzw85A==",
-        "dependencies": {
-          "System.Runtime.CompilerServices.Unsafe": "6.0.0"
-        }
+        "resolved": "7.0.0",
+        "contentHash": "LSyCblMpvOe0N3E+8e0skHcrIhgV2huaNcjUUEa8hRtgEAm36aGkRoC8Jxlb6Ra6GSfF29ftduPNywin8XolzQ=="
       },
       "System.Threading": {
         "type": "Transitive",
@@ -1333,15 +1326,10 @@
           "System.Runtime": "4.3.0"
         }
       },
-      "System.Threading.Tasks.Extensions": {
-        "type": "Transitive",
-        "resolved": "4.5.4",
-        "contentHash": "zteT+G8xuGu6mS+mzDzYXbzS7rd3K6Fjb9RiZlYlJPam2/hU7JCBZBVEcywNuR+oZ1ncTvc/cq0faRr3P01OVg=="
-      },
       "corvus.json.codegeneration.201909": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Extensions": "[1.1.10, )",
+          "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.CodeGeneration.Abstractions": "[1.0.0, )",
           "Corvus.Json.JsonSchema": "[1.0.0, )",
           "System.CodeDom": "[7.0.0, )"
@@ -1350,7 +1338,7 @@
       "corvus.json.codegeneration.202012": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Extensions": "[1.1.10, )",
+          "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.CodeGeneration.Abstractions": "[1.0.0, )",
           "Corvus.Json.JsonSchema": "[1.0.0, )",
           "System.CodeDom": "[7.0.0, )"
@@ -1359,7 +1347,7 @@
       "corvus.json.codegeneration.6": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Extensions": "[1.1.10, )",
+          "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.CodeGeneration.Abstractions": "[1.0.0, )",
           "Corvus.Json.JsonSchema": "[1.0.0, )",
           "System.CodeDom": "[7.0.0, )"
@@ -1368,7 +1356,7 @@
       "corvus.json.codegeneration.7": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Extensions": "[1.1.10, )",
+          "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.CodeGeneration.Abstractions": "[1.0.0, )",
           "Corvus.Json.JsonSchema": "[1.0.0, )",
           "System.CodeDom": "[7.0.0, )"
@@ -1377,50 +1365,50 @@
       "corvus.json.codegeneration.abstractions": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Extensions": "[1.1.10, )",
+          "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.ExtendedTypes": "[1.0.0, )",
-          "Microsoft.CodeAnalysis.CSharp": "[4.4.0, )",
+          "Microsoft.CodeAnalysis.CSharp": "[4.6.0, )",
           "System.CodeDom": "[7.0.0, )"
         }
       },
       "corvus.json.extendedtypes": {
         "type": "Project",
         "dependencies": {
-          "CommunityToolkit.HighPerformance": "[8.0.0, )",
-          "Corvus.Extensions": "[1.1.10, )",
-          "Corvus.UriTemplates": "[1.0.1, )",
+          "CommunityToolkit.HighPerformance": "[8.2.0, )",
+          "Corvus.Extensions": "[1.1.11, )",
+          "Corvus.UriTemplates": "[1.2.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.1, )",
-          "NodaTime": "[3.1.6, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.5, )",
+          "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
-          "System.Text.Json": "[7.0.1, )"
+          "System.Text.Json": "[7.0.2, )"
         }
       },
       "corvus.json.jsonschema": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Extensions": "[1.1.10, )",
+          "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.ExtendedTypes": "[1.0.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.1, )",
-          "NodaTime": "[3.1.6, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.5, )",
+          "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
-          "System.Text.Json": "[7.0.1, )"
+          "System.Text.Json": "[7.0.2, )"
         }
       },
       "corvus.json.patch": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Extensions": "[1.1.10, )",
+          "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.ExtendedTypes": "[1.0.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.1, )",
-          "NodaTime": "[3.1.6, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.5, )",
+          "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
-          "System.Text.Json": "[7.0.1, )"
+          "System.Text.Json": "[7.0.2, )"
         }
       }
     }

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Corvus.JsonPatch.Benchmarking.csproj
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Corvus.JsonPatch.Benchmarking.csproj
@@ -14,14 +14,14 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.3" />
+		<PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.13.5" />
 		<PackageReference Include="Endjin.RecommendedPractices.GitHub" Version="2.1.5">
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="BenchmarkDotNet" Version="0.13.3" />
+		<PackageReference Include="BenchmarkDotNet" Version="0.13.5" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-		<PackageReference Include="JsonPatch.Net" Version="2.0.4" />
+		<PackageReference Include="JsonPatch.Net" Version="2.1.0" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/packages.lock.json
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/packages.lock.json
@@ -4,11 +4,11 @@
     "net7.0": {
       "BenchmarkDotNet": {
         "type": "Direct",
-        "requested": "[0.13.3, )",
-        "resolved": "0.13.3",
-        "contentHash": "Y0aNdOZ9LdcwVniiAmQEcdYnpR8qe+BOSmqMBukJ1+ez7PiyqpwJHbppOJ1ibHKh28qdq781l8hsPIld5lvsIw==",
+        "requested": "[0.13.5, )",
+        "resolved": "0.13.5",
+        "contentHash": "PiwINqvreKV7L+BQlaZ2qcJ90s88LbLqZoUWbKnEPzvmsWd4pUH58Yjp+mFn311n8Jz0Y0JsD+jWa+Kh67IG3A==",
         "dependencies": {
-          "BenchmarkDotNet.Annotations": "0.13.3",
+          "BenchmarkDotNet.Annotations": "0.13.5",
           "CommandLineParser": "2.4.3",
           "Gee.External.Capstone": "2.3.0",
           "Iced": "1.17.0",
@@ -22,31 +22,31 @@
       },
       "BenchmarkDotNet.Diagnostics.Windows": {
         "type": "Direct",
-        "requested": "[0.13.3, )",
-        "resolved": "0.13.3",
-        "contentHash": "mlVmyFBcgrnOsupN7BvADjYaTxqlMbGjx6WTPV0ponFwupU1r2z5Vv27QF8guGvYViM8RjNFQvtNB8is/jyGdw==",
+        "requested": "[0.13.5, )",
+        "resolved": "0.13.5",
+        "contentHash": "bNKJlIgUvEMBotiiHrEzw2xyCFlNiEfE14/EcBOEDSgYg+spzByVVv+totq9baxKUk5MhfAFhyzguBMiuoho3Q==",
         "dependencies": {
-          "BenchmarkDotNet": "0.13.3",
+          "BenchmarkDotNet": "0.13.5",
           "Microsoft.Diagnostics.Tracing.TraceEvent": "3.0.2"
         }
       },
       "Endjin.RecommendedPractices.GitHub": {
         "type": "Direct",
-        "requested": "[2.1.4, )",
-        "resolved": "2.1.4",
-        "contentHash": "SUBvnwWuKtklIv9NWqY9PI/J1nONyvcOlitIhUTq5Hk8K0QnBoISc1xTZTe0C0tOtUW1JIAZeEYwAAeuzQwtYg==",
+        "requested": "[2.1.5, )",
+        "resolved": "2.1.5",
+        "contentHash": "PoZqxrp7iYbSF0Vi2Wtj2sepxwZA3i4Yq9CGueralFhLYcHE60E3bQOwHLwWsv4oNf60FYJrr3RjFPa7pv1HyA==",
         "dependencies": {
-          "Endjin.RecommendedPractices": "2.1.4",
+          "Endjin.RecommendedPractices": "2.1.5",
           "Microsoft.SourceLink.GitHub": "1.1.1"
         }
       },
       "JsonPatch.Net": {
         "type": "Direct",
-        "requested": "[2.0.4, )",
-        "resolved": "2.0.4",
-        "contentHash": "Pr0lHxEYOpa2r6cEJaji9HTamKrp3pIey8Cxg0sV7EovGFf/e24TemwLPHjJD/zZ2q2YDFf/53VQCbPoDh3kPw==",
+        "requested": "[2.1.0, )",
+        "resolved": "2.1.0",
+        "contentHash": "iTTUYeOk6tLGCwKTnqC/w28vkxaP8pO5BgIODpvwU3MM63XqZJ/p+iWZXhSvyRBUxqo3l+VHw49TnsxBZGTW9Q==",
         "dependencies": {
-          "JsonPointer.Net": "2.2.1"
+          "JsonPointer.Net": "3.0.1"
         }
       },
       "Microsoft.Extensions.Configuration.Json": {
@@ -64,9 +64,9 @@
       },
       "Roslynator.Analyzers": {
         "type": "Direct",
-        "requested": "[4.2.0, )",
-        "resolved": "4.2.0",
-        "contentHash": "3N8CNx1Q/Q5VDDL7qgfZRgTURyMqzHAkAB59AZKRnsOXoh2n9xRzhiBMIbJaUtBATmieECBx68GcjRn2xoNDug=="
+        "requested": "[4.3.0, )",
+        "resolved": "4.3.0",
+        "contentHash": "NZNaV9DAYGHKZ753WfhtBj8eoP40LLJsA6JQXdzhF87iTZAdbKCgp32mI3cnQF4TMXz7bk+CgzF/kDG+m+9bCg=="
       },
       "StyleCop.Analyzers": {
         "type": "Direct",
@@ -79,8 +79,8 @@
       },
       "BenchmarkDotNet.Annotations": {
         "type": "Transitive",
-        "resolved": "0.13.3",
-        "contentHash": "p0ur0mig3KCtyqs88V33ciTGH+iKr3u2bzJWwkm11/4u5EZs47dDgAq1VuZBj076E3QLjEYpe0utjttCwcGMdw=="
+        "resolved": "0.13.5",
+        "contentHash": "ORcRi9/fnjRfINKiAnAgIsRlQ15Gj2Lki7AluHnAVMk/lTyQ2nwaa+F+ezW8f3tElBDoZql02+J2lIwHbu1eoA=="
       },
       "CommandLineParser": {
         "type": "Transitive",
@@ -89,32 +89,32 @@
       },
       "CommunityToolkit.HighPerformance": {
         "type": "Transitive",
-        "resolved": "8.0.0",
-        "contentHash": "S5Iv1d5UJZNJLJbe/xzJmLqYJ2mhefbLAvhXCZEh3G4sFadUBuQZhQioE4oJG4enY69QMuJX3AX9+6P9rH1bMw=="
+        "resolved": "8.2.0",
+        "contentHash": "iKzsPiSnXoQUN5AoApYmdfnLn9osNb+YCLWRr5PFmrDEQVIu7OeOyf4DPvNBvbqbYLZCfvHozPkulyv6zBQsFw=="
       },
       "Corvus.Extensions": {
         "type": "Transitive",
-        "resolved": "1.1.10",
-        "contentHash": "F43KpxsKXQhdxYPV6DRgHy2GfOJiB6/Jlg4gZzE/IQN/G1tasxWaqwUWVj+fk9HKNiDOJkcVRgxactkwD6/E3w==",
+        "resolved": "1.1.11",
+        "contentHash": "HYRd2hg8OkhejLs6ywYaGi/xuP71B3ffBeRQkZ5kywlyhxXxfQzyNuE7mvZqwP0ASFCpNLnkZwa3n3BgC59uQg==",
         "dependencies": {
           "System.Interactive": "3.2.0"
         }
       },
       "Corvus.UriTemplates": {
         "type": "Transitive",
-        "resolved": "1.0.1",
-        "contentHash": "ExxU69vHUVBvhIOy65+8V1Vpp3tl/WxiEn0R1UmqSXGTD7MVaWsQCZM4dQ98QSn86BHmmn6irCedmrdHkQ8Glw==",
+        "resolved": "1.2.0",
+        "contentHash": "Mt8dz6chvHNaVrOSrMQJPqk4EMBMA74R/LsYgq+fy5H1om88INKXHrcRaRSBMesJlmbugAowaQ7vTlNLbbn9vw==",
         "dependencies": {
-          "CommunityToolkit.HighPerformance": "8.0.0",
-          "Microsoft.Extensions.ObjectPool": "7.0.0",
+          "CommunityToolkit.HighPerformance": "8.2.0",
+          "Microsoft.Extensions.ObjectPool": "7.0.5",
           "System.Buffers": "4.5.1",
           "System.Collections.Immutable": "7.0.0"
         }
       },
       "Endjin.RecommendedPractices": {
         "type": "Transitive",
-        "resolved": "2.1.4",
-        "contentHash": "3B8zpRU3LEwHNZvEU8NHhzFZKZDpVaI4sMhv8bXcEoLQhRvJiBKQ90hibZIz7veX1Zi9PXrsH11HzdZBQMmntQ==",
+        "resolved": "2.1.5",
+        "contentHash": "iEFt7iG7gaBi24xSkEPFywEkZkC4yoE61PEkh2Nspqe8zbwKifSn/05jRlvRnYnanXdON+AzTKxLZf28vgCOsA==",
         "dependencies": {
           "Microsoft.Build.Tasks.Git": "1.1.1"
         }
@@ -131,18 +131,18 @@
       },
       "Json.More.Net": {
         "type": "Transitive",
-        "resolved": "1.6.0",
-        "contentHash": "bn/agVu1jQ5V0UyMUYD11ZNMkGry5vmfYBGuRPs9SUkcGWTLf6UiVEEeEm8UQiyMQWdJmTEGBRE4DpqPI+4mzQ==",
+        "resolved": "1.8.0",
+        "contentHash": "JWxlYwCSYXZIWezmrvRgaxhI/vEEpQlZVm6/lskuS7p/uPrNJzQxbe2CPjzkF3UUz4RI8WkmObs6ycpxoE9T7w==",
         "dependencies": {
           "System.Text.Json": "6.0.2"
         }
       },
       "JsonPointer.Net": {
         "type": "Transitive",
-        "resolved": "2.2.1",
-        "contentHash": "yiofs6GG1rwwMecQeuzaY9SCXsCStAXZgU7Ek2IA5TFTUfNbzYKClmfaSl1ZB9PKyTjEj/mcp9fNHzP2ZkdQTA==",
+        "resolved": "3.0.1",
+        "contentHash": "TtUFnAp/0wK4v16quNKAbtAngXV7NrTBe3t70beTxiBU9VRhHFnLqjjU+MKWFMbM3AK++oiI2b4abgK2/7WNJA==",
         "dependencies": {
-          "Json.More.Net": "1.6.0"
+          "Json.More.Net": "1.8.0"
         }
       },
       "Microsoft.Bcl.AsyncInterfaces": {
@@ -308,8 +308,8 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "dDFItid/TGJljAnqbUQ0PkAl6ShIG0htwRR8J0cG/5Il6lIZPfkIZMwrZTWiF23AiQcqt6suPaUy2ih6dsCB9Q=="
+        "resolved": "7.0.5",
+        "contentHash": "uylNo8wuzAeqAJDyLDUM2JWSpTdCHTp11BXCsCO68LXnDjxwDM4PL6mJmho/+fJesWKdcJV5XB/Oa80wAJXnvQ=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -346,8 +346,8 @@
       },
       "NodaTime": {
         "type": "Transitive",
-        "resolved": "3.1.6",
-        "contentHash": "0ZGOyyLldBHYhFpDi22YcXDuAjj3bI33ChGJyp4/dP2gbhpIIVAKaIgU0h+1oUlh/LgA/UKeyJkWOCW2wHYfIg==",
+        "resolved": "3.1.9",
+        "contentHash": "EzjwDOtsETlXWBDE6qvTQqc3guP+9xrAOf9j1mHL++UD4VeZay+dbCPNnXyZhoQMkKAOZ/+hIOtz7STl0Rkknw==",
         "dependencies": {
           "System.Runtime.CompilerServices.Unsafe": "4.7.1"
         }
@@ -424,8 +424,8 @@
       },
       "System.Text.Json": {
         "type": "Transitive",
-        "resolved": "7.0.1",
-        "contentHash": "OtDEmCCiNl8JAduFKZ/r0Sw6XZNHwIicUYy/mXgMDGeOsZLshH37qi3oPRzFYiryVktiMoQLByMGPtRCEMYbeQ==",
+        "resolved": "7.0.2",
+        "contentHash": "/LZf/JrGyilojqwpaywb+sSz8Tew7ij4K/Sk+UW8AKfAK7KRhR6mKpKtTm06cYA7bCpGTWfYksIW+mVsdxPegQ==",
         "dependencies": {
           "System.Text.Encodings.Web": "7.0.0"
         }
@@ -438,28 +438,28 @@
       "corvus.json.extendedtypes": {
         "type": "Project",
         "dependencies": {
-          "CommunityToolkit.HighPerformance": "[8.0.0, )",
-          "Corvus.Extensions": "[1.1.10, )",
-          "Corvus.UriTemplates": "[1.0.1, )",
+          "CommunityToolkit.HighPerformance": "[8.2.0, )",
+          "Corvus.Extensions": "[1.1.11, )",
+          "Corvus.UriTemplates": "[1.2.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.1, )",
-          "NodaTime": "[3.1.6, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.5, )",
+          "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
-          "System.Text.Json": "[7.0.1, )"
+          "System.Text.Json": "[7.0.2, )"
         }
       },
       "corvus.json.patch": {
         "type": "Project",
         "dependencies": {
-          "Corvus.Extensions": "[1.1.10, )",
+          "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.ExtendedTypes": "[1.0.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.1, )",
-          "NodaTime": "[3.1.6, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.5, )",
+          "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
-          "System.Text.Json": "[7.0.1, )"
+          "System.Text.Json": "[7.0.2, )"
         }
       }
     }

--- a/Solutions/Sandbox/Sandbox.csproj
+++ b/Solutions/Sandbox/Sandbox.csproj
@@ -9,7 +9,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="JsonPatch.Net" Version="2.0.4" />
+		<PackageReference Include="JsonPatch.Net" Version="2.1.0" />
 	</ItemGroup>
 	
 	<ItemGroup>


### PR DESCRIPTION
We now support concatenating multiple JSON values (whether string like or not) into a JSON string value.

```csharp
JsonString firstValue = new("This is ");
JsonBoolean secondValue = true;

MyStringType value = MyStringType.Concatenate(firstValue, secondValue);

value.Equals("This is true"); // This is true!
```

The JSON values are serialized to the output value, and correctly encoded as a JSON string.

Internally, this uses the UTF8 writer and backs to a `JsonElement`; this makes it a very efficient way of composing JSON string values when mapping in a service implementation. No dotnet strings are allocated.