### PR TITLE
Added `Match` as a reserved word.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/JsonSchemaHelpers.Draft201909.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/JsonSchemaHelpers.Draft201909.cs
@@ -243,6 +243,7 @@ public static class JsonSchemaHelpers
             "FromNumber",
             "FromArray",
             "FromObject",
+            "Match",
             "Parse",
             "As",
             "Equals",

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/JsonSchemaHelpers.Draft202012.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/JsonSchemaHelpers.Draft202012.cs
@@ -128,6 +128,7 @@ public static class JsonSchemaHelpers
             "FromNumber",
             "FromArray",
             "FromObject",
+            "Match",
             "Parse",
             "As",
             "Equals",

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/JsonSchemaHelpers.Draft6.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/JsonSchemaHelpers.Draft6.cs
@@ -197,6 +197,7 @@ public static class JsonSchemaHelpers
             "FromNumber",
             "FromArray",
             "FromObject",
+            "Match",
             "Parse",
             "As",
             "Equals",

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/JsonSchemaHelpers.Draft7.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/JsonSchemaHelpers.Draft7.cs
@@ -197,6 +197,7 @@ public static class JsonSchemaHelpers
             "FromNumber",
             "FromArray",
             "FromObject",
+            "Match",
             "Parse",
             "As",
             "Equals",

--- a/Solutions/Corvus.Json.JsonSchema.Draft6/Draft6/Schema.Properties.cs
+++ b/Solutions/Corvus.Json.JsonSchema.Draft6/Draft6/Schema.Properties.cs
@@ -372,11 +372,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>additionalItems</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft6.Schema AdditionalItems
     {
         get
@@ -409,11 +404,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>additionalProperties</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft6.Schema AdditionalProperties
     {
         get
@@ -542,11 +532,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>contains</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft6.Schema Contains
     {
         get
@@ -1219,11 +1204,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>not</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft6.Schema Not
     {
         get
@@ -1384,11 +1364,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>propertyNames</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft6.Schema PropertyNames
     {
         get

--- a/Solutions/Corvus.Json.JsonSchema.Draft7/Draft7/Schema.Properties.cs
+++ b/Solutions/Corvus.Json.JsonSchema.Draft7/Draft7/Schema.Properties.cs
@@ -444,11 +444,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>additionalItems</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft7.Schema AdditionalItems
     {
         get
@@ -481,11 +476,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>additionalProperties</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft7.Schema AdditionalProperties
     {
         get
@@ -646,11 +636,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>contains</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft7.Schema Contains
     {
         get
@@ -875,11 +860,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>else</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft7.Schema Else
     {
         get
@@ -1104,11 +1084,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>if</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft7.Schema If
     {
         get
@@ -1461,11 +1436,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>not</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft7.Schema Not
     {
         get
@@ -1626,11 +1596,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>propertyNames</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft7.Schema PropertyNames
     {
         get
@@ -1791,11 +1756,6 @@ public readonly partial struct Schema
     /// <summary>
     /// Gets the (optional) <c>then</c> property.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Core schema meta-schema
-    /// </para>
-    /// </remarks>
     public Corvus.Json.JsonSchema.Draft7.Schema Then
     {
         get


### PR DESCRIPTION
A Match() function has been added to oneOf/anyOf types.
This needs to be included in the list of reserved words to prevent collisions.