### PR TITLE
Feature/198 add deep patch

### DIFF
--- a/Solutions/Corvus.Json.Benchmarking/Corvus.Json.Benchmarking.csproj
+++ b/Solutions/Corvus.Json.Benchmarking/Corvus.Json.Benchmarking.csproj
@@ -20,7 +20,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="JsonSchema.Net" Version="4.1.5" />
+		<PackageReference Include="JsonSchema.Net" Version="4.1.6" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
 		<PackageReference Include="JsonPatch.Net" Version="2.1.0" />
 	</ItemGroup>

--- a/Solutions/Corvus.Json.Benchmarking/packages.lock.json
+++ b/Solutions/Corvus.Json.Benchmarking/packages.lock.json
@@ -51,9 +51,9 @@
       },
       "JsonSchema.Net": {
         "type": "Direct",
-        "requested": "[4.1.5, )",
-        "resolved": "4.1.5",
-        "contentHash": "nDQqFfL4chnds2fEzWm5HFH0ypb1qC6gof4kzU2lT/aZKzhT2cnvVRvpPr0F+5m4wJ/3joNMa7sSYLBe/WefiQ==",
+        "requested": "[4.1.6, )",
+        "resolved": "4.1.6",
+        "contentHash": "l7EhrRfZ9jMiQGNFzaDb6uKb1G6txs2i3QecPSrs6gDi0Td8sWFCkqbL9E7i9fEgnMFJnUtWYcP13H62g/NsKw==",
         "dependencies": {
           "JetBrains.Annotations": "2021.2.0",
           "Json.More.Net": "1.8.0",
@@ -324,8 +324,8 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "7.0.7",
-        "contentHash": "pKyzYIhXug0Eom/F17SWIGf2aDB2N+A//aW+LJXP8/ZWrI3mXpxgf6SLNSu3gwakU3rZx+Xrsb6PT5MiB6QDvQ=="
+        "resolved": "7.0.8",
+        "contentHash": "aaNEWSL4d9Qhl5UXlBySXfgHvzIrR4sc6dScCDFfIcCw2uH4d5WuWy+KOnIRPumqj5YuP6J0ejkUTsipvm+xCQ=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -458,7 +458,7 @@
           "Corvus.Extensions": "[1.1.11, )",
           "Corvus.UriTemplates": "[1.2.1, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.8, )",
           "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",

--- a/Solutions/Corvus.Json.Benchmarking/packages.lock.json
+++ b/Solutions/Corvus.Json.Benchmarking/packages.lock.json
@@ -113,8 +113,8 @@
       },
       "Corvus.UriTemplates": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "Mt8dz6chvHNaVrOSrMQJPqk4EMBMA74R/LsYgq+fy5H1om88INKXHrcRaRSBMesJlmbugAowaQ7vTlNLbbn9vw==",
+        "resolved": "1.2.1",
+        "contentHash": "lDWJkAmoBDvYJER+xeDj3wY0m4jnql+KfCrre5k8212vMrDVKyeMjPPAfQJs7D5Bq1l7jqM4QFK6FB0Cr9Qv7Q==",
         "dependencies": {
           "CommunityToolkit.HighPerformance": "8.2.0",
           "Microsoft.Extensions.ObjectPool": "7.0.5",
@@ -456,7 +456,7 @@
         "dependencies": {
           "CommunityToolkit.HighPerformance": "[8.2.0, )",
           "Corvus.Extensions": "[1.1.11, )",
-          "Corvus.UriTemplates": "[1.2.0, )",
+          "Corvus.UriTemplates": "[1.2.1, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
           "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
           "NodaTime": "[3.1.9, )",

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json.ExtendedTypes.csproj
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json.ExtendedTypes.csproj
@@ -26,7 +26,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.7" />
+		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.8" />
 		<PackageReference Include="NodaTime" Version="3.1.9" />
 		<PackageReference Include="System.Buffers" Version="4.5.1" />
 		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />

--- a/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema.csproj
+++ b/Solutions/Corvus.Json.JsonSchema/Corvus.Json.JsonSchema.csproj
@@ -19,7 +19,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.7" />
+		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.8" />
 		<PackageReference Include="NodaTime" Version="3.1.9" />
 		<PackageReference Include="System.Buffers" Version="4.5.1" />
 		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />

--- a/Solutions/Corvus.Json.Patch.SpecGenerator/packages.lock.json
+++ b/Solutions/Corvus.Json.Patch.SpecGenerator/packages.lock.json
@@ -76,8 +76,8 @@
       },
       "Corvus.UriTemplates": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "Mt8dz6chvHNaVrOSrMQJPqk4EMBMA74R/LsYgq+fy5H1om88INKXHrcRaRSBMesJlmbugAowaQ7vTlNLbbn9vw==",
+        "resolved": "1.2.1",
+        "contentHash": "lDWJkAmoBDvYJER+xeDj3wY0m4jnql+KfCrre5k8212vMrDVKyeMjPPAfQJs7D5Bq1l7jqM4QFK6FB0Cr9Qv7Q==",
         "dependencies": {
           "CommunityToolkit.HighPerformance": "8.2.0",
           "Microsoft.Extensions.ObjectPool": "7.0.5",
@@ -244,7 +244,7 @@
         "dependencies": {
           "CommunityToolkit.HighPerformance": "[8.2.0, )",
           "Corvus.Extensions": "[1.1.11, )",
-          "Corvus.UriTemplates": "[1.2.0, )",
+          "Corvus.UriTemplates": "[1.2.1, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
           "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
           "NodaTime": "[3.1.9, )",

--- a/Solutions/Corvus.Json.Patch.SpecGenerator/packages.lock.json
+++ b/Solutions/Corvus.Json.Patch.SpecGenerator/packages.lock.json
@@ -157,8 +157,8 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "7.0.7",
-        "contentHash": "pKyzYIhXug0Eom/F17SWIGf2aDB2N+A//aW+LJXP8/ZWrI3mXpxgf6SLNSu3gwakU3rZx+Xrsb6PT5MiB6QDvQ=="
+        "resolved": "7.0.8",
+        "contentHash": "aaNEWSL4d9Qhl5UXlBySXfgHvzIrR4sc6dScCDFfIcCw2uH4d5WuWy+KOnIRPumqj5YuP6J0ejkUTsipvm+xCQ=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -246,7 +246,7 @@
           "Corvus.Extensions": "[1.1.11, )",
           "Corvus.UriTemplates": "[1.2.1, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.8, )",
           "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
@@ -259,7 +259,7 @@
           "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.ExtendedTypes": "[1.0.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.8, )",
           "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",

--- a/Solutions/Corvus.Json.Patch/Corvus.Json.Patch.csproj
+++ b/Solutions/Corvus.Json.Patch/Corvus.Json.Patch.csproj
@@ -19,7 +19,7 @@
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
 		<PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.7" />
+		<PackageReference Include="Microsoft.Extensions.ObjectPool" Version="7.0.8" />
 		<PackageReference Include="NodaTime" Version="3.1.9" />
 		<PackageReference Include="System.Buffers" Version="4.5.1" />
 		<PackageReference Include="System.Collections.Immutable" Version="7.0.0" />

--- a/Solutions/Corvus.Json.Patch/Corvus.Json.Patch/JsonPatchExtensions.RemoveVisitor.cs
+++ b/Solutions/Corvus.Json.Patch/Corvus.Json.Patch/JsonPatchExtensions.RemoveVisitor.cs
@@ -18,18 +18,30 @@ public static partial class JsonPatchExtensions
     {
         public RemoveVisitor(in JsonPatchDocument.RemoveEntity patchOperation)
         {
-            this.Path = patchOperation.Path;
-            this.BeginTerminator = this.Path.LastIndexOf('/') + 1;
+            this.Path = ((string)patchOperation.Path).AsMemory();
+            this.BeginTerminator = this.Path.Span.LastIndexOf('/') + 1;
         }
 
-        public string Path { get; }
+        public RemoveVisitor(string path)
+        {
+            this.Path = path.AsMemory();
+            this.BeginTerminator = this.Path.Span.LastIndexOf('/') + 1;
+        }
+
+        public RemoveVisitor(ReadOnlyMemory<char> path)
+        {
+            this.Path = path;
+            this.BeginTerminator = this.Path.Span.LastIndexOf('/') + 1;
+        }
+
+        public ReadOnlyMemory<char> Path { get; }
 
         public int BeginTerminator { get; }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Visit(ReadOnlySpan<char> path, in JsonAny nodeToVisit, ref VisitResult result)
         {
-            ReadOnlySpan<char> span = this.Path.AsSpan();
+            ReadOnlySpan<char> span = this.Path.Span;
             VisitForRemove(path, nodeToVisit, span, span[this.BeginTerminator..], ref result);
         }
 

--- a/Solutions/Corvus.Json.Patch/Corvus.Json.Patch/JsonPatchExtensions.ReplaceVisitor.cs
+++ b/Solutions/Corvus.Json.Patch/Corvus.Json.Patch/JsonPatchExtensions.ReplaceVisitor.cs
@@ -18,17 +18,29 @@ public static partial class JsonPatchExtensions
         public ReplaceVisitor(in JsonPatchDocument.ReplaceEntity patchOperation)
         {
             this.Value = patchOperation.Value;
-            this.Path = patchOperation.Path;
+            this.Path = ((string)patchOperation.Path).AsMemory();
+        }
+
+        public ReplaceVisitor(in JsonAny value, string path)
+        {
+            this.Value = value;
+            this.Path = path.AsMemory();
+        }
+
+        public ReplaceVisitor(in JsonAny value, ReadOnlyMemory<char> path)
+        {
+            this.Value = value;
+            this.Path = path;
         }
 
         public JsonAny Value { get; }
 
-        public string Path { get; }
+        public ReadOnlyMemory<char> Path { get; }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public void Visit(ReadOnlySpan<char> path, in JsonAny nodeToVisit, ref VisitResult result)
         {
-            VisitForReplace(path, nodeToVisit, this.Value, this.Path, ref result);
+            VisitForReplace(path, nodeToVisit, this.Value, this.Path.Span, ref result);
         }
 
         internal static void VisitForReplace(ReadOnlySpan<char> path, in JsonAny nodeToVisit, in JsonAny value, ReadOnlySpan<char> operationPath, ref VisitResult result)

--- a/Solutions/Corvus.Json.Patch/Corvus.Json.Patch/JsonValueExtensions.cs
+++ b/Solutions/Corvus.Json.Patch/Corvus.Json.Patch/JsonValueExtensions.cs
@@ -1,0 +1,113 @@
+﻿// <copyright file="JsonValueExtensions.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.Collections.Immutable;
+
+namespace Corvus.Json.Patch;
+
+/// <summary>
+/// Patch-related extensions to <see cref="IJsonValue"/>.
+/// </summary>
+public static class JsonValueExtensions
+{
+    private static readonly JsonAny EmptyObject = JsonAny.FromProperties(ImmutableDictionary<JsonPropertyName, JsonAny>.Empty);
+
+    /// <summary>
+    /// Sets a property on a JSON value, building any missing object property structure on the way.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue{T}"/> on which to set the deep property.</typeparam>
+    /// <typeparam name="TValue">The type of the <see cref="IJsonValue{T}"/> to set.</typeparam>
+    /// <param name="jsonValue">The <see cref="IJsonValue{T}"/> on which to set the deep property.</param>
+    /// <param name="path">The path at which to set the property.</param>
+    /// <param name="value">The value to set at that path.</param>
+    /// <param name="result">An instance of the value, with any additional object property structure built, and the appropriate value added or replaced.</param>
+    /// <returns><see langword="true"/> if the property could be set, otherwise <see langword="false"/>.</returns>
+    public static bool TrySetDeepProperty<T, TValue>(this T jsonValue, ReadOnlySpan<char> path, in TValue value, out T result)
+        where T : struct, IJsonValue<T>
+        where TValue : struct, IJsonValue<T>
+    {
+        if (path.Length == 0)
+        {
+            if (jsonValue.AsAny.TryReplace(path.ToString(), value.AsAny, out JsonAny patched))
+            {
+                result = patched.As<T>();
+                return true;
+            }
+            else
+            {
+                result = T.Undefined;
+                return false;
+            }
+        }
+
+        bool goingDeep = false;
+        int nextSlash;
+        int currentIndex = 0;
+
+        // To avoid constantly re-walking the tree, we stash the "last found" node,
+        // and trim the path as we go.
+        JsonAny currentNode = jsonValue.AsAny;
+        JsonAny currentResult = currentNode;
+
+        // Ignore a trailing slash
+        ReadOnlySpan<char> currentPath = (path[^1] == '/') ? path[..^1] : path;
+
+        while ((nextSlash = currentPath.IndexOf("/", StringComparison.Ordinal)) >= 0)
+        {
+            currentIndex += nextSlash;
+
+            if (!goingDeep && currentNode.TryResolvePointer(currentPath[..nextSlash], out currentNode))
+            {
+                currentPath = currentPath[(nextSlash + 1)..];
+                currentIndex++;
+            }
+            else
+            {
+                goingDeep = true;
+                if (!currentResult.TryAdd(
+                    path[..currentIndex].ToString(),
+                    EmptyObject,
+                    out currentResult))
+                {
+                    result = T.Undefined;
+                    return false;
+                }
+
+                currentPath = currentPath[(nextSlash + 1)..];
+                currentIndex++;
+            }
+        }
+
+        // We do not have a trailing slash (we dealt with that above) so there will always be
+        // something to do at the end to add or replace the final value.
+
+        // If we are not going deep, we may be replacing the element at the path
+        if (!goingDeep && jsonValue.TryResolvePointer(path, out _))
+        {
+            if (jsonValue.AsAny.TryReplace(path.ToString(), value.AsAny, out JsonAny patched))
+            {
+                result = patched.As<T>();
+                return true;
+            }
+            else
+            {
+                result = T.Undefined;
+                return false;
+            }
+        }
+        else
+        {
+            if (currentResult.TryAdd(path.ToString(), value.AsAny, out JsonAny patched))
+            {
+                result = patched.As<T>();
+                return true;
+            }
+            else
+            {
+                result = T.Undefined;
+                return false;
+            }
+        }
+    }
+}

--- a/Solutions/Corvus.Json.Patch/Corvus.Json.Patch/PatchBuilder.cs
+++ b/Solutions/Corvus.Json.Patch/Corvus.Json.Patch/PatchBuilder.cs
@@ -21,6 +21,11 @@ public readonly record struct PatchBuilder(JsonAny Value, JsonPatchDocument Patc
     /// <returns>An instance of a <see cref="PatchBuilder"/> with the updated value, and the operation added to the operation array.</returns>
     public PatchBuilder DeepAddOrReplaceObjectProperties(JsonAny value, ReadOnlySpan<char> path)
     {
+        if (path.Length == 0)
+        {
+            return this.Replace(value, path);
+        }
+
         bool goingDeep = false;
         int nextSlash;
         int currentIndex = 0;

--- a/Solutions/Corvus.Json.Patch/Corvus.Json.Patch/PatchBuilder.cs
+++ b/Solutions/Corvus.Json.Patch/Corvus.Json.Patch/PatchBuilder.cs
@@ -14,12 +14,12 @@ public readonly record struct PatchBuilder(JsonAny Value, JsonPatchDocument Patc
     private static readonly JsonObject EmptyObject = JsonObject.FromProperties(ImmutableDictionary<JsonPropertyName, JsonAny>.Empty);
 
     /// <summary>
-    /// Adds or replaces the value found at the given location, building any missing intermediate structure.
+    /// Adds or replaces the value found at the given location, building any missing intermediate structure as object properties.
     /// </summary>
     /// <param name="value">The value to add or replace at the <paramref name="path"/>.</param>
     /// <param name="path">The location at which to add or replace the <paramref name="value"/>.</param>
     /// <returns>An instance of a <see cref="PatchBuilder"/> with the updated value, and the operation added to the operation array.</returns>
-    public PatchBuilder DeepAddOrReplace(JsonAny value, ReadOnlySpan<char> path)
+    public PatchBuilder DeepAddOrReplaceObjectProperties(JsonAny value, ReadOnlySpan<char> path)
     {
         bool goingDeep = false;
         int nextSlash;
@@ -54,7 +54,10 @@ public readonly record struct PatchBuilder(JsonAny Value, JsonPatchDocument Patc
             }
         }
 
-        // If we are not going deep, it means we are replacing the element at the path
+        // We do not have a trailing slash (we dealt with that above) so there will always be
+        // something to do at the end to add or replace the final value.
+
+        // If we are not going deep, we may be replacing the element at the path
         if (!goingDeep && this.Value.TryResolvePointer(path, out _))
         {
             return currentBuilder.Replace(value, path);

--- a/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
+++ b/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
@@ -20,7 +20,7 @@
 	<ItemGroup>
 		<PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="2.0.1" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="7.0.0" />
-		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
+		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
 		<PackageReference Include="SolidToken.SpecFlow.DependencyInjection" Version="3.9.3" />
 		<PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
 

--- a/Solutions/Corvus.Json.Specs/Features/JsonPatch/DeepPatch.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonPatch/DeepPatch.feature
@@ -14,3 +14,18 @@ Examples:
 	| {"foo": 2}     | 3           | /bar/bash/bank | { "foo": 2, "bar": { "bash": {"bank": 3}} } |
 	| {"foo": [{}] } | 3           | /foo/0/bar     | { "foo": [ {"bar": 3} ] }                   |
 	| {"foo": [] }   | 3           | /foo/0/bar     | { "foo": [ {"bar": 3} ] }                   |
+
+Scenario Template: Set deep property
+	Given the document <document>
+	When I try to set a deep property on the JSON value <value> at the path <path>
+	Then the transformed document should equal <result>
+
+Examples:
+	| document       | value       | path           | result                                      |
+	| {}             | {"foo": 3 } |                | {"foo": 3 }                                 |
+	| {"foo": 2}     | 3           | /foo           | {"foo": 3 }                                 |
+	| {"foo": 2}     | 3           | /bar           | { "foo": 2, "bar": 3 }                      |
+	| {"foo": 2}     | 3           | /bar/baz       | { "foo": 2, "bar": { "baz": 3} }            |
+	| {"foo": 2}     | 3           | /bar/bash/bank | { "foo": 2, "bar": { "bash": {"bank": 3}} } |
+	| {"foo": [{}] } | 3           | /foo/0/bar     | { "foo": [ {"bar": 3} ] }                   |
+	| {"foo": [] }   | 3           | /foo/0/bar     | { "foo": [ {"bar": 3} ] }                   |

--- a/Solutions/Corvus.Json.Specs/Features/JsonPatch/DeepPatch.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonPatch/DeepPatch.feature
@@ -1,0 +1,16 @@
+Feature: Deep patching
+
+Scenario Template: Deep patch
+	Given the document <document>
+	When I deep patch the JSON value <value> at the path <path>
+	Then the transformed document should equal <result>
+
+Examples:
+	| document       | value       | path           | result                                      |
+	| {}             | {"foo": 3 } |                | {"foo": 3 }                                 |
+	| {"foo": 2}     | 3           | /foo           | {"foo": 3 }                                 |
+	| {"foo": 2}     | 3           | /bar           | { "foo": 2, "bar": 3 }                      |
+	| {"foo": 2}     | 3           | /bar/baz       | { "foo": 2, "bar": { "baz": 3} }            |
+	| {"foo": 2}     | 3           | /bar/bash/bank | { "foo": 2, "bar": { "bash": {"bank": 3}} } |
+	| {"foo": [{}] } | 3           | /foo/0/bar     | { "foo": [ {"bar": 3} ] }                   |
+	| {"foo": [] }   | 3           | /foo/0/bar     | { "foo": [ {"bar": 3} ] }                   |

--- a/Solutions/Corvus.Json.Specs/Steps/JsonPatchSteps.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/JsonPatchSteps.cs
@@ -53,6 +53,24 @@ public class JsonPatchSteps
         this.scenarioContext.Set(JsonAny.Parse(jsonString).As<JsonPatchDocument>(), PatchKey);
     }
 
+    [When("I deep patch the JSON value (.*) at the path (.*)")]
+    public void WhenIDeepPatchTheJSONValueAtThePath(string serializedValue, string path)
+    {
+        try
+        {
+            var value = JsonAny.ParseValue(serializedValue);
+            JsonAny document = this.scenarioContext.Get<JsonAny>(DocumentKey);
+            PatchBuilder builder = document.BeginPatch().DeepAddOrReplaceObjectProperties(value, path);
+            this.scenarioContext.Set(builder, BuilderKey);
+            this.scenarioContext.Set(builder.PatchOperations, PatchKey);
+            this.scenarioContext.Set(builder.Value, OutputKey);
+        }
+        catch (Exception ex)
+        {
+            this.scenarioContext.Set(ex, ExceptionKey);
+        }
+    }
+
     /// <summary>
     /// Parses the <paramref name="jsonString"/> and uses it to create a <see cref="PatchBuilder"/> for those operations. The result
     /// is stored in the context key <see cref="BuilderKey"/>. If the build fails, the exception is stored in the <see cref="ExceptionKey"/>.

--- a/Solutions/Corvus.Json.Specs/Steps/JsonPatchSteps.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/JsonPatchSteps.cs
@@ -71,6 +71,24 @@ public class JsonPatchSteps
         }
     }
 
+    [When("I try to set a deep property on the JSON value (.*) at the path (.*)")]
+    public void WhenITryToSetADeepPropertyOnTheJSONValueAtThePath(string serializedValue, string path)
+    {
+        try
+        {
+            var value = JsonAny.ParseValue(serializedValue);
+            JsonAny document = this.scenarioContext.Get<JsonAny>(DocumentKey);
+            if (document.TrySetDeepProperty(path, value, out JsonAny result))
+            {
+                this.scenarioContext.Set(result, OutputKey);
+            }
+        }
+        catch (Exception ex)
+        {
+            this.scenarioContext.Set(ex, ExceptionKey);
+        }
+    }
+
     /// <summary>
     /// Parses the <paramref name="jsonString"/> and uses it to create a <see cref="PatchBuilder"/> for those operations. The result
     /// is stored in the context key <see cref="BuilderKey"/>. If the build fails, the exception is stored in the <see cref="ExceptionKey"/>.

--- a/Solutions/Corvus.Json.Specs/packages.lock.json
+++ b/Solutions/Corvus.Json.Specs/packages.lock.json
@@ -67,12 +67,12 @@
       },
       "Microsoft.NET.Test.Sdk": {
         "type": "Direct",
-        "requested": "[17.6.2, )",
-        "resolved": "17.6.2",
-        "contentHash": "+WFxuoFVBG0aewD9Psw+1I90kaRToQgMIzK20xNVRO4QRWR9Bou3qGefrZvMZ/xTC+6bAmZppFbpPbiHDzrPyg==",
+        "requested": "[17.6.3, )",
+        "resolved": "17.6.3",
+        "contentHash": "MglaNTl646dC2xpHKotSk1xscmHO5uV3x3NK057IUA9BM3Wgl16WMEb9ptGczk518JfLd1+Th5OAYwnoWgHQQQ==",
         "dependencies": {
-          "Microsoft.CodeCoverage": "17.6.2",
-          "Microsoft.TestPlatform.TestHost": "17.6.2"
+          "Microsoft.CodeCoverage": "17.6.3",
+          "Microsoft.TestPlatform.TestHost": "17.6.3"
         }
       },
       "NUnit": {
@@ -233,8 +233,8 @@
       },
       "Microsoft.CodeCoverage": {
         "type": "Transitive",
-        "resolved": "17.6.2",
-        "contentHash": "t+DjPlq7GIxIkOK/jiTmNeiEMVkfVCynBEZyV+IMg2ro43NugKExng+7a04R1fBLi+d6voxjeDxL2ozdl+XyVg=="
+        "resolved": "17.6.3",
+        "contentHash": "Gorg6F1dOxlI28yHYKhbQ3pOOfHeW6sUfsmwFQFaIV+xttUAZ+l8KarHIfsR+rBAnjY9VH71BXvPXBuObCkXsw=="
       },
       "Microsoft.DotNet.PlatformAbstractions": {
         "type": "Transitive",
@@ -357,8 +357,8 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "7.0.7",
-        "contentHash": "pKyzYIhXug0Eom/F17SWIGf2aDB2N+A//aW+LJXP8/ZWrI3mXpxgf6SLNSu3gwakU3rZx+Xrsb6PT5MiB6QDvQ=="
+        "resolved": "7.0.8",
+        "contentHash": "aaNEWSL4d9Qhl5UXlBySXfgHvzIrR4sc6dScCDFfIcCw2uH4d5WuWy+KOnIRPumqj5YuP6J0ejkUTsipvm+xCQ=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -400,8 +400,8 @@
       },
       "Microsoft.TestPlatform.ObjectModel": {
         "type": "Transitive",
-        "resolved": "17.6.2",
-        "contentHash": "I3S/oELDAe/ckFltBnPb0PV+gADbpc8n0yGTtYfTd7q1hd0cAZKn/FrYoegA/rGws8fEFyJD/2PB6uq+nIjWsg==",
+        "resolved": "17.6.3",
+        "contentHash": "gSqtX3RvcFisaLPs6sKXdZkSwUix83NQ9nOU/w6pYrHTl+d8GsVHSL9rvDNxMgoV5BNOdyU7zK7JOfbSaVMDWQ==",
         "dependencies": {
           "NuGet.Frameworks": "6.5.0",
           "System.Reflection.Metadata": "1.6.0"
@@ -409,10 +409,10 @@
       },
       "Microsoft.TestPlatform.TestHost": {
         "type": "Transitive",
-        "resolved": "17.6.2",
-        "contentHash": "WszrF1CoG+Y2bA4WJFxlaPADQCWUuNP6TCxVRuScmP6DQsNvDDuOO9XiUxCA+wPmNOSyWVh9EGrPu7JoUpf2gA==",
+        "resolved": "17.6.3",
+        "contentHash": "lrgRXKFfIZSPlhuoQGLtciO/osL+4oADYEYb0d5or7n7YyJATIWespq3lRgz2IQpRh6N7cm0DnCOWeZiCRGzxA==",
         "dependencies": {
-          "Microsoft.TestPlatform.ObjectModel": "17.6.2",
+          "Microsoft.TestPlatform.ObjectModel": "17.6.3",
           "Newtonsoft.Json": "13.0.1"
         }
       },
@@ -1378,7 +1378,7 @@
           "Corvus.Extensions": "[1.1.11, )",
           "Corvus.UriTemplates": "[1.2.1, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.8, )",
           "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
@@ -1391,7 +1391,7 @@
           "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.ExtendedTypes": "[1.0.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.8, )",
           "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
@@ -1404,7 +1404,7 @@
           "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.ExtendedTypes": "[1.0.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.8, )",
           "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",

--- a/Solutions/Corvus.Json.Specs/packages.lock.json
+++ b/Solutions/Corvus.Json.Specs/packages.lock.json
@@ -182,8 +182,8 @@
       },
       "Corvus.UriTemplates": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "Mt8dz6chvHNaVrOSrMQJPqk4EMBMA74R/LsYgq+fy5H1om88INKXHrcRaRSBMesJlmbugAowaQ7vTlNLbbn9vw==",
+        "resolved": "1.2.1",
+        "contentHash": "lDWJkAmoBDvYJER+xeDj3wY0m4jnql+KfCrre5k8212vMrDVKyeMjPPAfQJs7D5Bq1l7jqM4QFK6FB0Cr9Qv7Q==",
         "dependencies": {
           "CommunityToolkit.HighPerformance": "8.2.0",
           "Microsoft.Extensions.ObjectPool": "7.0.5",
@@ -1376,7 +1376,7 @@
         "dependencies": {
           "CommunityToolkit.HighPerformance": "[8.2.0, )",
           "Corvus.Extensions": "[1.1.11, )",
-          "Corvus.UriTemplates": "[1.2.0, )",
+          "Corvus.UriTemplates": "[1.2.1, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
           "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
           "NodaTime": "[3.1.9, )",

--- a/Solutions/Corvus.JsonPatch.Benchmarking/packages.lock.json
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/packages.lock.json
@@ -102,8 +102,8 @@
       },
       "Corvus.UriTemplates": {
         "type": "Transitive",
-        "resolved": "1.2.0",
-        "contentHash": "Mt8dz6chvHNaVrOSrMQJPqk4EMBMA74R/LsYgq+fy5H1om88INKXHrcRaRSBMesJlmbugAowaQ7vTlNLbbn9vw==",
+        "resolved": "1.2.1",
+        "contentHash": "lDWJkAmoBDvYJER+xeDj3wY0m4jnql+KfCrre5k8212vMrDVKyeMjPPAfQJs7D5Bq1l7jqM4QFK6FB0Cr9Qv7Q==",
         "dependencies": {
           "CommunityToolkit.HighPerformance": "8.2.0",
           "Microsoft.Extensions.ObjectPool": "7.0.5",
@@ -440,7 +440,7 @@
         "dependencies": {
           "CommunityToolkit.HighPerformance": "[8.2.0, )",
           "Corvus.Extensions": "[1.1.11, )",
-          "Corvus.UriTemplates": "[1.2.0, )",
+          "Corvus.UriTemplates": "[1.2.1, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
           "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
           "NodaTime": "[3.1.9, )",

--- a/Solutions/Corvus.JsonPatch.Benchmarking/packages.lock.json
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/packages.lock.json
@@ -308,8 +308,8 @@
       },
       "Microsoft.Extensions.ObjectPool": {
         "type": "Transitive",
-        "resolved": "7.0.7",
-        "contentHash": "pKyzYIhXug0Eom/F17SWIGf2aDB2N+A//aW+LJXP8/ZWrI3mXpxgf6SLNSu3gwakU3rZx+Xrsb6PT5MiB6QDvQ=="
+        "resolved": "7.0.8",
+        "contentHash": "aaNEWSL4d9Qhl5UXlBySXfgHvzIrR4sc6dScCDFfIcCw2uH4d5WuWy+KOnIRPumqj5YuP6J0ejkUTsipvm+xCQ=="
       },
       "Microsoft.Extensions.Options": {
         "type": "Transitive",
@@ -442,7 +442,7 @@
           "Corvus.Extensions": "[1.1.11, )",
           "Corvus.UriTemplates": "[1.2.1, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.8, )",
           "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",
@@ -455,7 +455,7 @@
           "Corvus.Extensions": "[1.1.11, )",
           "Corvus.Json.ExtendedTypes": "[1.0.0, )",
           "Microsoft.Extensions.Http": "[7.0.0, )",
-          "Microsoft.Extensions.ObjectPool": "[7.0.7, )",
+          "Microsoft.Extensions.ObjectPool": "[7.0.8, )",
           "NodaTime": "[3.1.9, )",
           "System.Buffers": "[4.5.1, )",
           "System.Collections.Immutable": "[7.0.0, )",

--- a/Solutions/Sandbox/Program.cs
+++ b/Solutions/Sandbox/Program.cs
@@ -1,28 +1,6 @@
 ﻿using Corvus.Json;
-using Corvus.Json.Benchmarking.Models;
-using Corvus.Json.UriTemplates;
-using NodaTime;
+using Corvus.Json.Patch;
 
-string uriTemplate = "http://example.org/location{?value*}";
-JsonAny jsonValues = JsonAny.FromProperties(("foo", "bar"), ("bar", "baz"), ("baz", "bob")).AsJsonElementBackedValue();
-ReadOnlySpan<char> span = uriTemplate.AsSpan();
-
-for (int i = 0; i < 10000; i++)
-{
-    object? nullState = default;
-    JsonUriTemplateResolver.TryResolveResult(span, false, jsonValues, HandleResult, ref nullState);
-}
-
-static void HandleResult(ReadOnlySpan<char> resolvedTemplate, ref object? state)
-{
-    // NOP
-}
-
-var p =
-    Person.Create(
-        name: PersonName.Create("Adams", "Matthew"),
-        dateOfBirth: new LocalDate(1973, 02, 14));
-
-JsonNumber first = new(3);
-JsonInteger second = new(long.MaxValue);
-Console.WriteLine((JsonInteger)first < second);
+var value = JsonObject.FromProperties(("foo", "hello"), ("bar", "world"));
+PatchBuilder builder = value.BeginPatch().DeepAddOrReplace(3, "/baz/bat/bash");
+Console.WriteLine(builder.Value.ToString());

--- a/Solutions/Sandbox/Program.cs
+++ b/Solutions/Sandbox/Program.cs
@@ -2,5 +2,5 @@
 using Corvus.Json.Patch;
 
 var value = JsonObject.FromProperties(("foo", "hello"), ("bar", "world"));
-PatchBuilder builder = value.BeginPatch().DeepAddOrReplace(3, "/baz/bat/bash");
+PatchBuilder builder = value.BeginPatch().DeepAddOrReplaceObjectProperties(3, "/baz/bat/bash");
 Console.WriteLine(builder.Value.ToString());


### PR DESCRIPTION
- Added the ability to set a deep property (by scaffolding the missing objects and hteir properties) using Corvus.Json.Patch
- Added overloads to direct-apply Patch operations to a root node without collecting the patch document (but ensuring the semantics remain the same.
- Added specs for the above