### PR TITLE
Fixed the documentation in the generated enum.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Enum.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Enum.cs
@@ -16,7 +16,7 @@ namespace Corvus.Json.CodeGeneration.Generators.Draft201909 {
     public partial class CodeGeneratorEnum : CodeGeneratorEnumBase {
         
         
-        #line 129 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+        #line 105 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
 
     public bool ShouldGenerate
     {
@@ -121,111 +121,109 @@ namespace ");
             #line hidden
             
             #line 43 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// ");
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
             #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".\r\n        /// </summary>\r\n        /// <remarks>\r\n        /// {Description}.\r\n   " +
-                    "     /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(");\r\n        /// <summary>\r\n        /// Gets the ");
-            
-            #line default
-            #line hidden
-            
-            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" as a raw UTF8 string.\r\n        /// </summary>\r\n        /// <remarks>\r\n        //" +
-                    "/ {Description}.\r\n        /// </remarks>\r\n        public static ReadOnlySpan<byt" +
-                    "e> ");
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("Utf8 => ");
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
             
             #line default
             #line hidden
             
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(");\r\n        /// <summary>\r\n        /// Gets ");
+            
+            #line default
+            #line hidden
+            
+            #line 48 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 48 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a UTF8 string.\r\n        /// </summary>\r\n        public static ReadOnlySpan<by" +
+                    "te> ");
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("Utf8 => ");
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write("u8;\r\n");
             
             #line default
             #line hidden
             
-            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsBoolean)
         { 
@@ -233,74 +231,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 60 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 54 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 55 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 55 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 67 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 58 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsNumber)
         { 
@@ -308,74 +305,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 70 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 62 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 62 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 77 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 65 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsObject)
         { 
@@ -383,74 +379,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 80 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 68 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 81 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 81 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 69 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 69 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 87 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 72 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsArray)
         { 
@@ -458,74 +453,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 90 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 75 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 91 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 91 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 97 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 79 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsNull)
         { 
@@ -533,62 +527,50 @@ namespace ");
             #line default
             #line hidden
             
-            #line 100 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 82 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets \"null\" as a JSON value.\r\n        /// </su" +
+                    "mmary>\r\n        public static readonly ");
             
             #line default
             #line hidden
             
-            #line 101 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 101 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" Item");
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" = ");
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(".Parse(\"null\");\r\n");
             
             #line default
             #line hidden
             
-            #line 107 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         ++enumItemIndex;
     }
@@ -602,75 +584,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 116 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 95 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 117 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
             
             #line default
             #line hidden
             
-            #line 117 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        internal static readonly" +
-                    " ");
+            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        internal static readonly ");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" Item");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" = ");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(".Parse(");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 123 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 99 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
             enumItemIndex++;
     } 
@@ -678,13 +658,13 @@ namespace ");
             #line default
             #line hidden
             
-            #line 126 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 102 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write("    }\r\n}\r\n");
             
             #line default
             #line hidden
             
-            #line 128 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 104 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
  EndNesting(); 
             
             #line default

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Enum.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Enum.cs
@@ -16,7 +16,7 @@ namespace Corvus.Json.CodeGeneration.Generators.Draft202012 {
     public partial class CodeGeneratorEnum : CodeGeneratorEnumBase {
         
         
-        #line 129 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+        #line 105 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
 
     public bool ShouldGenerate
     {
@@ -121,111 +121,109 @@ namespace ");
             #line hidden
             
             #line 43 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// ");
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
             #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".\r\n        /// </summary>\r\n        /// <remarks>\r\n        /// {Description}.\r\n   " +
-                    "     /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(");\r\n        /// <summary>\r\n        /// Gets the ");
-            
-            #line default
-            #line hidden
-            
-            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" as a raw UTF8 string.\r\n        /// </summary>\r\n        /// <remarks>\r\n        //" +
-                    "/ {Description}.\r\n        /// </remarks>\r\n        public static ReadOnlySpan<byt" +
-                    "e> ");
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("Utf8 => ");
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
             
             #line default
             #line hidden
             
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(");\r\n        /// <summary>\r\n        /// Gets ");
+            
+            #line default
+            #line hidden
+            
+            #line 48 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 48 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a UTF8 string.\r\n        /// </summary>\r\n        public static ReadOnlySpan<by" +
+                    "te> ");
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("Utf8 => ");
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write("u8;\r\n");
             
             #line default
             #line hidden
             
