### PR TITLE
Fix issue with no NuGet symbol packages being published

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,7 @@ jobs:
       with:
         environmentVariablesYaml: |
           BUILDVAR_NuGetPublishSource: "${{ startsWith(github.ref, 'refs/tags/') && 'https://api.nuget.org/v3/index.json' || format('https://nuget.pkg.github.com/{0}/index.json', github.repository_owner) }}"
+          BUILDVAR_NugetPublishSymbolSource: "${{ startsWith(github.ref, 'refs/tags/') && 'https://api.nuget.org/v3/index.json' || format('https://nuget.pkg.github.com/{0}/index.json', github.repository_owner) }}"
         secretsYaml: |
           NUGET_API_KEY: "${{ startsWith(github.ref, 'refs/tags/') && secrets.NUGET_APIKEY || secrets.BUILD_PUBLISHER_PAT }}"
 

--- a/build.ps1
+++ b/build.ps1
@@ -161,6 +161,8 @@ $CovenantVersion = "0.19.0"
 
 $CreateGitHubRelease = $true
 $PublishNuGetPackagesAsGitHubReleaseArtefacts = $true
+# Interim local bugfix for symbol packages not being published
+$NugetPackagesToPublishGlobSuffix = '.$(($script:GitVersion).SemVer).*nupkg'
 
 
 # Synopsis: Build, Test and Package

--- a/build.ps1
+++ b/build.ps1
@@ -275,6 +275,55 @@ task RunTests -If {!$SkipTest -and $SolutionToBuild} {
     }
 }
 
+task PublishSolutionPackages -If {!$SkipSolutionPackages -and $SolutionToBuild -and $NugetPackageNamesToPublishGlob} Version,EnsurePackagesDir,{
+
+    # Force the wildcard expression to be evaluated now that GitVersion has been run
+    $evaluatedNugetPackagesToPublishGlob = Invoke-Expression "`"$($NugetPackageNamesToPublishGlob)$($NugetPackagesToPublishGlobSuffix)`""
+    Write-Build White "EvaluatedNugetPackagesToPublishGlob: $evaluatedNugetPackagesToPublishGlob"
+    $nugetPackagesToPublish = Get-ChildItem -Path "$here/_packages" -Filter $evaluatedNugetPackagesToPublishGlob
+    Write-Build White "NugetPackagesToPublish: `n`t$($nugetPackagesToPublish.FullName -join "`n`t")"
+
+    # Derive the NuGet API key to use - this also makes it easier to mask later on
+    # NOTE: Where NuGet auth has been setup beforehand (e.g. via a SOURCE), an API key still needs to be specified but it can be any value
+    $nugetApiKey = $env:NUGET_API_KEY ? $env:NUGET_API_KEY : "no-key"
+
+    # Setup the 'dotnet nuget push' command-line parameters that will be the same for each package
+    $nugetPushArgs = @(
+        "-s"
+        $NugetPublishSource
+        "-ss"
+        $NugetPublishSymbolSource
+        "--api-key"
+        $nugetApiKey
+    )
+
+    if ($NugetPublishSkipDuplicates) {
+        $nugetPushArgs += @(
+            "--skip-duplicate"
+        )
+    }
+
+    # Remove the existing log, since we append to it for each project being packaged via a NuSpec file
+    Get-Item $DotNetPackageNuSpecLogFile -ErrorAction Ignore | Remove-Item -Force
+
+    try {
+        foreach ($nugetPackage in $nugetPackagesToPublish.FullName) {
+
+            Write-Build Green "Publishing package: $nugetPackage"
+            # Ensure any NuGet API key is masked in the debug logging
+            Write-Verbose ("dotnet nuget push $nugetPackage $nugetPushArgs".Replace($nugetApiKey, "*****")) -Verbose:$true
+            exec {
+                & dotnet nuget push $nugetPackage $nugetPushArgs
+            }
+        }
+    }
+    finally {
+        if ((Test-Path $DotNetPackageNuSpecLogFile) -and $IsAzureDevOps) {
+            Write-Host "##vso[artifact.upload artifactname=logs]$((Resolve-Path $DotNetPackageNuSpecLogFile).Path)"
+        }
+    }
+}
+
 # Generate a markdown report from the code coverage files
 $CodeCoverageLowerThreshold = 60
 $CodeCoverageUpperThreshold = 80


### PR DESCRIPTION
* Fixes the wildcard expression used to select NuGet-related files that will be published (this is an interim fix until the build framework module is updated)
* Fixes incorrect symbol source feed being used for release builds