### PR TITLE
Added fallback to single allOf for implied format-by-base.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.AnyOf.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorAnyOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Add.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Add.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorArrayAdd
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorArray
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Remove.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Remove.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorArrayRemove
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Boolean.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Boolean.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorBoolean
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Const.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Const.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorConst
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorConversionsAccessors
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Conversions.Operators.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Conversions.Operators.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorConversionsOperators
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Defaults.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Defaults.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorDefaults
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.DependentRequired.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.DependentRequired.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorDependentRequired
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.DependentSchema.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.DependentSchema.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorDependentSchema
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Enum.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Enum.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorEnum
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.IfThenElse.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorIfThenElse
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Number.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Number.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorNumber
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Object.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorObject
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.OneOf.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorOneOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGenerator
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Pattern.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Pattern.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorPattern
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.PatternProperties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.PatternProperties.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorPatternProperties
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Properties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Properties.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorProperties
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.String.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.String.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorString
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.AllOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.AllOf.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateAllOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateAnyOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Array.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateArray
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Format.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Format.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateFormat
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateIfThenElse
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Not.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Not.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateNot
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Object.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateObject
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.OneOf.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateOneOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidate
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.RecursiveRef.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.RecursiveRef.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateRecursiveRef
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Ref.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Ref.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateRef
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Type.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Type.Partial.cs
@@ -2773,6 +2773,12 @@ public partial class CodeGeneratorValidateType
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Templates/CodeGeneratorPartial.tt
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Templates/CodeGeneratorPartial.tt
@@ -2776,6 +2776,12 @@ public partial class <#= PartialClassName #>
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.AnyOf.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorAnyOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Add.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Add.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorArrayAdd
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorArray
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Remove.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Remove.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorArrayRemove
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Boolean.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Boolean.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorBoolean
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Const.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Const.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorConst
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorConversionsAccessors
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Conversions.Operators.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Conversions.Operators.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorConversionsOperators
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Defaults.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Defaults.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorDefaults
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.DependentRequired.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.DependentRequired.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorDependentRequired
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.DependentSchema.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.DependentSchema.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorDependentSchema
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Enum.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Enum.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorEnum
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.IfThenElse.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorIfThenElse
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Number.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Number.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorNumber
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Object.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorObject
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.OneOf.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorOneOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGenerator
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Pattern.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Pattern.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorPattern
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.PatternProperties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.PatternProperties.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorPatternProperties
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Properties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Properties.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorProperties
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.String.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.String.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorString
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.AllOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.AllOf.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateAllOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateAnyOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Array.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateArray
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.DynamicRef.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.DynamicRef.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateDynamicRef
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Format.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Format.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateFormat
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateIfThenElse
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Not.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Not.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateNot
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Object.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateObject
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.OneOf.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateOneOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidate
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Ref.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Ref.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateRef
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Type.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Type.Partial.cs
@@ -2719,6 +2719,12 @@ public partial class CodeGeneratorValidateType
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Templates/CodeGeneratorPartial.tt
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Templates/CodeGeneratorPartial.tt
@@ -2722,6 +2722,12 @@ public partial class <#= PartialClassName #>
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.AnyOf.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorAnyOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Add.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Add.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorArrayAdd
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorArray
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Remove.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Remove.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorArrayRemove
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Boolean.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Boolean.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorBoolean
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Const.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Const.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorConst
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorConversionsAccessors
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Conversions.Operators.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Conversions.Operators.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorConversionsOperators
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Defaults.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Defaults.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorDefaults
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.DependentRequired.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.DependentRequired.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorDependentRequired
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.DependentSchema.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.DependentSchema.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorDependentSchema
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Enum.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Enum.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorEnum
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Number.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Number.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorNumber
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Object.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorObject
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.OneOf.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorOneOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGenerator
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Pattern.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Pattern.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorPattern
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.PatternProperties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.PatternProperties.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorPatternProperties
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Properties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Properties.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorProperties
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.String.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.String.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorString
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.AllOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.AllOf.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorValidateAllOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorValidateAnyOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Array.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorValidateArray
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Format.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Format.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorValidateFormat
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Not.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Not.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorValidateNot
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Object.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorValidateObject
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.OneOf.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorValidateOneOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorValidate
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Ref.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Ref.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorValidateRef
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Type.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Type.Partial.cs
@@ -2440,6 +2440,12 @@ public partial class CodeGeneratorValidateType
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Templates/CodeGeneratorPartial.tt
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Templates/CodeGeneratorPartial.tt
@@ -2443,6 +2443,12 @@ public partial class <#= PartialClassName #>
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.AnyOf.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorAnyOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Add.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Add.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorArrayAdd
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorArray
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Remove.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Remove.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorArrayRemove
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Boolean.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Boolean.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorBoolean
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Const.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Const.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorConst
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorConversionsAccessors
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Conversions.Operators.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Conversions.Operators.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorConversionsOperators
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Defaults.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Defaults.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorDefaults
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.DependentRequired.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.DependentRequired.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorDependentRequired
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.DependentSchema.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.DependentSchema.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorDependentSchema
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Enum.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Enum.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorEnum
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.IfThenElse.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorIfThenElse
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Number.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Number.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorNumber
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Object.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorObject
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.OneOf.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorOneOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGenerator
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Pattern.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Pattern.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorPattern
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.PatternProperties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.PatternProperties.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorPatternProperties
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Properties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Properties.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorProperties
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.String.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.String.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorString
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.AllOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.AllOf.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidateAllOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidateAnyOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Array.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidateArray
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Format.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Format.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidateFormat
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidateIfThenElse
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Not.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Not.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidateNot
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Object.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidateObject
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.OneOf.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidateOneOf
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidate
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Ref.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Ref.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidateRef
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Type.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Type.Partial.cs
@@ -2539,6 +2539,12 @@ public partial class CodeGeneratorValidateType
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Templates/CodeGeneratorPartial.tt
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Templates/CodeGeneratorPartial.tt
@@ -2542,6 +2542,12 @@ public partial class <#= PartialClassName #>
             return this.GetImpliedFormat(td);
         }
 
