### PR TITLE
Sort array-based ref-resolvable schema by array order.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/JsonSchemaHelpers.Draft201909.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/JsonSchemaHelpers.Draft201909.cs
@@ -399,7 +399,7 @@ public static class JsonSchemaHelpers
 
             if (schema.AllOf.IsNotUndefined())
             {
-                foreach (TypeDeclaration allOfTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/allOf")).Select(k => k.Value))
+                foreach (TypeDeclaration allOfTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/allOf")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
                     builder.FindAndBuildProperties(allOfTypeDeclaration, target, typesVisited, treatRequiredAsOptional);
                 }
@@ -417,7 +417,7 @@ public static class JsonSchemaHelpers
 
             if (schema.DependentSchemas.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependentSchemas")).Select(k => k.Value))
+                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependentSchemas")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
                     builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
                 }
@@ -425,7 +425,7 @@ public static class JsonSchemaHelpers
 
             if (schema.Dependencies.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).Select(k => k.Value))
+                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
                     builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
                 }

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/JsonSchemaHelpers.Draft201909.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/JsonSchemaHelpers.Draft201909.cs
@@ -325,7 +325,7 @@ public static class JsonSchemaHelpers
     }
 
     /// <summary>
-    /// Creates the predicate that determiens whether this schema represents a simple type.
+    /// Creates the predicate that determines whether this schema represents a simple type.
     /// </summary>
     /// <returns>A predicate that returns <see langword="true"/> if the schema is a simple type.</returns>
     private static Predicate<JsonAny> CreateDraft201909IsSimpleType()
@@ -417,17 +417,17 @@ public static class JsonSchemaHelpers
 
             if (schema.DependentSchemas.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependentSchemas")).OrderBy(k => k.Key).Select(k => k.Value))
+                foreach (TypeDeclaration dependentTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependentSchemas")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
-                    builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
+                    builder.FindAndBuildProperties(dependentTypeDeclaration, target, typesVisited, true);
                 }
             }
 
             if (schema.Dependencies.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
+                foreach (TypeDeclaration dependentTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
-                    builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
+                    builder.FindAndBuildProperties(dependentTypeDeclaration, target, typesVisited, true);
                 }
             }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/JsonSchemaHelpers.Draft202012.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/JsonSchemaHelpers.Draft202012.cs
@@ -310,7 +310,7 @@ public static class JsonSchemaHelpers
     }
 
     /// <summary>
-    /// Creates the predicate that determiens whether this Schema() represents a simple type.
+    /// Creates the predicate that determines whether this Schema() represents a simple type.
     /// </summary>
     /// <returns><see langword="true"/> if the Schema() is a simple type.</returns>
     private static Predicate<JsonAny> CreateDraft202012IsSimpleType()
@@ -402,17 +402,17 @@ public static class JsonSchemaHelpers
 
             if (schema.DependentSchemas.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependentSchemas")).OrderBy(k => k.Key).Select(k => k.Value))
+                foreach (TypeDeclaration dependentTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependentSchemas")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
-                    builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
+                    builder.FindAndBuildProperties(dependentTypeDeclaration, target, typesVisited, true);
                 }
             }
 
             if (schema.Dependencies.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
+                foreach (TypeDeclaration dependentTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
-                    builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
+                    builder.FindAndBuildProperties(dependentTypeDeclaration, target, typesVisited, true);
                 }
             }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/JsonSchemaHelpers.Draft202012.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/JsonSchemaHelpers.Draft202012.cs
