### PR TITLE
Revert "Fix issue with no NuGet symbol packages being published (#357)"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,7 +47,6 @@ jobs:
       with:
         environmentVariablesYaml: |
           BUILDVAR_NuGetPublishSource: "${{ startsWith(github.ref, 'refs/tags/') && 'https://api.nuget.org/v3/index.json' || format('https://nuget.pkg.github.com/{0}/index.json', github.repository_owner) }}"
-          BUILDVAR_NugetPublishSymbolSource: "${{ startsWith(github.ref, 'refs/tags/') && 'https://api.nuget.org/v3/index.json' || format('https://nuget.pkg.github.com/{0}/index.json', github.repository_owner) }}"
         secretsYaml: |
           NUGET_API_KEY: "${{ startsWith(github.ref, 'refs/tags/') && secrets.NUGET_APIKEY || secrets.BUILD_PUBLISHER_PAT }}"
 

--- a/build.ps1
+++ b/build.ps1
@@ -161,8 +161,6 @@ $CovenantVersion = "0.19.0"
 
 $CreateGitHubRelease = $true
 $PublishNuGetPackagesAsGitHubReleaseArtefacts = $true
-# Interim local bugfix for symbol packages not being published
-$NugetPackagesToPublishGlobSuffix = '.$(($script:GitVersion).SemVer).*nupkg'
 
 
 # Synopsis: Build, Test and Package


### PR DESCRIPTION
This reverts commit c9e5f2ce950be5e84f80e8a448387362f432afa1.