### PR TITLE
Fixed bug #238: support encoded paths with references to arbitrary keywords.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/JsonSchemaBuilder.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/JsonSchemaBuilder.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Text;
+using System.Text.Json;
 using Corvus.Json.CodeGeneration.Generators.Draft201909;
 
 namespace Corvus.Json.CodeGeneration.Draft201909;
@@ -22,6 +23,12 @@ public class JsonSchemaBuilder : IJsonSchemaBuilder
     public JsonSchemaBuilder(JsonSchemaTypeBuilder typeBuilder)
     {
         this.typeBuilder = typeBuilder.UseDraft201909();
+    }
+
+    /// <inheritdoc/>
+    public void AddDocument(string path, JsonDocument jsonDocument)
+    {
+        this.typeBuilder.AddDocument(path, jsonDocument);
     }
 
     /// <inheritdoc/>

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/JsonSchemaBuilder.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/JsonSchemaBuilder.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Text;
+using System.Text.Json;
 using Corvus.Json.CodeGeneration.Generators.Draft202012;
 
 namespace Corvus.Json.CodeGeneration.Draft202012;
@@ -22,6 +23,12 @@ public class JsonSchemaBuilder : IJsonSchemaBuilder
     public JsonSchemaBuilder(JsonSchemaTypeBuilder typeBuilder)
     {
         this.typeBuilder = typeBuilder.UseDraft202012();
+    }
+
+    /// <inheritdoc/>
+    public void AddDocument(string path, JsonDocument jsonDocument)
+    {
+        this.typeBuilder.AddDocument(path, jsonDocument);
     }
 
     /// <inheritdoc/>

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/JsonSchemaBuilder.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/JsonSchemaBuilder.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Text;
+using System.Text.Json;
 using Corvus.Json.CodeGeneration.Generators.Draft6;
 
 namespace Corvus.Json.CodeGeneration.Draft6;
@@ -22,6 +23,12 @@ public class JsonSchemaBuilder : IJsonSchemaBuilder
     public JsonSchemaBuilder(JsonSchemaTypeBuilder typeBuilder)
     {
         this.typeBuilder = typeBuilder.UseDraft6();
+    }
+
+    /// <inheritdoc/>
+    public void AddDocument(string path, JsonDocument jsonDocument)
+    {
+        this.typeBuilder.AddDocument(path, jsonDocument);
     }
 
     /// <inheritdoc/>

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/JsonSchemaBuilder.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/JsonSchemaBuilder.cs
@@ -4,6 +4,7 @@
 
 using System.Collections.Immutable;
 using System.Text;
+using System.Text.Json;
 using Corvus.Json.CodeGeneration.Generators.Draft7;
 
 namespace Corvus.Json.CodeGeneration.Draft7;
@@ -22,6 +23,12 @@ public class JsonSchemaBuilder : IJsonSchemaBuilder
     public JsonSchemaBuilder(JsonSchemaTypeBuilder typeBuilder)
     {
         this.typeBuilder = typeBuilder.UseDraft7();
+    }
+
+    /// <inheritdoc/>
+    public void AddDocument(string path, JsonDocument jsonDocument)
+    {
+        this.typeBuilder.AddDocument(path, jsonDocument);
     }
 
     /// <inheritdoc/>

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/IJsonSchemaBuilder.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/IJsonSchemaBuilder.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Collections.Immutable;
+using System.Text.Json;
 
 namespace Corvus.Json.CodeGeneration;
 