-            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsBoolean)
         { 
@@ -233,74 +231,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 60 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 54 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 55 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 55 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 67 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 58 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsNumber)
         { 
@@ -308,74 +305,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 70 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 62 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 62 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 77 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 65 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsObject)
         { 
@@ -383,74 +379,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 80 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 68 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 81 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 81 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 69 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 69 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 87 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 72 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsArray)
         { 
@@ -458,74 +453,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 90 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 75 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 91 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 91 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 97 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 79 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsNull)
         { 
@@ -533,62 +527,50 @@ namespace ");
             #line default
             #line hidden
             
-            #line 100 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 82 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets \"null\" as a JSON value.\r\n        /// </su" +
+                    "mmary>\r\n        public static readonly ");
             
             #line default
             #line hidden
             
-            #line 101 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 101 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" Item");
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" = ");
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(".Parse(\"null\");\r\n");
             
             #line default
             #line hidden
             
-            #line 107 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         ++enumItemIndex;
     }
@@ -602,75 +584,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 116 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 95 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 117 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
             
             #line default
             #line hidden
             
-            #line 117 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        internal static readonly" +
-                    " ");
+            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        internal static readonly ");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" Item");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" = ");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(".Parse(");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 123 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 99 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
             enumItemIndex++;
     } 
@@ -678,13 +658,13 @@ namespace ");
             #line default
             #line hidden
             
-            #line 126 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 102 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write("    }\r\n}\r\n");
             
             #line default
             #line hidden
             
-            #line 128 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 104 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
  EndNesting(); 
             
             #line default

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Enum.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Enum.cs
@@ -16,7 +16,7 @@ namespace Corvus.Json.CodeGeneration.Generators.Draft6 {
     public partial class CodeGeneratorEnum : CodeGeneratorEnumBase {
         
         
-        #line 129 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+        #line 105 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
 
     public bool ShouldGenerate
     {
@@ -121,111 +121,109 @@ namespace ");
             #line hidden
             
             #line 43 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// ");
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
             #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".\r\n        /// </summary>\r\n        /// <remarks>\r\n        /// {Description}.\r\n   " +
-                    "     /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(");\r\n        /// <summary>\r\n        /// Gets the ");
-            
-            #line default
-            #line hidden
-            
-            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" as a raw UTF8 string.\r\n        /// </summary>\r\n        /// <remarks>\r\n        //" +
-                    "/ {Description}.\r\n        /// </remarks>\r\n        public static ReadOnlySpan<byt" +
-                    "e> ");
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("Utf8 => ");
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
             
             #line default
             #line hidden
             
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(");\r\n        /// <summary>\r\n        /// Gets ");
+            
+            #line default
+            #line hidden
+            
+            #line 48 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 48 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a UTF8 string.\r\n        /// </summary>\r\n        public static ReadOnlySpan<by" +
+                    "te> ");
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("Utf8 => ");
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write("u8;\r\n");
             
             #line default
             #line hidden
             
-            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsBoolean)
         { 
@@ -233,74 +231,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 60 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 54 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 55 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 55 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 67 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 58 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsNumber)
         { 
@@ -308,74 +305,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 70 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 62 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 62 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 77 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 65 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsObject)
         { 
@@ -383,74 +379,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 80 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 68 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 81 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 81 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 69 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 69 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 87 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 72 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsArray)
         { 
@@ -458,74 +453,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 90 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 75 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 91 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 91 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 97 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 79 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsNull)
         { 
@@ -533,62 +527,50 @@ namespace ");
             #line default
             #line hidden
             
-            #line 100 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 82 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets \"null\" as a JSON value.\r\n        /// </su" +
+                    "mmary>\r\n        public static readonly ");
             
             #line default
             #line hidden
             
-            #line 101 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 101 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" Item");
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" = ");
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(".Parse(\"null\");\r\n");
             
             #line default
             #line hidden
             