+        if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
+        {
+            TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
+            return this.GetImpliedFormat(td);
+        }
+
         return string.Empty;
     }
 

--- a/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft201909/derived-numeric-type-net80.feature
+++ b/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft201909/derived-numeric-type-net80.feature
@@ -35,3 +35,35 @@ Examples:
 	| half    | 0         | false |
 	| half    | 1.1       | true  |
 	| half    | 64.1      | false |
+
+
+	Scenario Outline: type derived by single allOf supports implicit conversions
+	Given a schema file with format <format>
+		"""
+		{
+		    "allOf": [ {"$ref": "#/$defs/base" } ],
+		    "maximum": 64,
+		    "$defs": {
+		        "base": {
+		            "type": "number",
+		            "format": "{{format}}",
+		            "exclusiveMinimum": 0
+		        }
+		    }
+		}
+		"""
+	And I generate a type for the schema
+	And I create the instance by casting the <format> <inputData>
+	When I validate the instance
+	Then the result will be <valid>
+Examples:
+	| format  | inputData | valid |
+	| int128  | 0         | false |
+	| int128  | 1         | true  |
+	| int128  | 65        | false |
+	| uint128 | 0         | false |
+	| uint128 | 1         | true  |
+	| uint128 | 65        | false |
+	| half    | 0         | false |
+	| half    | 1.1       | true  |
+	| half    | 64.1      | false |

--- a/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft201909/derived-numeric-type.feature
+++ b/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft201909/derived-numeric-type.feature
@@ -59,3 +59,58 @@ Examples:
 	| single  | 0         | false |
 	| single  | 1.1       | true  |
 	| single  | 64.1      | false |
+
+Scenario Outline: type derived by single allOf supports implicit conversions
+	Given a schema file with format <format>
+		"""
+		{
+		    "allOf": [ {"$ref": "#/$defs/base" } ],
+		    "maximum": 64,
+		    "$defs": {
+		        "base": {
+		            "type": "number",
+		            "format": "{{format}}",
+		            "exclusiveMinimum": 0
+		        }
+		    }
+		}
+		"""
+	And I generate a type for the schema
+	And I create the instance by casting the <format> <inputData>
+	When I validate the instance
+	Then the result will be <valid>
+Examples:
+	| format  | inputData | valid |
+	| sbyte   | 0         | false |
+	| sbyte   | 1         | true  |
+	| sbyte   | 65        | false |
+	| int16   | 0         | false |
+	| int16   | 1         | true  |
+	| int16   | 65        | false |
+	| int32   | 0         | false |
+	| int32   | 1         | true  |
+	| int32   | 65        | false |
+	| int64   | 0         | false |
+	| int64   | 1         | true  |
+	| int64   | 65        | false |
+	| byte    | 0         | false |
+	| byte    | 1         | true  |
+	| byte    | 65        | false |
+	| uint16  | 0         | false |
+	| uint16  | 1         | true  |
+	| uint16  | 65        | false |
+	| uint32  | 0         | false |
+	| uint32  | 1         | true  |
+	| uint32  | 65        | false |
+	| uint64  | 0         | false |
+	| uint64  | 1         | true  |
+	| uint64  | 65        | false |
+	| double  | 0         | false |
+	| double  | 1.1       | true  |
+	| double  | 64.1      | false |
+	| decimal | 0         | false |
+	| decimal | 1.1       | true  |
+	| decimal | 64.1      | false |
+	| single  | 0         | false |
+	| single  | 1.1       | true  |
+	| single  | 64.1      | false |


### PR DESCRIPTION
Draft 6 and Draft 7 do not support non-naked $ref (they ignore peer keywords.)

People commonly use a single `allOf` to get the same effect. We now detect this for our specialized implied format detection.