### PR TITLE
Enable creating GitHub release as part of the build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ on:
         type: boolean
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,6 @@ on:
   pull_request:
     branches:
     - main
-    - feature/netstandard20
   workflow_dispatch:
     inputs:
       forcePublish:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,7 @@ jobs:
       netSdkVersion: '8.0.x'
       # additionalNetSdkVersion: '7.0.x'
       # workflow_dispatch inputs are always strings, the type property is just for the UI
-      forcePublish: ${{ github.event.inputs.forcePublish == 'true' || github.event_name == 'pull_request' }}
+      forcePublish: ${{ github.event.inputs.forcePublish == 'true' }}
       skipCleanup: ${{ github.event.inputs.skipCleanup == 'true' }}
       # testArtifactName: ''
       # testArtifactPath: ''

--- a/build.ps1
+++ b/build.ps1
@@ -159,6 +159,9 @@ $NuSpecFilesToPackage = @(
 $ReportGeneratorToolVersion = "5.1.10"
 $CovenantVersion = "0.19.0"
 
+$CreateGitHubRelease = $true
+$PublishNuGetPackagesAsGitHubReleaseArtefacts = $true
+
 
 # Synopsis: Build, Test and Package
 task . FullBuild


### PR DESCRIPTION
* Fix issue with PR builds running a full release build
* Adjust build workflow concurrency rule to prevent the 'double build' issue when doing a release