### PR TITLE
Feature/add implicit cast to dotnet primitives for naked oneOf

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.AnyOf.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorAnyOf
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorAnyOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorAnyOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Add.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Add.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorArrayAdd
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorArrayAdd
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorArrayAdd
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorArray
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorArray
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorArray
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Remove.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Array.Remove.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorArrayRemove
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorArrayRemove
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorArrayRemove
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Boolean.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Boolean.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorBoolean
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorBoolean
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorBoolean
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Const.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Const.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorConst
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorConst
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorConst
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorConversionsAccessors
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorConversionsAccessors
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorConversionsAccessors
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Conversions.Operators.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Conversions.Operators.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorConversionsOperators
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorConversionsOperators
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorConversionsOperators
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Defaults.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Defaults.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorDefaults
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorDefaults
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorDefaults
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.DependentRequired.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.DependentRequired.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorDependentRequired
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorDependentRequired
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorDependentRequired
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.DependentSchema.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.DependentSchema.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorDependentSchema
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorDependentSchema
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorDependentSchema
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Enum.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Enum.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorEnum
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorEnum
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorEnum
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.IfThenElse.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorIfThenElse
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorIfThenElse
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorIfThenElse
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Number.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Number.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorNumber
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorNumber
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorNumber
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Object.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorObject
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorObject
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorObject
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.OneOf.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorOneOf
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorOneOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorOneOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGenerator
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGenerator
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGenerator
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Pattern.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Pattern.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorPattern
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorPattern
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorPattern
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.PatternProperties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.PatternProperties.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorPatternProperties
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorPatternProperties
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorPatternProperties
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Properties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Properties.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorProperties
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorProperties
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorProperties
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.String.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.String.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorString
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorString
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorString
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.AllOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.AllOf.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateAllOf
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateAllOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateAllOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateAnyOf
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateAnyOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateAnyOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Array.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateArray
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateArray
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateArray
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Format.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Format.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateFormat
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateFormat
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateFormat
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateIfThenElse
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateIfThenElse
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateIfThenElse
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Not.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Not.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateNot
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateNot
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateNot
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Object.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateObject
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateObject
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateObject
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.OneOf.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateOneOf
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateOneOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateOneOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidate
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidate
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidate
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.RecursiveRef.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.RecursiveRef.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateRecursiveRef
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateRecursiveRef
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateRecursiveRef
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Ref.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Ref.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateRef
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateRef
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateRef
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Type.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Generators/CodeGenerator.Validate.Type.Partial.cs
@@ -2333,79 +2333,79 @@ public partial class CodeGeneratorValidateType
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2754,32 +2754,50 @@ public partial class CodeGeneratorValidateType
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2833,7 +2851,7 @@ public partial class CodeGeneratorValidateType
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Templates/CodeGeneratorPartial.tt
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration.Draft201909/Templates/CodeGeneratorPartial.tt
@@ -2336,79 +2336,79 @@ public partial class <#= PartialClassName #>
     }
 
     /// <summary>
