### PR TITLE
Added synchronous codepaths to generator.

### DIFF
--- a/Solutions/Corvus.Json.Benchmarking/ConstructFromJsonElement.cs
+++ b/Solutions/Corvus.Json.Benchmarking/ConstructFromJsonElement.cs
@@ -21,9 +21,9 @@
 ////    private readonly JsonDocument nullDocument = JsonDocument.Parse("null");
 
 ////    /// <summary>
-////    /// Global cleanup.
+////    /// Global clean-up.
 ////    /// </summary>
-////    /// <returns>A <see cref="Task"/> which completes once cleanup is complete.</returns>
+////    /// <returns>A <see cref="Task"/> which completes once clean-up is complete.</returns>
 ////    [GlobalCleanup]
 ////    public Task GlobalCleanup()
 ////    {

--- a/Solutions/Corvus.Json.Benchmarking/ValidateLargeDocument.cs
+++ b/Solutions/Corvus.Json.Benchmarking/ValidateLargeDocument.cs
@@ -42,7 +42,7 @@ public class ValidateLargeDocument
     /// <summary>
     /// Global setup.
     /// </summary>
-    /// <returns>A <see cref="Task"/> which completes once cleanup is complete.</returns>
+    /// <returns>A <see cref="Task"/> which completes once clean-up is complete.</returns>
     [GlobalSetup]
     public Task GlobalSetup()
     {
@@ -62,9 +62,9 @@ public class ValidateLargeDocument
     }
 
     /// <summary>
-    /// Global cleanup.
+    /// Global clean-up.
     /// </summary>