@@ -11,6 +12,13 @@ namespace Corvus.Json.CodeGeneration;
 /// </summary>
 public interface IJsonSchemaBuilder
 {
+    /// <summary>
+    /// Adds a virtual document to the document resolver for this builder.
+    /// </summary>
+    /// <param name="path">The virtual path to the document.</param>
+    /// <param name="jsonDocument">The document to add.</param>
+    void AddDocument(string path, JsonDocument jsonDocument);
+
     /// <summary>
     /// Builds types for the schema provided by the given reference.
     /// </summary>

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaRegistry.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaRegistry.cs
@@ -43,19 +43,9 @@ internal class JsonSchemaRegistry
     /// <remarks><paramref name="jsonSchemaPath"/> must point to a root scope. If it has a pointer into the document, then <paramref name="rebaseAsRoot"/> must be true.</remarks>
     public async Task<JsonReference> RegisterDocumentSchema(JsonReference jsonSchemaPath, bool rebaseAsRoot = false)
     {
-        var uri = new JsonUri(jsonSchemaPath);
-        if (!uri.IsValid() || uri.GetUri().IsFile)
+        if (SchemaReferenceNormalization.TryNormalizeSchemaReference(jsonSchemaPath, out string? result))
         {
-            string schemaFile = jsonSchemaPath;
-
-            // If this is, in fact, a local file path, not a uri, then convert to a fullpath and URI-style separators.
-            if (!Path.IsPathFullyQualified(schemaFile))
-            {
-                schemaFile = Path.GetFullPath(schemaFile);
-            }
-
-            schemaFile = schemaFile.Replace('\\', '/');
-            jsonSchemaPath = new JsonReference(schemaFile);
+            jsonSchemaPath = new(result);
         }
 
         JsonReference basePath = jsonSchemaPath.WithFragment(string.Empty);

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.ReduceTypes.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.ReduceTypes.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Diagnostics.CodeAnalysis;
+using System.Text.Json;
 
 namespace Corvus.Json.CodeGeneration;
 

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.References.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.References.cs
@@ -447,10 +447,9 @@ public partial class JsonSchemaTypeBuilder
 
         if (failed)
         {
-            string pointer = currentBuilder.ToString();
-            if (JsonPointerUtilities.TryResolvePointer(rootElement, pointer, out JsonElement? resolvedElement))
+            if (JsonPointerUtilities.TryResolvePointer(rootElement, fragment, out JsonElement? resolvedElement))
             {
-                var pointerRef = new JsonReference(pointer);
+                var pointerRef = new JsonReference(ReadOnlySpan<char>.Empty, fragment);
                 JsonReference location = baseSchemaForReferenceLocation.Apply(pointerRef);
                 this.schemaRegistry.AddSchemaAndSubschema(location, JsonAny.FromJson(resolvedElement.Value));
                 result = (baseSchemaForReferenceLocation, pointerRef);

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.cs
@@ -127,6 +127,16 @@ public partial class JsonSchemaTypeBuilder
     }
 
     /// <summary>
+    /// Adds a virtual document to the document resolver.
+    /// </summary>
+    /// <param name="path">The virtual path.</param>
+    /// <param name="jsonDocument">The document to add.</param>
+    public void AddDocument(string path, JsonDocument jsonDocument)
+    {
+        this.documentResolver.AddDocument(path, jsonDocument);
+    }
+
+    /// <summary>
     /// Replaces a located type declaration.
     /// </summary>
     /// <param name="location">The location for the replacement.</param>

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/SchemaReferenceNormalization.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/SchemaReferenceNormalization.cs
@@ -1,0 +1,38 @@
+﻿// <copyright file="SchemaReferenceNormalization.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+
+namespace Corvus.Json.CodeGeneration;
+
+/// <summary>
+/// Helpers for reference normalization.
+/// </summary>
+public static class SchemaReferenceNormalization
+{
+    /// <summary>
+    /// Attempts to normalize the form of a reference to a schema file.
+    /// </summary>
+    /// <param name="schemaFile">The schema file reference.</param>
+    /// <param name="result">The result of the operation.</param>
+    /// <returns><see langword="true"/> if the result required normalization, otherwise false.</returns>
+    public static bool TryNormalizeSchemaReference(string schemaFile, [NotNullWhen(true)] out string? result)
+    {
+        JsonUri uri = new(schemaFile);
+        if (!uri.IsValid() || uri.GetUri().IsFile)
+        {
+            // If this is, in fact, a local file path, not a uri, then convert to a fullpath and URI-style separators.
+            if (!Path.IsPathFullyQualified(schemaFile))
+            {
+                schemaFile = Path.GetFullPath(schemaFile);
+            }
+
+            result = schemaFile.Replace('\\', '/');
+            return true;
+        }
+
+        result = null;
+        return false;
+    }
+}

--- a/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
+++ b/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 	<Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
 	<PropertyGroup>
@@ -67,20 +67,6 @@
 
 	<ItemGroup>
 	  <PackageReference Update="Roslynator.Analyzers" Version="4.4.0" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <Folder Include="Features\JsonModel\JsonStringTryGetValue\" />
-	  <Folder Include="Features\JsonModel\JsonStringConcatenate\" />
-	  <Folder Include="Features\JsonModel\ParseValue\" />
-	  <Folder Include="Features\JsonSchema\Draft6\" />
-	</ItemGroup>
-
-	<ItemGroup>
-	  <SpecFlowFeatureFiles Update="Features\JsonModel\NumericComparison\JsonIntegerComparison.feature">
-	    <Visible>$(UsingMicrosoftNETSdk)</Visible>
-	    <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
-	  </SpecFlowFeatureFiles>
 	</ItemGroup>
 
 </Project>

--- a/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft201909/refOfUnknownKeyword.feature
+++ b/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft201909/refOfUnknownKeyword.feature
@@ -1,0 +1,25 @@
+@draft2019-09
+
+Feature: Path-like unknown keyword draft2019-09
+
+Scenario Outline: reference of an arbitrary keyword of a sub-schema
+	Given a schema file
+	"""
+	{
+		"$schema": "https://json-schema.org/draft/2019-09/schema",
+		"properties": {
+			"foo": {"path/like/keyword": {"type": "integer"}},
+			"bar": {"$ref": "#/properties/foo/path~1like~1keyword"}
+		}
+	}
+	"""
+	And the input data value <inputData>
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance
+	Then the result will be <valid>
+
+Examples:
+	| inputData        | valid |
+	| {"bar": 3}       | true  |
+	| {"bar": "hello"} | false |

--- a/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft202012/refOfUnknownKeyword.feature
+++ b/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft202012/refOfUnknownKeyword.feature
@@ -1,0 +1,25 @@
+@draft2020-12
+
+Feature: Path-like unknown keyword draft2020-12
+
+Scenario Outline: reference of an arbitrary keyword of a sub-schema
+	Given a schema file
+	"""
+	{
+		"$schema": "https://json-schema.org/draft/2020-12/schema",
+		"properties": {
+			"foo": {"path/like/keyword": {"type": "integer"}},
+			"bar": {"$ref": "#/properties/foo/path~1like~1keyword"}
+		}
+	}
+	"""
+	And the input data value <inputData>
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance
+	Then the result will be <valid>
+
+Examples:
+	| inputData        | valid |
+	| {"bar": 3}       | true  |
+	| {"bar": "hello"} | false |

--- a/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft6/refOfUnknownKeyword.feature
+++ b/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft6/refOfUnknownKeyword.feature
@@ -1,0 +1,24 @@
+@draft6
+
+Feature: Path-like unknown keyword draft6
+
+Scenario Outline: reference of an arbitrary keyword of a sub-schema
+	Given a schema file
+		"""
+		{
+			"properties": {
+				"foo": {"path/like/keyword": {"type": "integer"}},
+				"bar": {"$ref": "#/properties/foo/path~1like~1keyword"}
+			}
+		}
+		"""
+	And the input data value <inputData>
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance
+	Then the result will be <valid>
+
+Examples:
+	| inputData        | valid |
+	| {"bar": 3}       | true  |
+	| {"bar": "hello"} | false |

--- a/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft7/refOfUnknownKeyword.feature
+++ b/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft7/refOfUnknownKeyword.feature
@@ -1,0 +1,24 @@
+@draft7
+
+Feature: Path-like unknown keyword draft7
+
+Scenario Outline: reference of an arbitrary keyword of a sub-schema
+	Given a schema file
+		"""
+		{
+			"properties": {
+				"foo": {"path/like/keyword": {"type": "integer"}},
+				"bar": {"$ref": "#/properties/foo/path~1like~1keyword"}
+			}
+		}
+		"""
+	And the input data value <inputData>
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance
+	Then the result will be <valid>
+
+Examples:
+	| inputData        | valid |
+	| {"bar": 3}       | true  |
+	| {"bar": "hello"} | false |


### PR DESCRIPTION
Added specs involving a reference that requires encoding
Added support to the driver for generating code from inline schemas
Added support to the typebuilder (and related types) to allow the user to add virtual documents to the builder.