-    /// Gets the implied format for this type, following the reference hierarchy.
+    /// Gets the implied formats for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2757,32 +2757,50 @@ public partial class <#= PartialClassName #>
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().RecursiveRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$recursiveRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2836,7 +2854,7 @@ public partial class <#= PartialClassName #>
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.AnyOf.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorAnyOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorAnyOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorAnyOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Add.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Add.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorArrayAdd
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorArrayAdd
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorArrayAdd
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorArray
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorArray
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorArray
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Remove.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Array.Remove.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorArrayRemove
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorArrayRemove
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorArrayRemove
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Boolean.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Boolean.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorBoolean
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorBoolean
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorBoolean
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Const.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Const.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorConst
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorConst
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorConst
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorConversionsAccessors
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorConversionsAccessors
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorConversionsAccessors
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Conversions.Operators.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Conversions.Operators.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorConversionsOperators
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorConversionsOperators
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorConversionsOperators
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Defaults.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Defaults.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorDefaults
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorDefaults
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorDefaults
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.DependentRequired.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.DependentRequired.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorDependentRequired
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorDependentRequired
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorDependentRequired
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.DependentSchema.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.DependentSchema.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorDependentSchema
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorDependentSchema
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorDependentSchema
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Enum.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Enum.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorEnum
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorEnum
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorEnum
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.IfThenElse.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorIfThenElse
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorIfThenElse
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorIfThenElse
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Number.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Number.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorNumber
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorNumber
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorNumber
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Object.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorObject
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorObject
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorObject
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.OneOf.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorOneOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorOneOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorOneOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGenerator
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGenerator
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGenerator
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Pattern.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Pattern.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorPattern
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorPattern
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorPattern
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.PatternProperties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.PatternProperties.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorPatternProperties
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorPatternProperties
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorPatternProperties
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Properties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Properties.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorProperties
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorProperties
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorProperties
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.String.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.String.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorString
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorString
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorString
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.AllOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.AllOf.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateAllOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateAllOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateAllOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateAnyOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateAnyOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateAnyOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Array.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateArray
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateArray
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateArray
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.DynamicRef.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.DynamicRef.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateDynamicRef
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateDynamicRef
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateDynamicRef
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Format.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Format.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateFormat
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateFormat
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateFormat
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateIfThenElse
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateIfThenElse
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateIfThenElse
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Not.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Not.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateNot
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateNot
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateNot
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Object.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateObject
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateObject
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateObject
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.OneOf.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateOneOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateOneOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateOneOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidate
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidate
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidate
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Ref.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Ref.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateRef
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateRef
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateRef
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Type.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Generators/CodeGenerator.Validate.Type.Partial.cs
@@ -2281,77 +2281,77 @@ public partial class CodeGeneratorValidateType
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2700,32 +2700,50 @@ public partial class CodeGeneratorValidateType
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2779,7 +2797,7 @@ public partial class CodeGeneratorValidateType
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Templates/CodeGeneratorPartial.tt
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration.Draft202012/Templates/CodeGeneratorPartial.tt
@@ -2284,77 +2284,77 @@ public partial class <#= PartialClassName #>
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2703,32 +2703,50 @@ public partial class <#= PartialClassName #>
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
-        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
+        if (typeDeclaration.Schema().Ref.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().DynamicRef.IsNotUndefined() && !(typeDeclaration.Schema().IsNakedReference() || typeDeclaration.Schema().IsNakedRecursiveReference() || typeDeclaration.Schema().IsNakedDynamicReference()))
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$dynamicRef");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2782,7 +2800,7 @@ public partial class <#= PartialClassName #>
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.AnyOf.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorAnyOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorAnyOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorAnyOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Add.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Add.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorArrayAdd
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorArrayAdd
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorArrayAdd
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorArray
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorArray
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorArray
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Remove.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Array.Remove.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorArrayRemove
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorArrayRemove
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorArrayRemove
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Boolean.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Boolean.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorBoolean
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorBoolean
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorBoolean
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Const.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Const.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorConst
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorConst
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorConst
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorConversionsAccessors
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorConversionsAccessors
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorConversionsAccessors
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Conversions.Operators.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Conversions.Operators.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorConversionsOperators
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorConversionsOperators
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorConversionsOperators
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Defaults.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Defaults.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorDefaults
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorDefaults
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorDefaults
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.DependentRequired.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.DependentRequired.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorDependentRequired
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorDependentRequired
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorDependentRequired
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.DependentSchema.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.DependentSchema.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorDependentSchema
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorDependentSchema
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorDependentSchema
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Enum.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Enum.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorEnum
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorEnum
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorEnum
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Number.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Number.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorNumber
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorNumber
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorNumber
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Object.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorObject
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorObject
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorObject
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.OneOf.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorOneOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorOneOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorOneOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGenerator
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGenerator
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGenerator
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Pattern.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Pattern.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorPattern
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorPattern
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorPattern
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.PatternProperties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.PatternProperties.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorPatternProperties
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorPatternProperties
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorPatternProperties
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Properties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Properties.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorProperties
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorProperties
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorProperties
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.String.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.String.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorString
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorString
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorString
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.AllOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.AllOf.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorValidateAllOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorValidateAllOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorValidateAllOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorValidateAnyOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorValidateAnyOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorValidateAnyOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Array.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorValidateArray
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorValidateArray
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorValidateArray
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Format.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Format.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorValidateFormat
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorValidateFormat
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorValidateFormat
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Not.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Not.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorValidateNot
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorValidateNot
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorValidateNot
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Object.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorValidateObject
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorValidateObject
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorValidateObject
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.OneOf.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorValidateOneOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorValidateOneOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorValidateOneOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorValidate
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorValidate
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorValidate
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Ref.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Ref.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorValidateRef
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorValidateRef
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorValidateRef
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Type.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Generators/CodeGenerator.Validate.Type.Partial.cs
@@ -2008,77 +2008,77 @@ public partial class CodeGeneratorValidateType
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2427,26 +2427,44 @@ public partial class CodeGeneratorValidateType
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2500,7 +2518,7 @@ public partial class CodeGeneratorValidateType
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Templates/CodeGeneratorPartial.tt
+++ b/Solutions/Corvus.Json.CodeGeneration.6/Corvus.Json.CodeGeneration.Draft6/Templates/CodeGeneratorPartial.tt
@@ -2011,77 +2011,77 @@ public partial class <#= PartialClassName #>
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2430,26 +2430,44 @@ public partial class <#= PartialClassName #>
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2503,7 +2521,7 @@ public partial class <#= PartialClassName #>
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.AnyOf.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorAnyOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorAnyOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorAnyOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Add.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Add.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorArrayAdd
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorArrayAdd
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorArrayAdd
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorArray
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorArray
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorArray
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Remove.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Array.Remove.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorArrayRemove
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorArrayRemove
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorArrayRemove
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Boolean.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Boolean.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorBoolean
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorBoolean
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorBoolean
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Const.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Const.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorConst
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorConst
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorConst
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Conversions.Accessors.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorConversionsAccessors
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorConversionsAccessors
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorConversionsAccessors
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Conversions.Operators.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Conversions.Operators.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorConversionsOperators
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorConversionsOperators
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorConversionsOperators
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Defaults.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Defaults.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorDefaults
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorDefaults
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorDefaults
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.DependentRequired.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.DependentRequired.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorDependentRequired
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorDependentRequired
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorDependentRequired
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.DependentSchema.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.DependentSchema.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorDependentSchema
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorDependentSchema
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorDependentSchema
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Enum.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Enum.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorEnum
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorEnum
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorEnum
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.IfThenElse.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorIfThenElse
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorIfThenElse
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorIfThenElse
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Number.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Number.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorNumber
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorNumber
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorNumber
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Object.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorObject
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorObject
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorObject
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.OneOf.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorOneOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorOneOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorOneOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGenerator
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGenerator
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGenerator
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Pattern.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Pattern.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorPattern
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorPattern
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorPattern
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.PatternProperties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.PatternProperties.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorPatternProperties
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorPatternProperties
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorPatternProperties
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Properties.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Properties.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorProperties
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorProperties
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorProperties
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.String.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.String.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorString
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorString
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorString
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.AllOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.AllOf.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidateAllOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidateAllOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidateAllOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.AnyOf.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidateAnyOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidateAnyOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidateAnyOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Array.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Array.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidateArray
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidateArray
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidateArray
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Format.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Format.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidateFormat
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidateFormat
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidateFormat
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.IfThenElse.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidateIfThenElse
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidateIfThenElse
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidateIfThenElse
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.MediaTypeAndEncoding.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidateMediaTypeAndEncoding
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Not.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Not.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidateNot
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidateNot
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidateNot
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Object.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Object.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidateObject
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidateObject
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidateObject
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.OneOf.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.OneOf.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidateOneOf
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidateOneOf
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidateOneOf
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidate
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidate
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidate
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Ref.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Ref.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidateRef
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidateRef
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidateRef
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Type.Partial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Generators/CodeGenerator.Validate.Type.Partial.cs
@@ -2107,77 +2107,77 @@ public partial class CodeGeneratorValidateType
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2526,26 +2526,44 @@ public partial class CodeGeneratorValidateType
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2599,7 +2617,7 @@ public partial class CodeGeneratorValidateType
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Templates/CodeGeneratorPartial.tt
+++ b/Solutions/Corvus.Json.CodeGeneration.7/Corvus.Json.CodeGeneration.Draft7/Templates/CodeGeneratorPartial.tt
@@ -2110,77 +2110,77 @@ public partial class <#= PartialClassName #>
     /// <summary>
     /// Gets the implied format for this type, following the reference hierarchy.
     /// </summary>