-    /// <returns>A <see cref="Task"/> which completes once cleanup is complete.</returns>
+    /// <returns>A <see cref="Task"/> which completes once clean-up is complete.</returns>
     [GlobalCleanup]
     public Task GlobalCleanup()
     {

--- a/Solutions/Corvus.Json.Benchmarking/ValidateLargeDocumentWithAnnotationCollection.cs
+++ b/Solutions/Corvus.Json.Benchmarking/ValidateLargeDocumentWithAnnotationCollection.cs
@@ -42,7 +42,7 @@ public class ValidateLargeDocumentWithAnnotationCollection
     /// <summary>
     /// Global setup.
     /// </summary>
-    /// <returns>A <see cref="Task"/> which completes once cleanup is complete.</returns>
+    /// <returns>A <see cref="Task"/> which completes once clean-up is complete.</returns>
     [GlobalSetup]
     public Task GlobalSetup()
     {

--- a/Solutions/Corvus.Json.Benchmarking/ValidateSmallDocument.cs
+++ b/Solutions/Corvus.Json.Benchmarking/ValidateSmallDocument.cs
@@ -41,7 +41,7 @@ public class ValidateSmallDocument
     /// <summary>
     /// Global setup.
     /// </summary>
-    /// <returns>A <see cref="Task"/> which completes once cleanup is complete.</returns>
+    /// <returns>A <see cref="Task"/> which completes once clean-up is complete.</returns>
     [GlobalSetup]
     public Task GlobalSetup()
     {
@@ -53,9 +53,9 @@ public class ValidateSmallDocument
     }
 
     /// <summary>
-    /// Global cleanup.
+    /// Global clean-up.
     /// </summary>
-    /// <returns>A <see cref="Task"/> which completes once cleanup is complete.</returns>
+    /// <returns>A <see cref="Task"/> which completes once clean-up is complete.</returns>
     [GlobalCleanup]
     public Task GlobalCleanup()
     {

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/IJsonSchemaBuilder.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/IJsonSchemaBuilder.cs
@@ -27,6 +27,22 @@ public interface IJsonSchemaBuilder
     /// <param name="rebase">Indicates whether to rebase the root reference as if it were a root document.</param>
     /// <param name="baseUriToNamespaceMap">A map of base URIs to namespaces to use for specific types.</param>
     /// <param name="rootTypeName">A specific root type name for the root entity.</param>
-    /// <returns>A <see cref="Task"/> which completes once the types are built. The tuple provides the root type name, and the generated types.</returns>
-    Task<(string RootTypeName, ImmutableDictionary<JsonReference, TypeAndCode> GeneratedTypes)> BuildTypesFor(JsonReference reference, string rootNamespace, bool rebase = false, ImmutableDictionary<string, string>? baseUriToNamespaceMap = null, string? rootTypeName = null);
+    /// <returns>A <see cref="ValueTask"/> which completes once the types are built. The tuple provides the root type name, and the generated types.</returns>
+    ValueTask<(string RootTypeName, ImmutableDictionary<JsonReference, TypeAndCode> GeneratedTypes)> BuildTypesFor(JsonReference reference, string rootNamespace, bool rebase = false, ImmutableDictionary<string, string>? baseUriToNamespaceMap = null, string? rootTypeName = null);
+
+    /// <summary>
+    /// Builds types for the schema provided by the given reference.
+    /// </summary>
+    /// <param name="reference">a uri-reference to the schema in which to build the types.</param>
+    /// <param name="rootNamespace">The root namespace to use for types.</param>
+    /// <param name="rebase">Indicates whether to rebase the root reference as if it were a root document.</param>
+    /// <param name="baseUriToNamespaceMap">A map of base URIs to namespaces to use for specific types.</param>
+    /// <param name="rootTypeName">A specific root type name for the root entity.</param>
+    /// <returns>A <see cref="ValueTask"/> which completes once the types are built. The tuple provides the root type name, and the generated types.</returns>
+    /// <exception cref="InvalidOperationException">A required document was not preloaded via <see cref="AddDocument(string, JsonDocument)"/>.</exception>
+    /// <remarks>
+    /// Unlike <see cref="BuildTypesFor(JsonReference, string, bool, ImmutableDictionary{string, string}?, string?)"/>, this requires all documents to
+    /// have been preloaded by the <see cref="IDocumentResolver"/> - typically via <see cref="AddDocument(string, JsonDocument)"/>.
+    /// </remarks>
+    (string RootTypeName, ImmutableDictionary<JsonReference, TypeAndCode> GeneratedTypes) SafeBuildTypesFor(JsonReference reference, string rootNamespace, bool rebase = false, ImmutableDictionary<string, string>? baseUriToNamespaceMap = null, string? rootTypeName = null);
 }

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaRegistry.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaRegistry.cs
@@ -39,9 +39,9 @@ internal class JsonSchemaRegistry
     /// <param name="jsonSchemaPath">The path to the JSON schema root document.</param>
     /// <param name="rebaseAsRoot">Whether to rebase this path as a root document. This should only be done for a JSON schema island in a larger non-schema document.
     /// If <see langoword="true"/>, then references in this document should be taken as if the fragment was the root of a document.</param>
-    /// <returns>A <see cref="Task"/> which, when complete, provides the root scope for the document (which may be a generated $ref for a path with a fragment), and the base reference to the document containing the root element.</returns>
+    /// <returns>A <see cref="ValueTask"/> which, when complete, provides the root scope for the document (which may be a generated $ref for a path with a fragment), and the base reference to the document containing the root element.</returns>
     /// <remarks><paramref name="jsonSchemaPath"/> must point to a root scope. If it has a pointer into the document, then <paramref name="rebaseAsRoot"/> must be true.</remarks>
-    public async Task<(JsonReference RootUri, JsonReference BaseReference)> RegisterDocumentSchema(JsonReference jsonSchemaPath, bool rebaseAsRoot = false)
+    public async ValueTask<(JsonReference RootUri, JsonReference BaseReference)> RegisterDocumentSchema(JsonReference jsonSchemaPath, bool rebaseAsRoot = false)
     {
         if (SchemaReferenceNormalization.TryNormalizeSchemaReference(jsonSchemaPath, out string? result))
         {
@@ -104,7 +104,7 @@ internal class JsonSchemaRegistry
 
         return (this.AddSchemaAndSubschema(basePath, baseSchema), basePath);
 
-        async Task<JsonReference> AddSchemaForUpdatedPathAndElement(JsonReference jsonSchemaPath, JsonElement newBase)
+        async ValueTask<JsonReference> AddSchemaForUpdatedPathAndElement(JsonReference jsonSchemaPath, JsonElement newBase)
         {
             this.documentResolver.AddDocument(jsonSchemaPath, GetDocumentFrom(newBase));
             JsonElement? resolvedBase = await this.documentResolver.TryResolve(jsonSchemaPath).ConfigureAwait(false) ?? throw new InvalidOperationException($"Expected to find a rebased schema at {jsonSchemaPath}");

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.References.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.References.cs
@@ -490,7 +490,7 @@ public partial class JsonSchemaTypeBuilder
         }
     }
 
-    private async Task<LocatedSchema?> ResolveBaseReference(JsonReference baseSchemaForReferenceLocation)
+    private async ValueTask<LocatedSchema?> ResolveBaseReference(JsonReference baseSchemaForReferenceLocation)
     {
         if (!this.schemaRegistry.TryGetValue(baseSchemaForReferenceLocation, out LocatedSchema? baseReferenceSchema))
         {

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CodeGeneration/JsonSchemaTypeBuilder.cs
@@ -46,13 +46,13 @@ public partial class JsonSchemaTypeBuilder
     /// If <see langword="true"/>, then references in this document should be taken as if the fragment was the root of a document. This will effectively generate a custom $id for the root scope.</param>
     /// <param name="baseUriToNamespaceMap">An optional map of base URIs in the document to namespaces in which to generate the types.</param>
     /// <param name="rootTypeName">An optional explicit type name for the root element.</param>
-    /// <returns>A <see cref="Task"/> which, when complete, provides the requested type declaration.</returns>
+    /// <returns>A <see cref="ValueTask"/> which, when complete, provides the requested type declaration.</returns>
     /// <remarks>
     /// <para>This method may be called multiple times to build up a set of related types, perhaps from multiple fragments of a single document, or a family of related documents.</para>
     /// <para>Any re-used schema will (if possible) be reduced to the same type, to build a single coherent type system.</para>
     /// <para>Once you have finished adding types, call <see cref="TypeDeclaration.GetTypesToGenerate()"/> to retrieve the set of types that need to be built for each root type you wish to build.</para>
     /// </remarks>
-    public async Task<TypeDeclaration?> AddTypeDeclarationsFor(JsonReference documentPath, string rootNamespace, bool rebaseAsRoot = false, ImmutableDictionary<string, string>? baseUriToNamespaceMap = null, string? rootTypeName = null)
+    public async ValueTask<TypeDeclaration?> AddTypeDeclarationsFor(JsonReference documentPath, string rootNamespace, bool rebaseAsRoot = false, ImmutableDictionary<string, string>? baseUriToNamespaceMap = null, string? rootTypeName = null)
     {
         // First we do a document "load" - this enables us to build the map of the schema, anchors etc.
         (JsonReference scope, JsonReference baseReference) = await this.schemaRegistry.RegisterDocumentSchema(documentPath, rebaseAsRoot).ConfigureAwait(false);
@@ -90,8 +90,8 @@ public partial class JsonSchemaTypeBuilder
     /// </summary>
     /// <param name="reference">The reference to the document.</param>
     /// <param name="rebaseToRootPath">Whether we are rebasing the element to a root path.</param>
-    /// <returns>A <see cref="Task{ValidationSemantics}"/> that, when complete, provides the validation semantics for the reference.</returns>
-    public async Task<ValidationSemantics> GetValidationSemantics(JsonReference reference, bool rebaseToRootPath)
+    /// <returns>A <see cref="ValueTask{ValidationSemantics}"/> that, when complete, provides the validation semantics for the reference.</returns>
+    public async ValueTask<ValidationSemantics> GetValidationSemantics(JsonReference reference, bool rebaseToRootPath)
     {
         if (!rebaseToRootPath)
         {
@@ -224,13 +224,13 @@ public partial class JsonSchemaTypeBuilder
         }
     }
 
-    private async Task<TypeDeclaration> BuildTypeDeclarationFor(LocatedSchema baseSchema)
+    private async ValueTask<TypeDeclaration> BuildTypeDeclarationFor(LocatedSchema baseSchema)
     {
         WalkContext context = new(this, baseSchema);
         return await this.BuildTypeDeclarationFor(context).ConfigureAwait(false);
     }
 
-    private async Task<TypeDeclaration> BuildTypeDeclarationFor(WalkContext context)
+    private async ValueTask<TypeDeclaration> BuildTypeDeclarationFor(WalkContext context)
     {
         if (!this.schemaRegistry.TryGetValue(context.SubschemaLocation, out LocatedSchema? schema))
         {

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CompoundDocumentResolver.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/CompoundDocumentResolver.cs
@@ -34,7 +34,7 @@ public class CompoundDocumentResolver : IDocumentResolver
     }
 
     /// <inheritdoc/>
-    public async Task<JsonElement?> TryResolve(JsonReference reference)
+    public async ValueTask<JsonElement?> TryResolve(JsonReference reference)
     {
         this.CheckDisposed();
         string uri = reference.Uri.ToString();
@@ -77,7 +77,7 @@ public class CompoundDocumentResolver : IDocumentResolver
     /// <inheritdoc/>
     public void Dispose()
     {
-        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        // Do not change this code. Put clean-up code in 'Dispose(bool disposing)' method
         this.Dispose(disposing: true);
         GC.SuppressFinalize(this);
     }
@@ -116,9 +116,13 @@ public class CompoundDocumentResolver : IDocumentResolver
 
     private void CheckDisposed()
     {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(this.disposedValue, this);
+#else
         if (this.disposedValue)
         {
             throw new ObjectDisposedException(nameof(CompoundDocumentResolver));
         }
+#endif
     }
 }

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/FileSystemDocumentResolver.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/FileSystemDocumentResolver.cs
@@ -48,7 +48,7 @@ public class FileSystemDocumentResolver : IDocumentResolver
     }
 
     /// <inheritdoc/>
-    public async Task<JsonElement?> TryResolve(JsonReference reference)
+    public async ValueTask<JsonElement?> TryResolve(JsonReference reference)
     {
         this.CheckDisposed();
 
@@ -66,7 +66,11 @@ public class FileSystemDocumentResolver : IDocumentResolver
 
         try
         {
+#if NET8_0_OR_GREATER
+            await using Stream stream = File.OpenRead(path);
+#else
             using Stream stream = File.OpenRead(path);
+#endif
             result = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
             this.documents.Add(path, result);
             return JsonPointerUtilities.ResolvePointer(result, reference.Fragment);
@@ -87,7 +91,7 @@ public class FileSystemDocumentResolver : IDocumentResolver
     /// <inheritdoc/>
     public void Dispose()
     {
-        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        // Do not change this code. Put clean-up code in 'Dispose(bool disposing)' method
         this.Dispose(disposing: true);
         System.GC.SuppressFinalize(this);
     }
@@ -121,9 +125,13 @@ public class FileSystemDocumentResolver : IDocumentResolver
 
     private void CheckDisposed()
     {
+#if NET8_0_OR_GREATER
+        ObjectDisposedException.ThrowIf(this.disposedValue, this);
+#else
         if (this.disposedValue)
         {
             throw new ObjectDisposedException(nameof(CompoundDocumentResolver));
         }
+#endif
     }
 }

--- a/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/IDocumentResolver.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.Abstractions/Corvus.Json/IDocumentResolver.cs
@@ -17,8 +17,8 @@ public interface IDocumentResolver : IDisposable
     /// Gets the element from the document at the given <see cref="JsonReference.Uri"/> in the <paramref name="reference"/>.
     /// </summary>
     /// <param name="reference">The reference containing the document URI.</param>
-    /// <returns>A <see cref="Task{TResult}"/> which provides the <see cref="JsonDocument"/>, or <c>null</c> if it could not be retrieved.</returns>
-    Task<JsonElement?> TryResolve(JsonReference reference);
+    /// <returns>A <see cref="ValueTask{TResult}"/> which provides the <see cref="JsonDocument"/>, or <c>null</c> if it could not be retrieved.</returns>
+    ValueTask<JsonElement?> TryResolve(JsonReference reference);
 
     /// <summary>
     /// Add an existing document to the cache.

--- a/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
+++ b/Solutions/Corvus.Json.Specs/Corvus.Json.Specs.csproj
@@ -37,16 +37,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <SpecFlowObsoleteCodeBehindFiles Remove="Features\AdditionalSchema\Draft201909\derived-numeric-type.feature.cs" />
-	  <SpecFlowObsoleteCodeBehindFiles Remove="Features\AdditionalSchema\Draft201909\fixed-size-numeric-arays.feature.cs" />
-	  <SpecFlowObsoleteCodeBehindFiles Remove="Features\AdditionalSchema\Draft202012\derived-numeric-type - Copy.feature.cs" />
-	  <SpecFlowObsoleteCodeBehindFiles Remove="Features\AdditionalSchema\Draft6\derived-numeric-type.feature.cs" />
-	  <SpecFlowObsoleteCodeBehindFiles Remove="Features\AdditionalSchema\Draft6\fixed-size-numeric-arrays.feature.cs" />
-	  <SpecFlowObsoleteCodeBehindFiles Remove="Features\AdditionalSchema\Draft7\derived-numeric-type.feature.cs" />
-	  <SpecFlowObsoleteCodeBehindFiles Remove="Features\AdditionalSchema\Draft7\fixed-size-numeric-arrays.feature.cs" />
-	</ItemGroup>
-
-	<ItemGroup>
 		<PackageReference Include="Corvus.Testing.SpecFlow.NUnit" Version="3.0.2" />
 		<PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
 		<PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
@@ -80,30 +70,6 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <Compile Update="Features\AdditionalSchema\Draft201909\derived-numeric-type.feature.cs">
-	    <DependentUpon>%(Filename)</DependentUpon>
-	  </Compile>
-	  <Compile Update="Features\AdditionalSchema\Draft201909\fixed-size-numeric-arrays.feature.cs">
-	    <DependentUpon>fixed-size-numeric-arrays.feature</DependentUpon>
-	  </Compile>
-	  <Compile Update="Features\AdditionalSchema\Draft202012\derived-numeric-type-net80.feature.cs">
-	    <DependentUpon>derived-numeric-type-net80.feature</DependentUpon>
-	  </Compile>
-	  <Compile Update="Features\AdditionalSchema\Draft6\derived-numeric-type.feature.cs">
-	    <DependentUpon>%(Filename)</DependentUpon>
-	  </Compile>
-	  <Compile Update="Features\AdditionalSchema\Draft6\fixed-size-numeric-arrays.feature.cs">
-	    <DependentUpon>%(Filename)</DependentUpon>
-	  </Compile>
-	  <Compile Update="Features\AdditionalSchema\Draft7\derived-numeric-type.feature.cs">
-	    <DependentUpon>%(Filename)</DependentUpon>
-	  </Compile>
-	  <Compile Update="Features\AdditionalSchema\Draft7\fixed-size-numeric-arrays.feature.cs">
-	    <DependentUpon>%(Filename)</DependentUpon>
-	  </Compile>
-	</ItemGroup>
-
-	<ItemGroup>
 		<None Update="appsettings.json">
 			<CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
 		</None>
@@ -119,38 +85,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-	  <SpecFlowFeatureFiles Update="Features\AdditionalSchema\Draft201909\derived-numeric-type.feature">
-	    <Visible>$(UsingMicrosoftNETSdk)</Visible>
-	    <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
-	  </SpecFlowFeatureFiles>
-	  <SpecFlowFeatureFiles Update="Features\AdditionalSchema\Draft201909\fixed-size-numeric-arrays.feature">
-	    <Visible>$(UsingMicrosoftNETSdk)</Visible>
-	    <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
-	  </SpecFlowFeatureFiles>
-	  <SpecFlowFeatureFiles Update="Features\AdditionalSchema\Draft202012\derived-numeric-type-net80.feature">
-	    <Visible>$(UsingMicrosoftNETSdk)</Visible>
-	    <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
-	  </SpecFlowFeatureFiles>
-	  <SpecFlowFeatureFiles Update="Features\AdditionalSchema\Draft6\derived-numeric-type.feature">
-	    <Visible>$(UsingMicrosoftNETSdk)</Visible>
-	    <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
-	  </SpecFlowFeatureFiles>
-	  <SpecFlowFeatureFiles Update="Features\AdditionalSchema\Draft6\fixed-size-numeric-arrays.feature">
-	    <Visible>$(UsingMicrosoftNETSdk)</Visible>
-	    <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
-	  </SpecFlowFeatureFiles>
-	  <SpecFlowFeatureFiles Update="Features\AdditionalSchema\Draft7\derived-numeric-type.feature">
-	    <Visible>$(UsingMicrosoftNETSdk)</Visible>
-	    <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
-	  </SpecFlowFeatureFiles>
-	  <SpecFlowFeatureFiles Update="Features\AdditionalSchema\Draft7\fixed-size-numeric-arrays.feature">
-	    <Visible>$(UsingMicrosoftNETSdk)</Visible>
-	    <CodeBehindFile>%(RelativeDir)%(Filename).feature$(DefaultLanguageSourceExtension)</CodeBehindFile>
-	  </SpecFlowFeatureFiles>
-	</ItemGroup>
-
-	<ItemGroup>
 	  <Folder Include="Features\JsonSchema\" />
+	  <Folder Include="Features\SyncGenerator\" />
 	</ItemGroup>
 
 

--- a/Solutions/Corvus.Json.Specs/Fakes/FakeWebDocumentResolver.cs
+++ b/Solutions/Corvus.Json.Specs/Fakes/FakeWebDocumentResolver.cs
@@ -63,13 +63,13 @@ public class FakeWebDocumentResolver : IDocumentResolver
     /// <inheritdoc/>
     public void Dispose()
     {
-        // Do not change this code. Put cleanup code in 'Dispose(bool disposing)' method
+        // Do not change this code. Put clean-up code in 'Dispose(bool disposing)' method
         this.Dispose(disposing: true);
         System.GC.SuppressFinalize(this);
     }
 
     /// <inheritdoc/>
-    public async Task<JsonElement?> TryResolve(JsonReference reference)
+    public async ValueTask<JsonElement?> TryResolve(JsonReference reference)
     {
         this.CheckDisposed();
 

--- a/Solutions/Corvus.Json.Specs/Features/SyncGenerator/SyncGenerator.feature
+++ b/Solutions/Corvus.Json.Specs/Features/SyncGenerator/SyncGenerator.feature
@@ -1,0 +1,24 @@
+@draft2020-12
+
+Feature: synchronous code generation draft2020-12
+    In order to use json-schema
+    As a developer
+    I want to support synchronous code generation with pre-loaded files in draft2020-12
+
+Scenario Outline: type derived by reference supports implicit conversions
+	Given a schema file
+		"""
+		{
+			"type": "string"
+		}
+		"""
+	And the input data value <inputData>
+	And I synchronously generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance
+	Then the result will be <valid>
+
+Examples:
+	| inputData | valid |
+	| "hello"   | true  |
+	| 33        | false |

--- a/Solutions/Corvus.Json.Specs/Steps/JsonSchemaSteps.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/JsonSchemaSteps.cs
@@ -158,11 +158,11 @@ public class JsonSchemaSteps
     [Given(@"I create the instance by casting the ([^\s]*) (.*)")]
     public void GivenICreateTheInstanceByCastingTheSbyte(string numericType, string numericValue)
     {
-        IJsonValue value = this.driver.CastToInstance(this.scenarioContext.Get<Type>(SchemaType), numericType, numericValue);
+        IJsonValue value = JsonSchemaBuilderDriver.CastToInstance(this.scenarioContext.Get<Type>(SchemaType), numericType, numericValue);
         this.scenarioContext.Set(value, SchemaInstance);
     }
 
-    [When(@"I create the instance using FromValues with format '([^']*)' and input data '([^']*)'")]
+    [When("I create the instance using FromValues with format '([^']*)' and input data '([^']*)'")]
     public void WhenICreateTheInstanceUsingFromValuesWithFormatAndInputData(string format, string inputDataString)
     {
         try
@@ -200,7 +200,7 @@ public class JsonSchemaSteps
         {
             UInt128[] itemArray = BuildUInt128Array(inputDataString);
 
-            return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 #endif
 
@@ -208,28 +208,40 @@ public class JsonSchemaSteps
         {
             ulong[] itemArray = BuildUInt64Array(inputDataString);
 
-            return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 
         IJsonValue CreateUInt32Instance(string inputDataString)
         {
             uint[] itemArray = BuildUInt32Array(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+After:
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+*/
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 
         IJsonValue CreateUInt16Instance(string inputDataString)
         {
             ushort[] itemArray = BuildUInt16Array(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+After:
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+*/
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 
         IJsonValue CreateByteInstance(string inputDataString)
         {
             byte[] itemArray = BuildByteArray(inputDataString);
 
-            return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 
 #if NET8_0_OR_GREATER
@@ -237,7 +249,7 @@ public class JsonSchemaSteps
         {
             Int128[] itemArray = BuildInt128Array(inputDataString);
 
-            return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 #endif
 
@@ -245,49 +257,73 @@ public class JsonSchemaSteps
         {
             long[] itemArray = BuildInt64Array(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+After:
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+*/
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 
         IJsonValue CreateInt32Instance(string inputDataString)
         {
             int[] itemArray = BuildInt32Array(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+After:
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+*/
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 
         IJsonValue CreateInt16Instance(string inputDataString)
         {
             short[] itemArray = BuildInt16Array(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+After:
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+*/
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 
         IJsonValue CreateSByteInstance(string inputDataString)
         {
             sbyte[] itemArray = BuildSByteArray(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+After:
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+*/
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 
         IJsonValue CreateDecimalInstance(string inputDataString)
         {
             decimal[] itemArray = BuildDecimalArray(inputDataString);
 
-            return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 
         IJsonValue CreateDoubleInstance(string inputDataString)
         {
             double[] itemArray = BuildDoubleArray(inputDataString);
 
-            return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 
         IJsonValue CreateSingleInstance(string inputDataString)
         {
             float[] itemArray = BuildSingleArray(inputDataString);
 
-            return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 
 #if NET8_0_OR_GREATER
@@ -295,24 +331,24 @@ public class JsonSchemaSteps
         {
             Half[] itemArray = BuildHalfArray(inputDataString);
 
-            return this.driver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
+            return JsonSchemaBuilderDriver.CreateInstanceOfNumericArrayFromValues(this.scenarioContext.Get<Type>(SchemaType), itemArray);
         }
 #endif
     }
 
-    [Then(@"the result will not throw an exception")]
+    [Then("the result will not throw an exception")]
     public void ThenTheResultWillNotThrowAnException()
     {
         Assert.IsFalse(this.scenarioContext.ContainsKey(CreateException));
     }
 
-    [Then(@"the result will throw an exception")]
+    [Then("the result will throw an exception")]
     public void ThenTheResultWillThrowAnException()
     {
         Assert.IsTrue(this.scenarioContext.ContainsKey(CreateException));
     }
 
-    [Then(@"if an exception was not thrown then TryGetValues with format '([^']*)' will equal the input data '([^']*)'")]
+    [Then("if an exception was not thrown then TryGetValues with format '([^']*)' will equal the input data '([^']*)'")]
     public void ThenIfAnExceptionWasNotThrownThenTryGetValuesWithFormatWillEqualTheInputData(string format, string inputDataString)
     {
         if (this.scenarioContext.ContainsKey(CreateException))
@@ -348,7 +384,7 @@ public class JsonSchemaSteps
         {
             UInt128[] itemArray = BuildUInt128Array(inputDataString);
 
-            return this.driver.CompareInstanceOfNumericArrayWithValues(
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -359,7 +395,7 @@ public class JsonSchemaSteps
         {
             ulong[] itemArray = BuildUInt64Array(inputDataString);
 
-            return this.driver.CompareInstanceOfNumericArrayWithValues(
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -369,7 +405,13 @@ public class JsonSchemaSteps
         {
             uint[] itemArray = BuildUInt32Array(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CompareInstanceOfNumericArrayWithValues(
+After:
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
+*/
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -379,7 +421,13 @@ public class JsonSchemaSteps
         {
             ushort[] itemArray = BuildUInt16Array(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CompareInstanceOfNumericArrayWithValues(
+After:
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
+*/
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -389,7 +437,7 @@ public class JsonSchemaSteps
         {
             byte[] itemArray = BuildByteArray(inputDataString);
 
-            return this.driver.CompareInstanceOfNumericArrayWithValues(
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -400,7 +448,7 @@ public class JsonSchemaSteps
         {
             Int128[] itemArray = BuildInt128Array(inputDataString);
 
-            return this.driver.CompareInstanceOfNumericArrayWithValues(
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -411,7 +459,13 @@ public class JsonSchemaSteps
         {
             long[] itemArray = BuildInt64Array(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CompareInstanceOfNumericArrayWithValues(
+After:
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
+*/
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -421,7 +475,13 @@ public class JsonSchemaSteps
         {
             int[] itemArray = BuildInt32Array(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CompareInstanceOfNumericArrayWithValues(
+After:
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
+*/
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -431,7 +491,13 @@ public class JsonSchemaSteps
         {
             short[] itemArray = BuildInt16Array(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CompareInstanceOfNumericArrayWithValues(
+After:
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
+*/
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -441,7 +507,13 @@ public class JsonSchemaSteps
         {
             sbyte[] itemArray = BuildSByteArray(inputDataString);
 
+/* Unmerged change from project 'Corvus.Json.Specs (net481)'
+Before:
             return this.driver.CompareInstanceOfNumericArrayWithValues(
+After:
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
+*/
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -451,7 +523,7 @@ public class JsonSchemaSteps
         {
             decimal[] itemArray = BuildDecimalArray(inputDataString);
 
-            return this.driver.CompareInstanceOfNumericArrayWithValues(
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -461,7 +533,7 @@ public class JsonSchemaSteps
         {
             double[] itemArray = BuildDoubleArray(inputDataString);
 
-            return this.driver.CompareInstanceOfNumericArrayWithValues(
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -471,7 +543,7 @@ public class JsonSchemaSteps
         {
             float[] itemArray = BuildSingleArray(inputDataString);
 
-            return this.driver.CompareInstanceOfNumericArrayWithValues(
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -482,7 +554,7 @@ public class JsonSchemaSteps
         {
             Half[] itemArray = BuildHalfArray(inputDataString);
 
-            return this.driver.CompareInstanceOfNumericArrayWithValues(
+            return JsonSchemaBuilderDriver.CompareInstanceOfNumericArrayWithValues(
                 this.scenarioContext.Get<Type>(SchemaType),
                 this.scenarioContext.Get<IJsonValue>(SchemaInstance),
                 itemArray);
@@ -513,29 +585,64 @@ public class JsonSchemaSteps
         {
             if (this.scenarioContext.ContainsKey(InputDataPath))
             {
-                string inputDataPath = this.scenarioContext.Get<string>(InputDataPath);
-                type = await this.driver.GenerateTypeFor(
-                    false,
-#if NET8_0_OR_GREATER
-                    int.Parse(inputDataPath.AsSpan().Slice(12, 3)),
-#else
-                    int.Parse(inputDataPath.Substring(12, 3)),
-#endif
+                type = await this.driver.GenerateTypeForJsonSchemaTestSuite(
                     filename,
                     schemaPath,
-                    inputDataPath,
                     featureName,
-                    scenarioName,
-                    bool.Parse((string)this.scenarioContext.ScenarioInfo.Arguments[1]!)).ConfigureAwait(false);
+                    scenarioName).ConfigureAwait(false);
             }
             else
             {
                 string schema = this.scenarioContext.Get<string>(SchemaInstance);
-                type = await this.driver.GenerateTypeFor(
+                type = await this.driver.GenerateTypeForVirtualFile(
                     schema,
                     filename,
                     featureName,
                     scenarioName).ConfigureAwait(false);
+            }
+
+            this.featureContext.Set(type, key);
+        }
+
+        this.scenarioContext.Set(type, SchemaType);
+    }
+
+    /// <summary>
+    /// Synchronously generates the code for the schema in the scenario property <see cref="SchemaPath"/>, compiles it, and loads the assembly. The fully qualified type name is stored in a scenario property called <see cref="SchemaType"/>.
+    /// </summary>
+    [Given("I synchronously generate a type for the schema")]
+    public void GivenISynchronouslyGenerateATypeForTheSchema()
+    {
+        string featureName = Formatting.ToPascalCaseWithReservedWords(this.featureContext.FeatureInfo.Title).ToString();
+        string scenarioName = Formatting.ToPascalCaseWithReservedWords(this.scenarioContext.ScenarioInfo.Title).ToString();
+        string filename = this.scenarioContext.Get<string>(InputJsonFileName);
+        string schemaPath = this.scenarioContext.Get<string>(SchemaPath);
+        string key = filename + schemaPath;
+
+        Type type;
+
+        if (this.featureContext.ContainsKey(key))
+        {
+            type = this.featureContext.Get<Type>(key);
+        }
+        else
+        {
+            if (this.scenarioContext.ContainsKey(InputDataPath))
+            {
+                type = this.driver.SynchronouslyGenerateTypeForJsonSchemaTestSuite(
+                    filename,
+                    schemaPath,
+                    featureName,
+                    scenarioName);
+            }
+            else
+            {
+                string schema = this.scenarioContext.Get<string>(SchemaInstance);
+                type = this.driver.SynchronouslyGenerateTypeForVirtualFile(
+                    schema,
+                    filename,
+                    featureName,
+                    scenarioName);
             }
 
             this.featureContext.Set(type, key);
@@ -550,7 +657,7 @@ public class JsonSchemaSteps
     [Given("I construct an instance of the schema type from the data")]
     public void GivenIConstructAnInstanceOfTheSchemaTypeFromTheData()
     {
-        IJsonValue value = this.driver.CreateInstance(this.scenarioContext.Get<Type>(SchemaType), this.scenarioContext.Get<JsonElement>(InputData));
+        IJsonValue value = JsonSchemaBuilderDriver.CreateInstance(this.scenarioContext.Get<Type>(SchemaType), this.scenarioContext.Get<JsonElement>(InputData));
         this.scenarioContext.Set(value, SchemaInstance);
     }
 


### PR DESCRIPTION
Forces pre-load of required files.
Throws `InvalidOperationException` if the codepath goes async.
Replaced `Task<T>` with `ValueTask<T>` throughout the generator as the usual codepath is synchronous, even in the async case.