@@ -384,7 +384,7 @@ public static class JsonSchemaHelpers
 
             if (schema.AllOf.IsNotUndefined())
             {
-                foreach (TypeDeclaration allOfTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/allOf")).Select(k => k.Value))
+                foreach (TypeDeclaration allOfTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/allOf")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
                     builder.FindAndBuildProperties(allOfTypeDeclaration, target, typesVisited, treatRequiredAsOptional);
                 }
@@ -402,7 +402,7 @@ public static class JsonSchemaHelpers
 
             if (schema.DependentSchemas.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependentSchemas")).Select(k => k.Value))
+                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependentSchemas")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
                     builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
                 }
@@ -410,7 +410,7 @@ public static class JsonSchemaHelpers
 
             if (schema.Dependencies.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).Select(k => k.Value))
+                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
                     builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
                 }

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/JsonSchemaHelpers.Draft6.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/JsonSchemaHelpers.Draft6.cs
@@ -348,7 +348,7 @@ public static class JsonSchemaHelpers
 
             if (schema.AllOf.IsNotUndefined())
             {
-                foreach (TypeDeclaration allOfTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/allOf")).Select(k => k.Value))
+                foreach (TypeDeclaration allOfTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/allOf")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
                     builder.FindAndBuildProperties(allOfTypeDeclaration, target, typesVisited, treatRequiredAsOptional);
                 }
@@ -356,7 +356,7 @@ public static class JsonSchemaHelpers
 
             if (schema.Dependencies.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).Select(k => k.Value))
+                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
                     builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
                 }

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/JsonSchemaHelpers.Draft6.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/JsonSchemaHelpers.Draft6.cs
@@ -274,7 +274,7 @@ public static class JsonSchemaHelpers
     }
 
     /// <summary>
-    /// Creates the predicate that determiens whether this schema represents a simple type.
+    /// Creates the predicate that determines whether this schema represents a simple type.
     /// </summary>
     /// <returns><see langword="true"/> if the schema is a simple type.</returns>
     private static Predicate<JsonAny> CreateDraft6IsSimpleType()
@@ -356,9 +356,9 @@ public static class JsonSchemaHelpers
 
             if (schema.Dependencies.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
+                foreach (TypeDeclaration dependentTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
-                    builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
+                    builder.FindAndBuildProperties(dependentTypeDeclaration, target, typesVisited, true);
                 }
             }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/JsonSchemaHelpers.Draft7.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/JsonSchemaHelpers.Draft7.cs
@@ -351,7 +351,7 @@ public static class JsonSchemaHelpers
 
             if (schema.AllOf.IsNotUndefined())
             {
-                foreach (TypeDeclaration allOfTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/allOf")).Select(k => k.Value))
+                foreach (TypeDeclaration allOfTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/allOf")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
                     builder.FindAndBuildProperties(allOfTypeDeclaration, target, typesVisited, treatRequiredAsOptional);
                 }
@@ -369,7 +369,7 @@ public static class JsonSchemaHelpers
 
             if (schema.Dependencies.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).Select(k => k.Value))
+                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
                     builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
                 }

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/JsonSchemaHelpers.Draft7.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/JsonSchemaHelpers.Draft7.cs
@@ -277,7 +277,7 @@ public static class JsonSchemaHelpers
     }
 
     /// <summary>
-    /// Creates the predicate that determiens whether this schema represents a simple type.
+    /// Creates the predicate that determines whether this schema represents a simple type.
     /// </summary>
     /// <returns><see langword="true"/> if the schema is a simple type.</returns>
     private static Predicate<JsonAny> CreateDraft7IsSimpleType()
@@ -369,9 +369,9 @@ public static class JsonSchemaHelpers
 
             if (schema.Dependencies.IsNotUndefined())
             {
-                foreach (TypeDeclaration dependentypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
+                foreach (TypeDeclaration dependentTypeDeclaration in source.RefResolvablePropertyDeclarations.Where(k => k.Key.StartsWith("#/dependencies")).OrderBy(k => k.Key).Select(k => k.Value))
                 {
-                    builder.FindAndBuildProperties(dependentypeDeclaration, target, typesVisited, true);
+                    builder.FindAndBuildProperties(dependentTypeDeclaration, target, typesVisited, true);
                 }
             }
 


### PR DESCRIPTION
- Stabilise the ordering of the property generation for `allOf`, `dependencies` and `dependentSchemas`.
- Fix spelling typos