-    public string? ImpliedFormat => this.GetImpliedFormat(this.TypeDeclaration);
+    public string[] ImpliedFormats => this.GetImpliedFormats(this.TypeDeclaration);
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a byte format.
     /// </summary>
-    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToByte => BuiltInTypes.ImplicitConversionToByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int16 format.
     /// </summary>
-    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt16 => BuiltInTypes.ImplicitConversionToInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int32 format.
     /// </summary>
-    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt32 => BuiltInTypes.ImplicitConversionToInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int64 format.
     /// </summary>
-    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt64 => BuiltInTypes.ImplicitConversionToInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an int128 format.
     /// </summary>
-    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToInt128 => BuiltInTypes.ImplicitConversionToInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an sbyte format.
     /// </summary>
-    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSByte => BuiltInTypes.ImplicitConversionToSByte(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint16 format.
     /// </summary>
-    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt16 => BuiltInTypes.ImplicitConversionToUInt16(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint32 format.
     /// </summary>
-    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt32 => BuiltInTypes.ImplicitConversionToUInt32(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint64 format.
     /// </summary>
-    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt64 => BuiltInTypes.ImplicitConversionToUInt64(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an uint128 format.
     /// </summary>
-    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToUInt128 => BuiltInTypes.ImplicitConversionToUInt128(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an double format.
     /// </summary>
-    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDouble => BuiltInTypes.ImplicitConversionToDouble(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to an decimal format.
     /// </summary>
-    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToDecimal => BuiltInTypes.ImplicitConversionToDecimal(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a half format.
     /// </summary>
-    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToHalf => BuiltInTypes.ImplicitConversionToHalf(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this can implicitly convert to a single format.
     /// </summary>
-    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormat) ? "implicit" : "explicit";
+    public string ConversionOperatorToSingle => BuiltInTypes.ImplicitConversionToSingle(this.ImpliedFormats) ? "implicit" : "explicit";
 
     /// <summary>
     /// Gets a value indicating whether this is an IPV4 address.
@@ -2529,26 +2529,44 @@ public partial class <#= PartialClassName #>
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to get the implied format.</param>
     /// <returns>The implied format, if any.</returns>
-    public string? GetImpliedFormat(TypeDeclaration typeDeclaration)
+    public string[] GetImpliedFormats(TypeDeclaration typeDeclaration)
     {
         if (typeDeclaration.Schema().Format.IsNotUndefined())
         {
-            return typeDeclaration.Schema().Format.GetString();
+            string? format = typeDeclaration.Schema().Format.GetString();
+            return format is string f ? [f] : [];
         }
 
         if (typeDeclaration.Schema().Ref.IsNotUndefined() && !typeDeclaration.Schema().IsNakedReference())
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForProperty(typeDeclaration, "$ref");
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
         if (typeDeclaration.Schema().AllOf.IsNotUndefined() && typeDeclaration.Schema().AllOf.GetArrayLength() == 1)
         {
             TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "allOf", 0);
-            return this.GetImpliedFormat(td);
+            return this.GetImpliedFormats(td);
         }
 
-        return string.Empty;
+        if (typeDeclaration.Schema().OneOf.IsNotUndefined() && typeDeclaration.Schema().IsNakedOneOf())
+        {
+            HashSet<string> result = new();
+            int i = 0;
+            foreach (Schema item in typeDeclaration.Schema().OneOf.EnumerateArray())
+            {
+                TypeDeclaration td = this.Builder.GetTypeDeclarationForPropertyArrayIndex(typeDeclaration, "oneOf", i++);
+
+                foreach (string format in this.GetImpliedFormats(td))
+                {
+                    result.Add(format);
+                }
+            }
+
+            return result.ToArray();
+        }
+
+        return [];
     }
 
     private static string GetRawTextAsQuotedString(JsonAny? value)
@@ -2602,7 +2620,7 @@ public partial class <#= PartialClassName #>
         {
             if (typeDeclaration.Schema().IsNumberType())
             {
-                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormat(typeDeclaration));
+                return BuiltInTypes.GetCSharpPrimitiveForNumeric(this.GetImpliedFormats(typeDeclaration));
             }
 
             throw new InvalidOperationException("The leaf type was not numeric.");

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/BuiltInTypes.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/BuiltInTypes.cs
@@ -274,15 +274,151 @@ public static class BuiltInTypes
     /// <summary>
     /// Determines if the format allows implicit conversion to sbyte.
     /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to sbyte.</returns>
+    public static bool ImplicitConversionToSByte(string[] format)
+    {
+        return format.Contains("sbyte");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to byte.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to byte.</returns>
+    public static bool ImplicitConversionToByte(string[] format)
+    {
+        return format.Contains("byte");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to int16.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to int16.</returns>
+    public static bool ImplicitConversionToInt16(string[] format)
+    {
+        return format.Contains("int16");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to uint16.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to uint16.</returns>
+    public static bool ImplicitConversionToUInt16(string[] format)
+    {
+        return format.Contains("uint16");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to int32.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to int32.</returns>
+    public static bool ImplicitConversionToInt32(string[] format)
+    {
+        return format.Contains("int32");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to uint32.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to uint32.</returns>
+    public static bool ImplicitConversionToUInt32(string[] format)
+    {
+        return format.Contains("uint32");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to int64.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to uint64.</returns>
+    public static bool ImplicitConversionToInt64(string[] format)
+    {
+        return format.Contains("int64");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to uint64.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to uint64.</returns>
+    public static bool ImplicitConversionToUInt64(string[] format)
+    {
+        return format.Contains("uint64");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to int128.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to int128.</returns>
+    public static bool ImplicitConversionToInt128(string[] format)
+    {
+        return format.Contains("int128");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to uint128.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to uint128.</returns>
+    public static bool ImplicitConversionToUInt128(string[] format)
+    {
+        return format.Contains("uint128");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to half.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to half.</returns>
+    public static bool ImplicitConversionToHalf(string[] format)
+    {
+        return format.Contains("half");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to single.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to single.</returns>
+    public static bool ImplicitConversionToSingle(string[] format)
+    {
+        return format.Contains("single");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to double.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to double.</returns>
+    public static bool ImplicitConversionToDouble(string[] format)
+    {
+        return format.Contains("double");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to decimal.
+    /// </summary>
+    /// <param name="format">The format strings, or the empty array if there is no format.</param>
+    /// <returns><see langword="true"/> if the format allows implicit conversion to decimal.</returns>
+    public static bool ImplicitConversionToDecimal(string[] format)
+    {
+        return format.Contains("decimal");
+    }
+
+    /// <summary>
+    /// Determines if the format allows implicit conversion to sbyte.
+    /// </summary>
     /// <param name="format">The format string, or null if there is no format.</param>
     /// <returns><see langword="true"/> if the format allows implicit conversion to sbyte.</returns>
     public static bool ImplicitConversionToSByte(string? format)
     {
-        return format switch
-        {
-            "sbyte" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToSByte([f]);
     }
 
     /// <summary>
@@ -292,11 +428,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to byte.</returns>
     public static bool ImplicitConversionToByte(string? format)
     {
-        return format switch
-        {
-            "byte" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToByte([f]);
     }
 
     /// <summary>
@@ -306,11 +438,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to int16.</returns>
     public static bool ImplicitConversionToInt16(string? format)
     {
-        return format switch
-        {
-            "int16" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToInt16([f]);
     }
 
     /// <summary>
@@ -320,11 +448,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to uint16.</returns>
     public static bool ImplicitConversionToUInt16(string? format)
     {
-        return format switch
-        {
-            "uint16" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToUInt16([f]);
     }
 
     /// <summary>
@@ -334,11 +458,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to int32.</returns>
     public static bool ImplicitConversionToInt32(string? format)
     {
-        return format switch
-        {
-            "int32" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToInt32([f]);
     }
 
     /// <summary>
@@ -348,11 +468,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to uint32.</returns>
     public static bool ImplicitConversionToUInt32(string? format)
     {
-        return format switch
-        {
-            "uint32" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToUInt32([f]);
     }
 
     /// <summary>
@@ -362,11 +478,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to uint64.</returns>
     public static bool ImplicitConversionToInt64(string? format)
     {
-        return format switch
-        {
-            "int64" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToInt64([f]);
     }
 
     /// <summary>
@@ -376,11 +488,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to uint64.</returns>
     public static bool ImplicitConversionToUInt64(string? format)
     {
-        return format switch
-        {
-            "uint64" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToUInt64([f]);
     }
 
     /// <summary>
@@ -390,11 +498,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to int128.</returns>
     public static bool ImplicitConversionToInt128(string? format)
     {
-        return format switch
-        {
-            "int128" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToInt128([f]);
     }
 
     /// <summary>
@@ -404,11 +508,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to uint128.</returns>
     public static bool ImplicitConversionToUInt128(string? format)
     {
-        return format switch
-        {
-            "uint128" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToUInt128([f]);
     }
 
     /// <summary>
@@ -418,11 +518,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to half.</returns>
     public static bool ImplicitConversionToHalf(string? format)
     {
-        return format switch
-        {
-            "half" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToHalf([f]);
     }
 
     /// <summary>
@@ -432,11 +528,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to single.</returns>
     public static bool ImplicitConversionToSingle(string? format)
     {
-        return format switch
-        {
-            "single" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToSingle([f]);
     }
 
     /// <summary>
@@ -446,11 +538,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to double.</returns>
     public static bool ImplicitConversionToDouble(string? format)
     {
-        return format switch
-        {
-            "double" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToDouble([f]);
     }
 
     /// <summary>
@@ -460,11 +548,7 @@ public static class BuiltInTypes
     /// <returns><see langword="true"/> if the format allows implicit conversion to decimal.</returns>
     public static bool ImplicitConversionToDecimal(string? format)
     {
-        return format switch
-        {
-            "decimal" => true,
-            _ => false,
-        };
+        return format is string f && ImplicitConversionToDecimal([f]);
     }
 
     /// <summary>
@@ -490,6 +574,25 @@ public static class BuiltInTypes
             null => GetIntegerFor(format) ?? GetNumberFor(format) ?? GetStringFor(format, contentEncoding, contentMediaType) ?? throw new InvalidOperationException($"Unsupported format declaration {format}."),
             _ => throw new InvalidOperationException($"Unsupported type declaration {type}."),
         };
+    }
+
+    /// <summary>
+    /// Gets the CSharp primitive type for the given numeric format.
+    /// </summary>
+    /// <param name="formats">The formats for the numeric primitive.</param>
+    /// <returns>The CSharp primitive for the given format, or "double" if the format is not recognized.</returns>
+    public static string GetCSharpPrimitiveForNumeric(string[] formats)
+    {
+        foreach (string format in formats)
+        {
+            if (GetNumberFor(format) is not null || GetIntegerFor(format) is not null)
+            {
+                return GetCSharpPrimitiveForNumeric(format);
+            }
+        }
+
+        // Default to double
+        return "double";
     }
 
     /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/LargeFileBenchmark.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/LargeFileBenchmark.cs
@@ -178,7 +178,7 @@ public class LargeFileBenchmark : BenchmarkBase
     }
 
     /// <summary>
-    /// Validates using the Newtonsoft types.
+    /// Validates using the JsonEverything types.
     /// </summary>
     [Benchmark(Baseline = true)]
     public void PatchJsonEverything()


### PR DESCRIPTION
Our support for implicit downcasts for naked oneOf types did not extend to the native dotnet numeric types, because they are handled separately from the regular conversions.

This extends the support for implied formats to include naked oneOf types, including the ability to support *multiple* potential formats on sum type of this kind. 