-            #line 107 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         ++enumItemIndex;
     }
@@ -602,75 +584,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 116 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 95 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 117 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
             
             #line default
             #line hidden
             
-            #line 117 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        internal static readonly" +
-                    " ");
+            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        internal static readonly ");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" Item");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" = ");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(".Parse(");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 123 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 99 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
             enumItemIndex++;
     } 
@@ -678,13 +658,13 @@ namespace ");
             #line default
             #line hidden
             
-            #line 126 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 102 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write("    }\r\n}\r\n");
             
             #line default
             #line hidden
             
-            #line 128 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 104 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
  EndNesting(); 
             
             #line default

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Enum.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Enum.cs
@@ -16,7 +16,7 @@ namespace Corvus.Json.CodeGeneration.Generators.Draft7 {
     public partial class CodeGeneratorEnum : CodeGeneratorEnumBase {
         
         
-        #line 129 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+        #line 105 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
 
     public bool ShouldGenerate
     {
@@ -121,111 +121,109 @@ namespace ");
             #line hidden
             
             #line 43 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// ");
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
             #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".\r\n        /// </summary>\r\n        /// <remarks>\r\n        /// {Description}.\r\n   " +
-                    "     /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
-            
-            #line default
-            #line hidden
-            
-            #line 49 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(");\r\n        /// <summary>\r\n        /// Gets the ");
-            
-            #line default
-            #line hidden
-            
-            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" as a raw UTF8 string.\r\n        /// </summary>\r\n        /// <remarks>\r\n        //" +
-                    "/ {Description}.\r\n        /// </remarks>\r\n        public static ReadOnlySpan<byt" +
-                    "e> ");
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("Utf8 => ");
-            
-            #line default
-            #line hidden
-            
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
             
             #line default
             #line hidden
             
-            #line 56 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 44 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 46 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(");\r\n        /// <summary>\r\n        /// Gets ");
+            
+            #line default
+            #line hidden
+            
+            #line 48 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 48 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a UTF8 string.\r\n        /// </summary>\r\n        public static ReadOnlySpan<by" +
+                    "te> ");
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.AsPropertyName ));
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("Utf8 => ");
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 50 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write("u8;\r\n");
             
             #line default
             #line hidden
             
-            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 51 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsBoolean)
         { 
@@ -233,74 +231,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 60 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 54 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 55 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 66 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 55 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 57 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 67 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 58 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsNumber)
         { 
@@ -308,74 +305,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 70 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 61 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 62 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 62 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 64 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 77 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 65 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsObject)
         { 
@@ -383,74 +379,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 80 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 68 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 81 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 81 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 69 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 69 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 71 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 87 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 72 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsArray)
         { 
@@ -458,74 +453,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 90 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 75 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 91 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 91 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" Item");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(" = ");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(".Parse(");
-            
-            #line default
-            #line hidden
-            
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 76 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        public static readonly ");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" Item");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" = ");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(".Parse(");
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
+            
+            #line default
+            #line hidden
+            
+            #line 78 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 97 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 79 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         else if (enumValue.IsNull)
         { 
@@ -533,62 +527,50 @@ namespace ");
             #line default
             #line hidden
             
-            #line 100 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 82 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets \"null\" as a JSON value.\r\n        /// </su" +
+                    "mmary>\r\n        public static readonly ");
             
             #line default
             #line hidden
             
-            #line 101 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
-            
-            #line default
-            #line hidden
-            
-            #line 101 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        public static readonly ");
-            
-            #line default
-            #line hidden
-            
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" Item");
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" = ");
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 106 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 85 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(".Parse(\"null\");\r\n");
             
             #line default
             #line hidden
             
-            #line 107 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 86 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
         ++enumItemIndex;
     }
@@ -602,75 +584,73 @@ namespace ");
             #line default
             #line hidden
             
-            #line 116 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("        /// <summary>\r\n        /// [{Title} || Item ");
+            #line 95 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write("        /// <summary>\r\n        /// Gets ");
             
             #line default
             #line hidden
             
-            #line 117 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
+            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.RawStringValue ));
             
             #line default
             #line hidden
             
