### PR TITLE
Added SchemaLocation to the reserved words.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/JsonSchemaHelpers.Draft201909.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/JsonSchemaHelpers.Draft201909.cs
@@ -159,6 +159,7 @@ public static class JsonSchemaHelpers
     {
         return
         [
+            "SchemaLocation",
             "Item",
             "Add",
             "AddRange",

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/JsonSchemaHelpers.Draft202012.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/JsonSchemaHelpers.Draft202012.cs
@@ -44,6 +44,7 @@ public static class JsonSchemaHelpers
     {
         return
         [
+            "SchemaLocation",
             "Item",
             "Add",
             "AddRange",

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/JsonSchemaHelpers.Draft6.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/JsonSchemaHelpers.Draft6.cs
@@ -113,6 +113,7 @@ public static class JsonSchemaHelpers
     {
         return
         [
+            "SchemaLocation",
             "Item",
             "Add",
             "AddRange",

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/JsonSchemaHelpers.Draft7.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/JsonSchemaHelpers.Draft7.cs
@@ -113,6 +113,7 @@ public static class JsonSchemaHelpers
     {
         return
         [
+            "SchemaLocation",
             "Item",
             "Add",
             "AddRange",


### PR DESCRIPTION
To prevent naming collisions, add SchemaLocation to the reserved words. 