### PR TITLE
Change the type name formatting behaviour when there are multiple capitalized characters, and/or numeric characters.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/Formatting.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/Formatting.cs
@@ -164,6 +164,7 @@ public static class Formatting
                         {
                             chars[setIndex] = char.ToLowerInvariant(chars[readIndex]);
                             uppercasedCount = 0;
+                            setIndex++;
                             continue;
                         }
                     }
@@ -182,8 +183,8 @@ public static class Formatting
             {
                 chars[setIndex] = chars[readIndex];
 
-                // We capitalize the next character we find after a run of digits
-                capitalizeNext = true;
+                // We do not capitalize the next character we find after a run of digits
+                capitalizeNext = false;
                 setIndex++;
             }
             else

--- a/Solutions/Corvus.Json.Specs/Features/Formatting.feature
+++ b/Solutions/Corvus.Json.Specs/Features/Formatting.feature
@@ -1,0 +1,9 @@
+Feature: Formatting Identifiers
+
+Scenario Outline: Formatting strings
+	When I format the input string "<input>" with <format> casing
+	Then The output will be "<output>"
+Examples:
+	| input               | format | output              |
+	| aadB2cConfiguration | Pascal | AadB2cConfiguration |
+	| aadB2CConfiguration | Pascal | AadB2Cconfiguration |

--- a/Solutions/Corvus.Json.Specs/Steps/FormattingSteps.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/FormattingSteps.cs
@@ -1,0 +1,30 @@
+﻿// <copyright file="FormattingSteps.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using Corvus.Json.CodeGeneration;
+using NUnit.Framework;
+using TechTalk.SpecFlow;
+
+namespace Steps;
+
+/// <summary>
+/// Steps for the formatting scenarios.
+/// </summary>
+[Binding]
+public class FormattingSteps
+{
+    private string formatted = string.Empty;
+
+    [When(@"I format the input string ""([^""]*)"" with Pascal casing")]
+    public void WhenIFormatTheInputStringWithPascalCasing(string input)
+    {
+        this.formatted = Formatting.ToPascalCaseWithReservedWords(input).ToString();
+    }
+
+    [Then(@"The output will be ""([^""]*)""")]
+    public void ThenTheOutputWillBe(string expected)
+    {
+        Assert.AreEqual(expected, this.formatted);
+    }
+}


### PR DESCRIPTION
` `

`In the `Formatting.cs` file, added a line of code to increment the `setIndex` variable within a conditional statement that checks if the count of uppercase characters is more than 2. This prevents it from overwriting the character in the output in this case. This is effectively a breaking change, but brings the behaviour in line with that expected.

Modified the behavior when a digit character is encountered so that it does *not* capitalize the next character. This is a potentially breaking change for types with numbers in them that have strange capitalization.

In the `Formatting.feature` file, introduced a new feature for formatting identifiers with a scenario outline for formatting strings.

Added a new class `FormattingSteps` in the `FormattingSteps.cs` file that contains step definitions for the formatting scenarios. This includes methods for formatting the input string with Pascal casing and checking that the output matches the expected result.