### PR TITLE
fix: use the fragment as pointer when resolving a sub schema as the c…

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.References.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.References.cs
@@ -447,7 +447,7 @@ public partial class JsonSchemaTypeBuilder
 
         if (failed)
         {
-            string pointer = currentBuilder.ToString();
+            string pointer = fragment.ToString();
             if (JsonPointerUtilities.TryResolvePointer(rootElement, pointer, out JsonElement? resolvedElement))
             {
                 var pointerRef = new JsonReference(pointer);


### PR DESCRIPTION
…urrent builder doesn't contain a pointer

The current builder in this scope contains an un-escaped url which might not be a proper json pointer, for example when using a uri as a json key. This problem probably spans further than this piece of code.

I don't really know how to test this, as no tests test this code explicitly, but there are test coverage covering these changes, but they don't test this specific scenario.

I found this issue using a json document that contains json schemas (like OpenAPI). One of the schemas point to a schema that is relative to the json document, not the schema, hence why it's not registered at this point. That pointer has a segment that is a url, which cannot be resolved as the currentbuilder is not a proper json pointer (each segment has already been decoded).
I.e.: 
```
{
  "foo": {
    "/this/is/a/url/property/name/": {
    ....
    }
  }
}
```
Which is referenced as `/foo/~1this~1is~1a~1url~1property~1name~1/`
CurrentBuilder will contain something like `/foo//this/is/a/url/property/name//`