-            #line 117 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
-            this.Write("] (with predictable naming).\r\n        /// </summary>\r\n        /// <remarks>\r\n    " +
-                    "    /// {Description}.\r\n        /// </remarks>\r\n        internal static readonly" +
-                    " ");
+            #line 96 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            this.Write(" as a JSON value.\r\n        /// </summary>\r\n        internal static readonly ");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" Item");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumItemIndex ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(" = ");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( TypeDeclaration.DotnetTypeName ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(".Parse(");
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(this.ToStringHelper.ToStringWithCulture( enumValue.SerializedValue ));
             
             #line default
             #line hidden
             
-            #line 122 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 98 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write(");\r\n");
             
             #line default
             #line hidden
             
-            #line 123 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 99 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
       }
             enumItemIndex++;
     } 
@@ -678,13 +658,13 @@ namespace ");
             #line default
             #line hidden
             
-            #line 126 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 102 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
             this.Write("    }\r\n}\r\n");
             
             #line default
             #line hidden
             
-            #line 128 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
+            #line 104 "D:\source\corvus-dotnet\Corvus.JsonSchema\Solutions\Corvus.Json.CodeGeneration.Abstractions\SharedTemplates\CodeGenerator.Enum.tt"
  EndNesting(); 
             
             #line default

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/SharedTemplates/CodeGenerator.Enum.tt
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/SharedTemplates/CodeGenerator.Enum.tt
@@ -41,68 +41,47 @@ public readonly partial struct <#= TypeDeclaration.DotnetTypeName #>
         if (enumValue.IsString)
         { #>
         /// <summary>
-        /// <#= enumValue.AsPropertyName #>.
+        /// Gets <#= enumValue.RawStringValue #> as a JSON value.
         /// </summary>
-        /// <remarks>
-        /// {Description}.
-        /// </remarks>
         public static readonly <#= TypeDeclaration.DotnetTypeName #> <#= enumValue.AsPropertyName #> = <#= TypeDeclaration.DotnetTypeName #>.Parse(<#= enumValue.SerializedValue #>);
         /// <summary>
-        /// Gets the <#= enumValue.AsPropertyName #> as a raw UTF8 string.
+        /// Gets <#= enumValue.RawStringValue #> as a UTF8 string.
         /// </summary>
-        /// <remarks>
-        /// {Description}.
-        /// </remarks>
         public static ReadOnlySpan<byte> <#= enumValue.AsPropertyName #>Utf8 => <#= enumValue.RawStringValue #>u8;
 <#      }
         else if (enumValue.IsBoolean)
         { #>
         /// <summary>
-        /// [{Title} || Item <#= enumItemIndex#>] (with predictable naming).
+        /// Gets <#= enumValue.SerializedValue #> as a JSON value.
         /// </summary>
-        /// <remarks>
-        /// {Description}.
-        /// </remarks>
         public static readonly <#= TypeDeclaration.DotnetTypeName #> Item<#= enumItemIndex #> = <#= TypeDeclaration.DotnetTypeName #>.Parse(<#= enumValue.SerializedValue #>);
 <#      }
         else if (enumValue.IsNumber)
         { #>
         /// <summary>
-        /// [{Title} || Item <#= enumItemIndex #>] (with predictable naming).
+        /// Gets <#= enumValue.SerializedValue #> as a JSON value.
         /// </summary>
-        /// <remarks>
-        /// {Description}.
-        /// </remarks>
         public static readonly <#= TypeDeclaration.DotnetTypeName #> Item<#= enumItemIndex #> = <#= TypeDeclaration.DotnetTypeName #>.Parse(<#= enumValue.SerializedValue #>);
 <#      }
         else if (enumValue.IsObject)
         { #>
         /// <summary>
-        /// [{Title} || Item <#= enumItemIndex#>] (with predictable naming).
+        /// Gets <#= enumValue.SerializedValue #> as a JSON value.
         /// </summary>
-        /// <remarks>
-        /// {Description}.
-        /// </remarks>
         public static readonly <#= TypeDeclaration.DotnetTypeName #> Item<#= enumItemIndex#> = <#= TypeDeclaration.DotnetTypeName #>.Parse(<#= enumValue.SerializedValue #>);
 <#      }
         else if (enumValue.IsArray)
         { #>
         /// <summary>
-        /// [{Title} || Item <#= enumItemIndex #>] (with predictable naming).
+        /// Gets <#= enumValue.SerializedValue #> as a JSON value.
         /// </summary>
-        /// <remarks>
-        /// {Description}.
-        /// </remarks>
         public static readonly <#= TypeDeclaration.DotnetTypeName #> Item<#= enumItemIndex #> = <#= TypeDeclaration.DotnetTypeName #>.Parse(<#= enumValue.SerializedValue #>);
 <#      }
         else if (enumValue.IsNull)
         { #>
         /// <summary>
-        /// [{Title} || Item <#= enumItemIndex #>] (with predictable naming).
+        /// Gets "null" as a JSON value.
         /// </summary>
-        /// <remarks>
-        /// {Description}.
-        /// </remarks>
         public static readonly <#= TypeDeclaration.DotnetTypeName #> Item<#= enumItemIndex#> = <#= TypeDeclaration.DotnetTypeName #>.Parse("null");
 <#      }
         ++enumItemIndex;
@@ -114,11 +93,8 @@ public readonly partial struct <#= TypeDeclaration.DotnetTypeName #>
         if (enumValue.IsString)
         { #>
         /// <summary>
-        /// [{Title} || Item <#= enumItemIndex #>] (with predictable naming).
+        /// Gets <#= enumValue.RawStringValue #> as a JSON value.
         /// </summary>
-        /// <remarks>
-        /// {Description}.
-        /// </remarks>
         internal static readonly <#= TypeDeclaration.DotnetTypeName #> Item<#= enumItemIndex #> = <#= TypeDeclaration.DotnetTypeName #>.Parse(<#= enumValue.SerializedValue #>);
 <#      }
             enumItemIndex++;

--- a/Solutions/Corvus.Json.JsonSchema.Draft201909/Draft201909/Validation.SimpleTypes.Enum.cs
+++ b/Solutions/Corvus.Json.JsonSchema.Draft201909/Draft201909/Validation.SimpleTypes.Enum.cs
@@ -27,158 +27,95 @@ public readonly partial struct Validation
         public static class EnumValues
         {
             /// <summary>
-            /// Array.
+            /// Gets "array" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Array = SimpleTypes.Parse("\"array\"");
             /// <summary>
-            /// Gets the Array as a raw UTF8 string.
+            /// Gets "array" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> ArrayUtf8 => "array"u8;
 
             /// <summary>
-            /// Boolean.
+            /// Gets "boolean" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Boolean = SimpleTypes.Parse("\"boolean\"");
             /// <summary>
-            /// Gets the Boolean as a raw UTF8 string.
+            /// Gets "boolean" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> BooleanUtf8 => "boolean"u8;
 
             /// <summary>
-            /// Integer.
+            /// Gets "integer" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Integer = SimpleTypes.Parse("\"integer\"");
             /// <summary>
-            /// Gets the Integer as a raw UTF8 string.
+            /// Gets "integer" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> IntegerUtf8 => "integer"u8;
 
             /// <summary>
-            /// Null.
+            /// Gets "null" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Null = SimpleTypes.Parse("\"null\"");
             /// <summary>
-            /// Gets the Null as a raw UTF8 string.
+            /// Gets "null" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> NullUtf8 => "null"u8;
 
             /// <summary>
-            /// Number.
+            /// Gets "number" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Number = SimpleTypes.Parse("\"number\"");
             /// <summary>
-            /// Gets the Number as a raw UTF8 string.
+            /// Gets "number" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> NumberUtf8 => "number"u8;
 
             /// <summary>
-            /// Object.
+            /// Gets "object" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Object = SimpleTypes.Parse("\"object\"");
             /// <summary>
-            /// Gets the Object as a raw UTF8 string.
+            /// Gets "object" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> ObjectUtf8 => "object"u8;
 
             /// <summary>
-            /// String.
+            /// Gets "string" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes String = SimpleTypes.Parse("\"string\"");
             /// <summary>
-            /// Gets the String as a raw UTF8 string.
+            /// Gets "string" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> StringUtf8 => "string"u8;
 
             /// <summary>
-            /// [{Title} || Item 0] (with predictable naming).
+            /// Gets "array" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item0 = SimpleTypes.Parse("\"array\"");
             /// <summary>
-            /// [{Title} || Item 1] (with predictable naming).
+            /// Gets "boolean" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item1 = SimpleTypes.Parse("\"boolean\"");
             /// <summary>
-            /// [{Title} || Item 2] (with predictable naming).
+            /// Gets "integer" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item2 = SimpleTypes.Parse("\"integer\"");
             /// <summary>
-            /// [{Title} || Item 3] (with predictable naming).
+            /// Gets "null" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item3 = SimpleTypes.Parse("\"null\"");
             /// <summary>
-            /// [{Title} || Item 4] (with predictable naming).
+            /// Gets "number" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item4 = SimpleTypes.Parse("\"number\"");
             /// <summary>
-            /// [{Title} || Item 5] (with predictable naming).
+            /// Gets "object" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item5 = SimpleTypes.Parse("\"object\"");
             /// <summary>
-            /// [{Title} || Item 6] (with predictable naming).
+            /// Gets "string" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item6 = SimpleTypes.Parse("\"string\"");
         }
     }

--- a/Solutions/Corvus.Json.JsonSchema.Draft202012/Draft202012/Validation.SimpleTypes.Enum.cs
+++ b/Solutions/Corvus.Json.JsonSchema.Draft202012/Draft202012/Validation.SimpleTypes.Enum.cs
@@ -27,158 +27,95 @@ public readonly partial struct Validation
         public static class EnumValues
         {
             /// <summary>
-            /// Array.
+            /// Gets "array" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Array = SimpleTypes.Parse("\"array\"");
             /// <summary>
-            /// Gets the Array as a raw UTF8 string.
+            /// Gets "array" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> ArrayUtf8 => "array"u8;
 
             /// <summary>
-            /// Boolean.
+            /// Gets "boolean" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Boolean = SimpleTypes.Parse("\"boolean\"");
             /// <summary>
-            /// Gets the Boolean as a raw UTF8 string.
+            /// Gets "boolean" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> BooleanUtf8 => "boolean"u8;
 
             /// <summary>
-            /// Integer.
+            /// Gets "integer" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Integer = SimpleTypes.Parse("\"integer\"");
             /// <summary>
-            /// Gets the Integer as a raw UTF8 string.
+            /// Gets "integer" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> IntegerUtf8 => "integer"u8;
 
             /// <summary>
-            /// Null.
+            /// Gets "null" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Null = SimpleTypes.Parse("\"null\"");
             /// <summary>
-            /// Gets the Null as a raw UTF8 string.
+            /// Gets "null" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> NullUtf8 => "null"u8;
 
             /// <summary>
-            /// Number.
+            /// Gets "number" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Number = SimpleTypes.Parse("\"number\"");
             /// <summary>
-            /// Gets the Number as a raw UTF8 string.
+            /// Gets "number" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> NumberUtf8 => "number"u8;
 
             /// <summary>
-            /// Object.
+            /// Gets "object" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Object = SimpleTypes.Parse("\"object\"");
             /// <summary>
-            /// Gets the Object as a raw UTF8 string.
+            /// Gets "object" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> ObjectUtf8 => "object"u8;
 
             /// <summary>
-            /// String.
+            /// Gets "string" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes String = SimpleTypes.Parse("\"string\"");
             /// <summary>
-            /// Gets the String as a raw UTF8 string.
+            /// Gets "string" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> StringUtf8 => "string"u8;
 
             /// <summary>
-            /// [{Title} || Item 0] (with predictable naming).
+            /// Gets "array" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item0 = SimpleTypes.Parse("\"array\"");
             /// <summary>
-            /// [{Title} || Item 1] (with predictable naming).
+            /// Gets "boolean" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item1 = SimpleTypes.Parse("\"boolean\"");
             /// <summary>
-            /// [{Title} || Item 2] (with predictable naming).
+            /// Gets "integer" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item2 = SimpleTypes.Parse("\"integer\"");
             /// <summary>
-            /// [{Title} || Item 3] (with predictable naming).
+            /// Gets "null" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item3 = SimpleTypes.Parse("\"null\"");
             /// <summary>
-            /// [{Title} || Item 4] (with predictable naming).
+            /// Gets "number" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item4 = SimpleTypes.Parse("\"number\"");
             /// <summary>
-            /// [{Title} || Item 5] (with predictable naming).
+            /// Gets "object" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item5 = SimpleTypes.Parse("\"object\"");
             /// <summary>
-            /// [{Title} || Item 6] (with predictable naming).
+            /// Gets "string" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item6 = SimpleTypes.Parse("\"string\"");
         }
     }

--- a/Solutions/Corvus.Json.JsonSchema.Draft6/Draft6/Schema.SimpleTypes.Enum.cs
+++ b/Solutions/Corvus.Json.JsonSchema.Draft6/Draft6/Schema.SimpleTypes.Enum.cs
@@ -27,158 +27,95 @@ public readonly partial struct Schema
         public static class EnumValues
         {
             /// <summary>
-            /// Array.
+            /// Gets "array" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Array = SimpleTypes.Parse("\"array\"");
             /// <summary>
-            /// Gets the Array as a raw UTF8 string.
+            /// Gets "array" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> ArrayUtf8 => "array"u8;
 
             /// <summary>
-            /// Boolean.
+            /// Gets "boolean" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Boolean = SimpleTypes.Parse("\"boolean\"");
             /// <summary>
-            /// Gets the Boolean as a raw UTF8 string.
+            /// Gets "boolean" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> BooleanUtf8 => "boolean"u8;
 
             /// <summary>
-            /// Integer.
+            /// Gets "integer" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Integer = SimpleTypes.Parse("\"integer\"");
             /// <summary>
-            /// Gets the Integer as a raw UTF8 string.
+            /// Gets "integer" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> IntegerUtf8 => "integer"u8;
 
             /// <summary>
-            /// Null.
+            /// Gets "null" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Null = SimpleTypes.Parse("\"null\"");
             /// <summary>
-            /// Gets the Null as a raw UTF8 string.
+            /// Gets "null" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> NullUtf8 => "null"u8;
 
             /// <summary>
-            /// Number.
+            /// Gets "number" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Number = SimpleTypes.Parse("\"number\"");
             /// <summary>
-            /// Gets the Number as a raw UTF8 string.
+            /// Gets "number" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> NumberUtf8 => "number"u8;
 
             /// <summary>
-            /// Object.
+            /// Gets "object" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Object = SimpleTypes.Parse("\"object\"");
             /// <summary>
-            /// Gets the Object as a raw UTF8 string.
+            /// Gets "object" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> ObjectUtf8 => "object"u8;
 
             /// <summary>
-            /// String.
+            /// Gets "string" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes String = SimpleTypes.Parse("\"string\"");
             /// <summary>
-            /// Gets the String as a raw UTF8 string.
+            /// Gets "string" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> StringUtf8 => "string"u8;
 
             /// <summary>
-            /// [{Title} || Item 0] (with predictable naming).
+            /// Gets "array" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item0 = SimpleTypes.Parse("\"array\"");
             /// <summary>
-            /// [{Title} || Item 1] (with predictable naming).
+            /// Gets "boolean" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item1 = SimpleTypes.Parse("\"boolean\"");
             /// <summary>
-            /// [{Title} || Item 2] (with predictable naming).
+            /// Gets "integer" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item2 = SimpleTypes.Parse("\"integer\"");
             /// <summary>
-            /// [{Title} || Item 3] (with predictable naming).
+            /// Gets "null" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item3 = SimpleTypes.Parse("\"null\"");
             /// <summary>
-            /// [{Title} || Item 4] (with predictable naming).
+            /// Gets "number" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item4 = SimpleTypes.Parse("\"number\"");
             /// <summary>
-            /// [{Title} || Item 5] (with predictable naming).
+            /// Gets "object" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item5 = SimpleTypes.Parse("\"object\"");
             /// <summary>
-            /// [{Title} || Item 6] (with predictable naming).
+            /// Gets "string" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item6 = SimpleTypes.Parse("\"string\"");
         }
     }

--- a/Solutions/Corvus.Json.JsonSchema.Draft7/Draft7/Schema.SimpleTypes.Enum.cs
+++ b/Solutions/Corvus.Json.JsonSchema.Draft7/Draft7/Schema.SimpleTypes.Enum.cs
@@ -27,158 +27,95 @@ public readonly partial struct Schema
         public static class EnumValues
         {
             /// <summary>
-            /// Array.
+            /// Gets "array" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Array = SimpleTypes.Parse("\"array\"");
             /// <summary>
-            /// Gets the Array as a raw UTF8 string.
+            /// Gets "array" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> ArrayUtf8 => "array"u8;
 
             /// <summary>
-            /// Boolean.
+            /// Gets "boolean" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Boolean = SimpleTypes.Parse("\"boolean\"");
             /// <summary>
-            /// Gets the Boolean as a raw UTF8 string.
+            /// Gets "boolean" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> BooleanUtf8 => "boolean"u8;
 
             /// <summary>
-            /// Integer.
+            /// Gets "integer" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Integer = SimpleTypes.Parse("\"integer\"");
             /// <summary>
-            /// Gets the Integer as a raw UTF8 string.
+            /// Gets "integer" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> IntegerUtf8 => "integer"u8;
 
             /// <summary>
-            /// Null.
+            /// Gets "null" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Null = SimpleTypes.Parse("\"null\"");
             /// <summary>
-            /// Gets the Null as a raw UTF8 string.
+            /// Gets "null" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> NullUtf8 => "null"u8;
 
             /// <summary>
-            /// Number.
+            /// Gets "number" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Number = SimpleTypes.Parse("\"number\"");
             /// <summary>
-            /// Gets the Number as a raw UTF8 string.
+            /// Gets "number" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> NumberUtf8 => "number"u8;
 
             /// <summary>
-            /// Object.
+            /// Gets "object" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes Object = SimpleTypes.Parse("\"object\"");
             /// <summary>
-            /// Gets the Object as a raw UTF8 string.
+            /// Gets "object" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> ObjectUtf8 => "object"u8;
 
             /// <summary>
-            /// String.
+            /// Gets "string" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static readonly SimpleTypes String = SimpleTypes.Parse("\"string\"");
             /// <summary>
-            /// Gets the String as a raw UTF8 string.
+            /// Gets "string" as a UTF8 string.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             public static ReadOnlySpan<byte> StringUtf8 => "string"u8;
 
             /// <summary>
-            /// [{Title} || Item 0] (with predictable naming).
+            /// Gets "array" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item0 = SimpleTypes.Parse("\"array\"");
             /// <summary>
-            /// [{Title} || Item 1] (with predictable naming).
+            /// Gets "boolean" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item1 = SimpleTypes.Parse("\"boolean\"");
             /// <summary>
-            /// [{Title} || Item 2] (with predictable naming).
+            /// Gets "integer" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item2 = SimpleTypes.Parse("\"integer\"");
             /// <summary>
-            /// [{Title} || Item 3] (with predictable naming).
+            /// Gets "null" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item3 = SimpleTypes.Parse("\"null\"");
             /// <summary>
-            /// [{Title} || Item 4] (with predictable naming).
+            /// Gets "number" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item4 = SimpleTypes.Parse("\"number\"");
             /// <summary>
-            /// [{Title} || Item 5] (with predictable naming).
+            /// Gets "object" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item5 = SimpleTypes.Parse("\"object\"");
             /// <summary>
-            /// [{Title} || Item 6] (with predictable naming).
+            /// Gets "string" as a JSON value.
             /// </summary>
-            /// <remarks>
-            /// {Description}.
-            /// </remarks>
             internal static readonly SimpleTypes Item6 = SimpleTypes.Parse("\"string\"");
         }
     }


### PR DESCRIPTION
Now emit the value you are going to get from the enum as the documentation for the enum.

(Note that `enum` doesn't support documentation - it is simply an array of instance values.)