### PR TITLE
Added cancellability to generation.

### DIFF
--- a/Solutions/Corvus.Json.Benchmarking/packages.lock.json
+++ b/Solutions/Corvus.Json.Benchmarking/packages.lock.json
@@ -71,6 +71,21 @@
           "System.Text.Json": "8.0.0"
         }
       },
+      "Roslynator.Analyzers": {
+        "type": "Direct",
+        "requested": "[4.12.3, )",
+        "resolved": "4.12.3",
+        "contentHash": "6+O9GwAxOxJr1rZ4aaLiBiSH3pxDkJuXLE8qjo/JXLvGkZhKRLbAz30WA32RmJb5Nn1TmjZ2T3kWt3GJmEDj1w=="
+      },
+      "StyleCop.Analyzers": {
+        "type": "Direct",
+        "requested": "[1.2.0-beta.556, )",
+        "resolved": "1.2.0-beta.556",
+        "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
+        "dependencies": {
+          "StyleCop.Analyzers.Unstable": "1.2.0.556"
+        }
+      },
       "System.Private.Uri": {
         "type": "Direct",
         "requested": "[4.3.2, )",
@@ -434,6 +449,11 @@
         "dependencies": {
           "System.Memory": "4.5.3"
         }
+      },
+      "StyleCop.Analyzers.Unstable": {
+        "type": "Transitive",
+        "resolved": "1.2.0.556",
+        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
       },
       "System.Buffers": {
         "type": "Transitive",

--- a/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration/Draft201909/VocabularyAnalyser.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.201909/Corvus.Json.CodeGeneration/Draft201909/VocabularyAnalyser.cs
@@ -56,12 +56,12 @@ public sealed class VocabularyAnalyser : IVocabularyAnalyser
             this.documentResolver,
             this.vocabularyRegistry,
             schemaInstance,
-            AnalyseChild).ConfigureAwait(false);
+            AnalyseChild);
     }
 
     private static async ValueTask<IVocabulary?> AnalyseChild(IDocumentResolver documentResolver, VocabularyRegistry vocabularyRegistry, JsonReference childSchema)
     {
-        JsonElement? childSchemaInstance = await documentResolver.TryResolve(childSchema).ConfigureAwait(false);
+        JsonElement? childSchemaInstance = await documentResolver.TryResolve(childSchema);
         if (childSchemaInstance is null)
         {
             return default;
@@ -73,7 +73,7 @@ public sealed class VocabularyAnalyser : IVocabularyAnalyser
             documentResolver,
             vocabularyRegistry,
             childSchemaInstance.Value,
-            null).ConfigureAwait(false);
+            null);
     }
 
     private static async ValueTask<IVocabulary?> TryGetVocabularyCore(IDocumentResolver documentResolver, VocabularyRegistry vocabularyRegistry, JsonElement schemaInstance, Func<IDocumentResolver, VocabularyRegistry, JsonReference, ValueTask<IVocabulary?>>? processUnknownSchema)
@@ -101,7 +101,7 @@ public sealed class VocabularyAnalyser : IVocabularyAnalyser
         {
             if (dollarSchema.GetString() is string s)
             {
-                IVocabulary? result = await processUnknownSchema(documentResolver, vocabularyRegistry, new(s)).ConfigureAwait(false);
+                IVocabulary? result = await processUnknownSchema(documentResolver, vocabularyRegistry, new(s));
                 if (result is IVocabulary v)
                 {
                     return v;

--- a/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration/Draft202012/VocabularyAnalyser.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.202012/Corvus.Json.CodeGeneration/Draft202012/VocabularyAnalyser.cs
@@ -58,12 +58,12 @@ public sealed class VocabularyAnalyser : IVocabularyAnalyser
             this.documentResolver,
             this.vocabularyRegistry,
             schemaInstance,
-            AnalyseChild).ConfigureAwait(false);
+            AnalyseChild);
     }
 
     private static async ValueTask<IVocabulary?> AnalyseChild(IDocumentResolver documentResolver, VocabularyRegistry vocabularyRegistry, JsonReference childSchema)
     {
-        JsonElement? childSchemaInstance = await documentResolver.TryResolve(childSchema).ConfigureAwait(false);
+        JsonElement? childSchemaInstance = await documentResolver.TryResolve(childSchema);
         if (childSchemaInstance is null)
         {
             return default;
@@ -75,7 +75,7 @@ public sealed class VocabularyAnalyser : IVocabularyAnalyser
             documentResolver,
             vocabularyRegistry,
             childSchemaInstance.Value,
-            null).ConfigureAwait(false);
+            null);
     }
 
     private static async ValueTask<IVocabulary?> TryGetVocabularyCore(IDocumentResolver documentResolver, VocabularyRegistry vocabularyRegistry, JsonElement schemaInstance, Func<IDocumentResolver, VocabularyRegistry, JsonReference, ValueTask<IVocabulary?>>? processUnknownSchema)
@@ -103,7 +103,7 @@ public sealed class VocabularyAnalyser : IVocabularyAnalyser
         {
             if (dollarSchema.GetString() is string s)
             {
-                IVocabulary? result = await processUnknownSchema(documentResolver, vocabularyRegistry, new(s)).ConfigureAwait(false);
+                IVocabulary? result = await processUnknownSchema(documentResolver, vocabularyRegistry, new(s));
                 if (result is IVocabulary v)
                 {
                     return v;

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Array.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Array.cs
@@ -17,6 +17,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendEmptyArrayInstanceStaticProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("EmptyArray")
             .AppendSeparatorLine()
@@ -39,6 +44,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendArrayRankStaticProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayRank() is int rank)
         {
             generator
@@ -66,6 +76,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendArrayDimensionStaticProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayDimension() is int dimension)
         {
             generator
@@ -93,6 +108,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendArrayValueBufferSizeStaticProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayValueBufferSize() is int valueBufferSize)
         {
             generator
@@ -125,6 +145,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendTryGetNumericValuesMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayItemsType() is not ArrayItemsTypeDeclaration arrayItemsType ||
             arrayItemsType.ReducedType.PreferredDotnetNumericTypeName() is not string preferredNumericTypeName ||
             typeDeclaration.ArrayRank() is not int arrayRank)
@@ -181,6 +206,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendForJsonElementBacking(CodeGenerator generator, string fieldName, string preferredNumericTypeName, string arrayItemsTypeName, int arrayRank)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("if (this.", fieldName, ".ValueKind != JsonValueKind.Number)")
                 .AppendBlockIndent(
@@ -241,6 +271,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendForArrayBacking(CodeGenerator generator, string fieldName, string preferredNumericTypeName, string arrayItemsTypeName, int arrayRank)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("foreach (", arrayItemsTypeName, " item in this.", fieldName, ")")
                 .AppendLineIndent("{")
@@ -292,6 +327,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendArrayIndexerProperties(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendSeparatorLine();
 
@@ -339,6 +379,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendTupleItemProperties(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.TupleType() is TupleTypeDeclaration tupleType)
         {
             generator
@@ -346,6 +391,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 0; i < tupleType.ItemsTypes.Length; i++)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 TypeDeclaration tupleItem = tupleType.ItemsTypes[i].ReducedType;
                 generator
                     .ReserveName($"Item{i + 1}")
@@ -435,6 +485,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendArrayAddMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         bool isTupleOrHasArrayItemsType = typeDeclaration.IsTuple() || typeDeclaration.ArrayItemsType() is not null;
 
         return generator
@@ -470,6 +525,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendArrayRemoveMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         bool isTupleOrHasArrayItemsType = typeDeclaration.IsTuple() || typeDeclaration.ArrayItemsType() is not null;
 
         return generator
@@ -490,6 +550,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendCorvusArrayHelpers(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("__CorvusArrayHelpers")
             .AppendSeparatorLine()
@@ -686,6 +751,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendGetImmutableListInsertingEnumerable(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendIndent("if (arrayInstance.")
                 .Append(fieldName)
@@ -701,6 +771,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendInsertEnumerable(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("try")
                 .AppendLineIndent("{")
@@ -720,6 +795,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendGetImmutableListInserting(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendIndent("if (arrayInstance.")
                 .Append(fieldName)
@@ -735,6 +815,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendInsertAtIndex(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("try")
                 .AppendLineIndent("{")
@@ -754,6 +839,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendGetImmutableListWithoutRange(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendIndent("if (arrayInstance.")
                 .Append(fieldName)
@@ -769,6 +859,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendRemoveRange(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("try")
                 .AppendLineIndent("{")
@@ -788,6 +883,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendGetImmutableListWithout(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendIndent("if (arrayInstance.")
                 .Append(fieldName)
@@ -803,6 +903,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendGetImmutableListReplacingValue(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendIndent("if (arrayInstance.")
                 .Append(fieldName)
@@ -818,6 +923,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendGetImmutableListSettingIndexToValue(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendIndent("if (arrayInstance.")
                 .Append(fieldName)
@@ -833,6 +943,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendSetItemAtIndexToValue(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("try")
                 .AppendLineIndent("{")
@@ -852,6 +967,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendBuildImmutableList(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendIndent("if (arrayInstance.")
                 .Append(fieldName)
@@ -881,6 +1001,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendEnumerateArrayMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         bool hasStrongType = false;
 
         if (typeDeclaration.ArrayItemsType() is ArrayItemsTypeDeclaration arrayItemsType)
@@ -976,6 +1101,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendGetArrayLengthMethod(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("GetArrayLength")
             .AppendSeparatorLine()
@@ -998,6 +1128,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsImmutableListMethods(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("AsImmutableList")
             .ReserveNameIfNotReserved("AsImmutableListBuilder")
@@ -1026,6 +1161,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendCollectionEnumerableMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.IsTuple())
         {
             return generator;
@@ -1063,6 +1203,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendCreateTupleFactoryMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.TupleType() is TupleTypeDeclaration tupleType)
         {
             generator
@@ -1077,6 +1222,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 0; i < tupleType.ItemsTypes.Length; ++i)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 generator
                     .AppendIndent("/// <param name=\"item")
                     .Append(i + 1)
@@ -1093,6 +1243,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 0; i < tupleType.ItemsTypes.Length; ++i)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 if (i > 0)
                 {
                     generator.Append(", ");
@@ -1127,6 +1282,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendTupleConversions(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         // We can only do ValueTuple<T1,T2> so there must be more than two items in tuple.
         if (typeDeclaration.TupleType() is TupleTypeDeclaration tupleType &&
             tupleType.ItemsTypes.Length > 1)
@@ -1190,6 +1350,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("From")
@@ -1222,6 +1387,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         // Don't generate this if we have a tuple type or a fixed-size numeric array.
         if (typeDeclaration.IsFixedSizeArray() || typeDeclaration.IsTuple())
         {
@@ -1265,6 +1435,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.IsFixedSizeArray() || typeDeclaration.IsTuple())
         {
             return generator;
@@ -1338,6 +1513,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendFromRangeFactoryMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string arrayItemsType =
             typeDeclaration.ArrayItemsType()?.ReducedType.FullyQualifiedDotnetTypeName()
             ?? WellKnownTypeDeclarations.JsonAny.FullyQualifiedDotnetTypeName();
@@ -1361,6 +1541,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendFromValuesFactoryMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (!typeDeclaration.IsFixedSizeNumericArray())
         {
             return generator;
@@ -1415,6 +1600,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendFromSerializedItemsMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.IsFixedSizeArray() || typeDeclaration.IsTuple() || typeDeclaration.ArrayItemsType() is not null)
         {
             return generator;
@@ -1472,6 +1662,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendLine("#if NET8_0_OR_GREATER")
             .AppendIndent("[CollectionBuilder(typeof(")
@@ -1482,6 +1677,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendArrayIndexer(this CodeGenerator generator, TypeDeclaration typeDeclaration, string itemsTypeName, bool isExplicit)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (!isExplicit)
         {
             generator
@@ -1523,6 +1723,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendArrayItem(CodeGenerator generator, string fieldName, string itemsTypeName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("try")
                 .AppendLineIndent("{")
@@ -1554,6 +1759,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static void AppendArrayIndex(CodeGenerator generator, string fieldName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return;
+        }
+
         generator
             .AppendBlockIndent(
                 """
@@ -1583,6 +1793,11 @@ internal static partial class CodeGeneratorExtensions
     {
         for (int i = 1; i <= 7; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendGenericFromItemsFactoryMethod(typeDeclaration, i);
         }
@@ -1594,6 +1809,11 @@ internal static partial class CodeGeneratorExtensions
     {
         for (int i = 1; i <= 7; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendNonGenericFromItemsFactoryMethod(typeDeclaration, arrayItemsType, i);
         }
@@ -1603,6 +1823,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendFromRangeFactoryMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration, string arrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (!(typeDeclaration.IsFixedSizeArray() || typeDeclaration.IsTuple()))
         {
             // Adds the strongly typed implementation for either JsonAny or any other type.
@@ -1665,6 +1890,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AddExplicitImplementations(CodeGenerator generator, TypeDeclaration typeDeclaration)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                    .ReserveNameIfNotReserved("FromRange")
                    .AppendSeparatorLine()
@@ -1711,6 +1941,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendNonGenericFromItemsFactoryMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration, string arrayItemsType, int itemCount)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -1721,6 +1956,11 @@ internal static partial class CodeGeneratorExtensions
 
         for (int i = 1; i <= itemCount; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendIndent("/// <param name=\"item")
                 .Append(i)
@@ -1745,6 +1985,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendGenericFromItemsFactoryMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration, int itemCount)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -1755,6 +2000,11 @@ internal static partial class CodeGeneratorExtensions
 
         for (int i = 1; i <= itemCount; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendIndent("/// <typeparam name=\"TItem")
                 .Append(i)
@@ -1765,6 +2015,11 @@ internal static partial class CodeGeneratorExtensions
 
         for (int i = 1; i <= itemCount; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendIndent("/// <param name=\"item")
                 .Append(i)
@@ -1786,6 +2041,11 @@ internal static partial class CodeGeneratorExtensions
 
         for (int i = 1; i <= itemCount; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendIndent("where TItem")
                 .Append(i)
@@ -1805,12 +2065,22 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendReturnNewArrayTypeBuiltFromItems(this CodeGenerator generator, int itemCount, bool isJsonAny)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendSeparatorLine()
             .AppendIndent("return new([");
 
         for (int i = 1; i <= itemCount; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (i > 1)
             {
                 generator.Append(", ");
@@ -1833,6 +2103,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendBuildNumericArray(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         TypeDeclaration arrayItemsType =
                  typeDeclaration.ArrayItemsType()?.ReducedType
                 ?? throw new InvalidOperationException("Unexpected missing ArrayItemsType() in numeric array build.");
@@ -1869,6 +2144,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendReturnNewArrayTypeBuiltFromValue(this CodeGenerator generator, string valueName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendIndent("return new([..")
             .Append(valueName)
@@ -1877,6 +2157,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendFromRangeBuiltInTypeFactoryMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration, string itemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayItemsType() is not null || typeDeclaration.IsTuple())
         {
             return generator;
@@ -1907,6 +2192,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendInsertRangeTArray(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -1940,6 +2230,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendInsertItemJsonAny(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -1970,6 +2265,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendInsertItemArrayItemsType(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayItemsType() is ArrayItemsTypeDeclaration arrayItemsType)
         {
             generator
@@ -1992,6 +2292,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendInsertRangeEnumerableJsonAny(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2022,6 +2327,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendInsertRangeEnumerableArrayItemsType(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayItemsType() is ArrayItemsTypeDeclaration arrayItemsType)
         {
             generator
@@ -2044,6 +2354,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendInsertRangeEnumerableTItem(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2077,6 +2392,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendAddRangeEnumerableJsonAny(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2112,6 +2432,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendAddRangeEnumerableArrayItemsType(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayItemsType() is ArrayItemsTypeDeclaration arrayItemsType)
         {
             generator
@@ -2144,6 +2469,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendAddRangeEnumerableTItem(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2186,6 +2516,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendAddParamsJsonAny(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2225,6 +2560,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendAddParamsArrayItemsType(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayItemsType() is ArrayItemsTypeDeclaration arrayItemsType)
         {
             generator
@@ -2257,6 +2597,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendAddRangeTArray(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2299,6 +2644,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendAddItemJsonAny(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2334,6 +2684,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendAddItemArrayItemsType(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayItemsType() is ArrayItemsTypeDeclaration arrayItemsType)
         {
             generator
@@ -2361,6 +2716,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendRemoveJsonAny(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2391,6 +2751,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendRemoveArrayItemsType(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayItemsType() is ArrayItemsTypeDeclaration arrayItemsType)
         {
             generator
@@ -2413,6 +2778,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendReplaceJsonAny(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2443,6 +2813,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendReplaceArrayItemsType(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayItemsType() is ArrayItemsTypeDeclaration arrayItemsType)
         {
             generator
@@ -2467,6 +2842,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendRemoveAt(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2497,6 +2877,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendRemoveRange(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2527,6 +2912,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendSetItemJsonAny(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isTupleOrHasArrayItemsType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         if (isTupleOrHasArrayItemsType)
@@ -2557,6 +2947,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendSetItemArrayItemsType(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ArrayItemsType() is ArrayItemsTypeDeclaration arrayItemsType)
         {
             generator

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Boolean.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Boolean.cs
@@ -16,6 +16,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendTryGetBoolean(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("TryGetBoolean")
             .AppendSeparatorLine()
@@ -51,6 +56,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendGetBoolean(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("GetBoolean")
             .AppendSeparatorLine()

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Documentation.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Documentation.cs
@@ -17,6 +17,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendDocumentation(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ShortDocumentation() is string shortDocumentation)
         {
             generator.AppendSummary(shortDocumentation);
@@ -38,6 +43,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendSummary(this CodeGenerator generator, string summaryText)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendLineIndent("/// <summary>")
             .AppendBlockIndentWithPrefix(summaryText, "/// ")
@@ -56,6 +66,11 @@ internal static partial class CodeGeneratorExtensions
     /// </remarks>
     public static CodeGenerator AppendRemarks(this CodeGenerator generator, string? longDocumentation, string[]? documentationExamples)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (longDocumentation is null && documentationExamples is null)
         {
             return generator;
@@ -85,12 +100,22 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendExamples(this CodeGenerator generator, string[] examples)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendLineIndent("/// <para>")
             .AppendLineIndent("/// Examples:");
 
         foreach (string example in examples)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator.AppendExample(example);
         }
 
@@ -106,6 +131,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendExample(this CodeGenerator generator, string example)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendLineIndent("/// <example>")
             .AppendLineIndent("/// <code>")

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Numeric.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Numeric.cs
@@ -18,6 +18,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendEqualsBinaryJsonNumber(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("Equals")
             .AppendSeparatorLine()
@@ -42,6 +47,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendJsonElementComparison(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendIndent("return this.")
                 .Append(fieldName)
@@ -59,6 +69,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsDotnetNumericValue(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.PreferredDotnetNumericTypeName() is string numericTypeName)
         {
             bool isNet80OrGreaterType = IsNet8OrGreaterNumericType(numericTypeName);
@@ -103,6 +118,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsBinaryJsonNumber(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -125,6 +145,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendParse(CodeGenerator generator, string fieldName, TypeDeclaration typeDeclaration)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator.AppendLineIndent(
                 "return BinaryJsonNumber.FromJson(this.",
                 fieldName,
@@ -142,6 +167,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumberFormatPublicStaticMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.NumberFormatHandlers.AppendFormatPublicStaticMethods(generator, typeDeclaration, format);
@@ -158,6 +188,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumberFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.NumberFormatHandlers.AppendFormatPublicMethods(generator, typeDeclaration, format);
@@ -174,6 +209,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumberFormatPrivateStaticMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.NumberFormatHandlers.AppendFormatPrivateStaticMethods(generator, typeDeclaration, format);
@@ -190,6 +230,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumberFormatPrivateMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.NumberFormatHandlers.AppendFormatPrivateMethods(generator, typeDeclaration, format);
@@ -206,6 +251,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumberFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.NumberFormatHandlers.AppendFormatConversionOperators(generator, typeDeclaration, format);
@@ -222,6 +272,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumberFormatPublicStaticProperties(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.NumberFormatHandlers.AppendFormatPublicStaticProperties(generator, typeDeclaration, format);
@@ -238,6 +293,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumberFormatPublicProperties(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.NumberFormatHandlers.AppendFormatPublicProperties(generator, typeDeclaration, format);
@@ -254,6 +314,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumberFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.NumberFormatHandlers.AppendFormatConstructors(generator, typeDeclaration, format);
@@ -270,6 +335,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumericOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendNumericComparison(typeDeclaration, "<", "Less than operator.", "<see langword=\"true\"/> if the left is less than the right, otherwise <see langword=\"false\"/>.")
             .AppendNumericComparison(typeDeclaration, "<=", "Less than or equals operator.", "<see langword=\"true\"/> if the left is less than or equal to the right, otherwise <see langword=\"false\"/>.")
@@ -294,6 +364,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumericConversions(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool allImplicit = false, bool fromOnly = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendNumericConversionsForDotnetType(typeDeclaration, "byte", "SafeGetByte", allImplicit: allImplicit, fromOnly: fromOnly)
             .AppendNumericConversionsForDotnetType(typeDeclaration, "decimal", "SafeGetDecimal", allImplicit: allImplicit, fromOnly: fromOnly)
@@ -319,6 +394,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumericEquals(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendNumericEqualsForDotnetType(typeDeclaration, "byte")
             .AppendNumericEqualsForDotnetType(typeDeclaration, "decimal")
@@ -346,6 +426,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumericEqualsForDotnetType(this CodeGenerator generator, TypeDeclaration typeDeclaration, string dotnetType, FrameworkType frameworkType = FrameworkType.All)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.PreferredDotnetNumericTypeName() != dotnetType)
         {
             return generator;
@@ -355,6 +440,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendEquals(CodeGenerator generator, string dotnetType)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .ReserveNameIfNotReserved("Equals")
                 .AppendSeparatorLine()
@@ -380,6 +470,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendJsonElementComparison(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent(
                     "return this.",
@@ -411,12 +506,22 @@ internal static partial class CodeGeneratorExtensions
         bool allImplicit = false,
         bool fromOnly = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendSeparatorLine();
 
         return ConditionalCodeSpecification.AppendConditional(generator, AppendConversions, frameworkType);
 
         void AppendConversions(CodeGenerator generator)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string operatorKind = typeDeclaration.PreferredDotnetNumericTypeName() == numericType || allImplicit ? "implicit" : "explicit";
 
             if (!fromOnly)
@@ -500,6 +605,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string preferredNumericTypeName =
             typeDeclaration.PreferredDotnetNumericTypeName()
             ?? throw new InvalidOperationException("There must be a preferred numeric type name for a numeric type");
@@ -555,6 +665,11 @@ internal static partial class CodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         string numericTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -575,6 +690,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendNumericCompare(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string backingName = generator.GetFieldNameInScope("backing");
         string numberBacking = generator.GetFieldNameInScope("numberBacking");
         string jsonElementBacking = generator.GetFieldNameInScope("jsonElementBacking");
@@ -688,6 +808,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendNumericUnaryOperator(this CodeGenerator generator, TypeDeclaration typeDeclaration, string op, string summary)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -714,6 +839,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendNumericBinaryOperator(this CodeGenerator generator, TypeDeclaration typeDeclaration, string op, string summary)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -742,6 +872,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendNumericComparison(this CodeGenerator generator, TypeDeclaration typeDeclaration, string op, string summary, string returns)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Object.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Object.cs
@@ -20,6 +20,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsPropertyBackingMethod(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("AsPropertyBacking")
             .AppendSeparatorLine()
@@ -49,6 +54,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendReadOnlyDictionaryProperties(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.FallbackObjectPropertyType() is FallbackObjectPropertyType propertyType
              && !propertyType.ReducedType.IsBuiltInJsonAnyType())
         {
@@ -79,6 +89,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendPropertyCount(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("Count")
             .AppendSeparatorLine()
@@ -102,6 +117,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void CountProperties(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("int count = 0;")
                 .AppendIndent("foreach (var _ in this.")
@@ -124,6 +144,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendReadOnlyDictionaryMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.FallbackObjectPropertyType() is FallbackObjectPropertyType propertyType
              && !propertyType.ReducedType.IsBuiltInJsonAnyType())
         {
@@ -180,8 +205,18 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendPropertyAccessors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (PropertyDeclaration property in typeDeclaration.PropertyDeclarations)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             bool isNullable = typeDeclaration.OptionalAsNullable() && property.RequiredOrOptional == RequiredOrOptional.Optional;
             generator
                 .AppendSeparatorLine()
@@ -199,6 +234,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendJsonBackedAccessor(CodeGenerator generator, TypeDeclaration typeDeclaration, string fieldName, PropertyDeclaration property)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("if (this.", fieldName, ".ValueKind != JsonValueKind.Object)")
                 .AppendLineIndent("{")
@@ -238,6 +278,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendObjectBackedAccessor(CodeGenerator generator, TypeDeclaration typeDeclaration, string fieldName, PropertyDeclaration property)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendSeparatorLine()
                 .AppendLineIndent(
@@ -288,6 +333,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendJsonPropertyNamesClass(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (!typeDeclaration.HasPropertyDeclarations)
         {
             return generator;
@@ -303,6 +353,11 @@ internal static partial class CodeGeneratorExtensions
         int i = 0;
         foreach (PropertyDeclaration property in typeDeclaration.PropertyDeclarations)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (i > 0)
             {
                 generator
@@ -324,6 +379,11 @@ internal static partial class CodeGeneratorExtensions
 
         foreach (PropertyDeclaration property in typeDeclaration.PropertyDeclarations)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (i > 0)
             {
                 generator
@@ -355,6 +415,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendObjectIndexerProperties(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendSeparatorLine();
 
@@ -396,6 +461,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendEnumerateObjectMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveNameIfNotReserved("EnumerateObject");
 
@@ -424,16 +494,31 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendPatternPropertiesMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.PatternProperties() is IReadOnlyDictionary<IObjectPatternPropertyValidationKeyword, IReadOnlyCollection<PatternPropertyDeclaration>> patternProperties)
         {
             foreach (IObjectPatternPropertyValidationKeyword keyword in patternProperties.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 IReadOnlyCollection<PatternPropertyDeclaration> declarations = patternProperties[keyword];
                 int index = 1;
                 bool hasIndex = declarations.Count > 1;
 
                 foreach (PatternPropertyDeclaration declaration in declarations)
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return generator;
+                    }
+
                     string regexAccessor =
                         generator.GetStaticReadOnlyFieldNameInScope(
                             declaration.Keyword.Keyword,
@@ -488,16 +573,31 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendPatternPropertiesStaticProperties(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.PatternProperties() is IReadOnlyDictionary<IObjectPatternPropertyValidationKeyword, IReadOnlyCollection<PatternPropertyDeclaration>> patternProperties)
         {
             foreach (IObjectPatternPropertyValidationKeyword keyword in patternProperties.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 IReadOnlyCollection<PatternPropertyDeclaration> declarations = patternProperties[keyword];
                 int index = 1;
                 bool hasIndex = declarations.Count > 1;
 
                 foreach (PatternPropertyDeclaration declaration in declarations)
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return generator;
+                    }
+
                     string regexAccessor =
                         generator.GetStaticReadOnlyFieldNameInScope(
                             declaration.Keyword.Keyword,
@@ -531,13 +631,28 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendTryGetAsDependentSchemaMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.DependentSchemasSubschemaTypes() is IReadOnlyDictionary<IObjectPropertyDependentSchemasValidationKeyword, IReadOnlyCollection<DependentSchemaDeclaration>> dependencies)
         {
             HashSet<string> visitedTypeNames = [];
             foreach (IReadOnlyCollection<DependentSchemaDeclaration> declarations in dependencies.Values)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 foreach (DependentSchemaDeclaration declaration in declarations)
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return generator;
+                    }
+
                     if (!visitedTypeNames.Add(declaration.JsonPropertyName))
                     {
                         continue;
@@ -593,6 +708,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendCreateFactoryMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (!typeDeclaration.HasPropertyDeclarations)
         {
             return generator;
@@ -621,6 +741,11 @@ internal static partial class CodeGeneratorExtensions
 
         static MethodParameter[] BuildMethodParameters(CodeGenerator generator, TypeDeclaration typeDeclaration)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return [];
+            }
+
             // Filter out the constant values from the property list;
             // we don't need to supply them.
             return
@@ -660,11 +785,21 @@ internal static partial class CodeGeneratorExtensions
 
         static CodeGenerator AppendBuildObjectFromParameters(CodeGenerator generator, PropertyDeclaration[] properties)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendLineIndent("var builder = ImmutableList.CreateBuilder<JsonObjectProperty>();");
 
             foreach (PropertyDeclaration property in properties)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 if (property.RequiredOrOptional == RequiredOrOptional.Required)
                 {
                     AddRequiredProperty(generator, property);
@@ -682,6 +817,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AddRequiredProperty(CodeGenerator generator, PropertyDeclaration property)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string propertyNamesClass = generator.JsonPropertyNamesClassName();
             if (property.ReducedPropertyType.SingleConstantValue().ValueKind != JsonValueKind.Undefined)
             {
@@ -713,6 +853,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AddOptionalProperty(CodeGenerator generator, PropertyDeclaration property)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string propertyNamesClass = generator.JsonPropertyNamesClassName();
             string parameterName = generator.GetParameterNameInScope(property.DotnetPropertyName());
 
@@ -742,6 +887,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendFromPropertiesFactoryMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveNameIfNotReserved("FromProperties");
 
@@ -878,6 +1028,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendHasPropertiesMethod(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("HasProperties")
             .AppendSeparatorLine()
@@ -894,6 +1049,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void TestEnumerable(CodeGenerator generator, string fieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendIndent("using JsonElement.ObjectEnumerator enumerator = this.")
                 .Append(fieldName)
@@ -909,6 +1069,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendHasPropertyMethods(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("HasProperty")
             .AppendHasPropertyForJsonPropertyNameMethod()
@@ -925,6 +1090,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendTryGetPropertyMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("TryGetProperty")
             .AppendTryGetPropertyForJsonPropertyNameMethod(typeDeclaration)
@@ -945,6 +1115,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendRemovePropertyMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("RemoveProperty")
             .AppendRemovePropertyMethod(typeDeclaration, "in JsonPropertyName")
@@ -961,6 +1136,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendSetPropertyMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveNameIfNotReserved("SetProperty");
 
@@ -987,6 +1167,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendCorvusObjectHelpers(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("__CorvusObjectHelpers")
             .AppendSeparatorLine()
@@ -1028,6 +1213,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendPropertyDocumentation(this CodeGenerator generator, PropertyDeclaration property)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         bool optional = property.RequiredOrOptional == RequiredOrOptional.Optional;
 
         generator
@@ -1128,6 +1318,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendGetPropertyBackingWithout(this CodeGenerator generator, string dotnetTypeName, string parameterNameAndModifiers)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendBlockIndent(
@@ -1160,6 +1355,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendGetPropertyBackingWith(this CodeGenerator generator, string dotnetTypeName, string parameterNameAndModifiers)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendBlockIndent(
@@ -1192,6 +1392,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendSetPropertyMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration, string propertyTypeName, bool isGeneric = false, bool isExplicit = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendSeparatorLine();
 
@@ -1271,6 +1476,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendTryGetPropertyMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration, string propertyNameType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.FallbackObjectPropertyType() is FallbackObjectPropertyType propertyType && !propertyType.ReducedType.IsBuiltInJsonAnyType())
         {
             generator
@@ -1287,6 +1497,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendTryGetPropertyForJsonPropertyNameMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.FallbackObjectPropertyType() is FallbackObjectPropertyType propertyType && !propertyType.ReducedType.IsBuiltInJsonAnyType())
         {
             generator
@@ -1303,6 +1518,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendRemovePropertyMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration, string parameterTypeAndModifier)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <inheritdoc />")
@@ -1320,6 +1540,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendTryGetPropertyForJsonPropertyNameMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration, bool isExplicit, string? propertyTypeName = null, bool isGenericPropertyNameType = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendSeparatorLine();
 
@@ -1411,6 +1636,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void TryGetPropertyFromJsonElement(CodeGenerator generator, string fieldName, string? propertyTypeName, bool isGenericPropertyNameType)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("if (this.", fieldName, ".ValueKind != JsonValueKind.Object)")
                 .AppendLineIndent("{")
@@ -1458,6 +1688,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendTryGetPropertyMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration, string propertyNameType, bool isExplicit, string? propertyTypeName = null, bool isGenericPropertyNameType = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendSeparatorLine();
 
@@ -1551,6 +1786,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void TryGetPropertyFromJsonElement(CodeGenerator generator, string fieldName, string? propertyTypeName, bool isGenericPropertyNameType)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("if (this.", fieldName, ".ValueKind != JsonValueKind.Object)")
                 .AppendLineIndent("{")
@@ -1598,6 +1838,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static void TryGetPropertyFromImmutableDictionary(CodeGenerator generator, string fieldName, string? propertyTypeName, bool isGenericPropertyNameType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return;
+        }
+
         generator
             .AppendIndent("if (this.")
             .Append(fieldName)
@@ -1645,6 +1890,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendGenericTryGetPropertyMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration, string propertyNameType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.FallbackObjectPropertyType() is not null)
         {
             generator
@@ -1660,6 +1910,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendGenericTryGetPropertyForJsonPropertyNameMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.FallbackObjectPropertyType() is not null)
         {
             generator
@@ -1675,6 +1930,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendHasPropertyMethod(this CodeGenerator generator, string propertyNameType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <inheritdoc />")
@@ -1693,6 +1953,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendHasPropertyForJsonPropertyNameMethod(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <inheritdoc />")
@@ -1709,6 +1974,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendEnumerateObjectMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration, string? propertyTypeName = null, bool isExplicit = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendSeparatorLine();
 
@@ -1762,6 +2032,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendGenericParameterIfRequired(this CodeGenerator generator, string? propertyTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (propertyTypeName is string ptn)
         {
             generator
@@ -1775,6 +2050,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendObjectIndexer(this CodeGenerator generator, TypeDeclaration typeDeclaration, string propertyTypeName, bool isExplicit)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (!isExplicit)
         {
             generator
@@ -1816,6 +2096,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendReadOnlyDictionaryIndexer(this CodeGenerator generator, string propertyTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendIndent(propertyTypeName)
             .Append(" IReadOnlyDictionary<JsonPropertyName, ")
@@ -1825,6 +2110,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendReadOnlyDictionaryKeys(this CodeGenerator generator, string propertyTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendIndent("IEnumerable<JsonPropertyName> IReadOnlyDictionary<JsonPropertyName, ")
             .Append(propertyTypeName)
@@ -1845,6 +2135,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendReadOnlyDictionaryValues(this CodeGenerator generator, string propertyTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendIndent("IEnumerable<")
             .Append(propertyTypeName)
@@ -1867,6 +2162,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendObsoleteAttribute(this CodeGenerator generator, PropertyDeclaration property)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (property.UnreducedPropertyType.IsDeprecated(out string? message) ||
             property.ReducedPropertyType.IsDeprecated(out message))
         {
@@ -1882,6 +2182,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendReadOnlyDictionaryCount(this CodeGenerator generator, string propertyTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendIndent("int IReadOnlyCollection<KeyValuePair<JsonPropertyName, ")
             .Append(propertyTypeName)

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.String.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.String.cs
@@ -2,8 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-using System.Text.Json;
-
 namespace Corvus.Json.CodeGeneration.CSharp;
 
 /// <summary>
@@ -21,6 +19,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string backing = generator.GetFieldNameInScope("backing");
         string stringBacking = generator.GetFieldNameInScope("stringBacking");
         string jsonElementBacking = generator.GetFieldNameInScope("jsonElementBacking");
@@ -69,6 +72,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendImplicitConversionToStringFormat(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format && FormatHandlerRegistry.Instance.StringFormatHandlers.GetCorvusJsonTypeNameFor(format) is string formatType)
         {
             return generator
@@ -87,8 +95,18 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendStringConcatenation(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         for (int i = 2; i <= 8; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator.AppendSeparatorLine();
             AppendStringConcatenation(generator, typeDeclaration, i);
         }
@@ -97,6 +115,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendStringConcatenation(CodeGenerator generator, TypeDeclaration typeDeclaration, int count)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .ReserveName("Concatenate")
                 .AppendLineIndent("/// <summary>")
@@ -109,6 +132,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 1; i <= count; ++i)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 generator
                     .AppendIndent("/// <typeparam name=\"T")
                     .Append(i)
@@ -122,6 +150,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 1; i <= count; ++i)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 generator
                     .AppendIndent("/// <param name=\"value")
                     .Append(i)
@@ -138,6 +171,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 1; i <= count; ++i)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 if (i > 1)
                 {
                     generator.Append(", ");
@@ -153,6 +191,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 1; i <= count; ++i)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 if (i > 1)
                 {
                     generator.Append(", ");
@@ -171,6 +214,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 1; i <= count; ++i)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 generator
                     .AppendIndent("where T")
                     .Append(i)
@@ -187,6 +235,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 1; i <= count; ++i)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 if (i > 1)
                 {
                     generator.Append(", ");
@@ -212,6 +265,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendTryGetString(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string backing = generator.GetFieldNameInScope("backing");
         string stringBacking = generator.GetFieldNameInScope("stringBacking");
         string jsonElementBacking = generator.GetFieldNameInScope("jsonElementBacking");
@@ -250,6 +308,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendGetString(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("GetString")
             .AppendSeparatorLine()
@@ -278,6 +341,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendEqualsUtf8Bytes(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string backing = generator.GetFieldNameInScope("backing");
         string jsonElementBacking = generator.GetFieldNameInScope("jsonElementBacking");
 
@@ -364,12 +432,22 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendPublicStringConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "in ReadOnlySpan<char>", CoreTypes.String, "value.ToString()")
             .AppendPublicConvertedValueWithBodyConstructor(typeDeclaration, "in ReadOnlySpan<byte>", CoreTypes.String, AppendRoSByteConversion);
 
         static void AppendRoSByteConversion(CodeGenerator generator, TypeDeclaration typeDeclaration, string backingFieldName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendSeparatorLine()
                 .AppendLine("#if NET8_0_OR_GREATER")
@@ -401,6 +479,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendStringFormatPublicStaticMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.StringFormatHandlers.AppendFormatPublicStaticMethods(generator, typeDeclaration, format);
@@ -417,6 +500,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendStringFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.StringFormatHandlers.AppendFormatPublicMethods(generator, typeDeclaration, format);
@@ -433,6 +521,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendStringFormatPrivateStaticMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.StringFormatHandlers.AppendFormatPrivateStaticMethods(generator, typeDeclaration, format);
@@ -449,6 +542,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendStringFormatPrivateMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.StringFormatHandlers.AppendFormatPrivateMethods(generator, typeDeclaration, format);
@@ -465,6 +563,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendStringFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.StringFormatHandlers.AppendFormatConversionOperators(generator, typeDeclaration, format);
@@ -481,6 +584,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendStringFormatPublicStaticProperties(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.StringFormatHandlers.AppendFormatPublicStaticProperties(generator, typeDeclaration, format);
@@ -497,6 +605,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendStringFormatPublicProperties(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.StringFormatHandlers.AppendFormatPublicProperties(generator, typeDeclaration, format);
@@ -513,6 +626,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendStringFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Format() is string format)
         {
             FormatHandlerRegistry.Instance.StringFormatHandlers.AppendFormatConstructors(generator, typeDeclaration, format);
@@ -528,6 +646,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendEqualsString(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string backing = generator.GetFieldNameInScope("backing");
         string stringBacking = generator.GetFieldNameInScope("stringBacking");
         string jsonElementBacking = generator.GetFieldNameInScope("jsonElementBacking");
@@ -604,6 +727,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNet80Formatting(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string backing = generator.GetFieldNameInScope("backing");
         string stringBacking = generator.GetFieldNameInScope("stringBacking");
         string jsonElementBacking = generator.GetFieldNameInScope("jsonElementBacking");
@@ -687,6 +815,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendGetHashCodeAndToStringMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("GetHashCode")
             .ReserveNameIfNotReserved("ToString")

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.StringFormatMethods.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.StringFormatMethods.cs
@@ -19,6 +19,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendBase64ContentFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "JsonDocument", CoreTypes.String, "StandardBase64.EncodeToString(value);");
 
@@ -33,6 +38,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendBase64ContentFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .ReserveNameIfNotReserved("GetDecodedBufferSize")
             .AppendBlockIndent(
@@ -182,6 +192,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendJsonContentFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .AppendBlockIndent(
@@ -302,6 +317,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendJsonContentFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "JsonDocument", CoreTypes.String, "value.RootElement.GetRawText();");
 
@@ -316,6 +336,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendJsonContentFormatEqualsTBody(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendBlockIndent(
             """
@@ -381,6 +406,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendBase64StringFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("FromByteArray")
@@ -532,6 +562,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendUriTemplateFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .AppendBlockIndent(
@@ -605,6 +640,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendCreateParser(CodeGenerator generator, string backingValue)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("result = Corvus.UriTemplates.UriTemplateParserFactory.CreateParser(this.", backingValue, ");")
                 .AppendLineIndent("return true;");
@@ -619,6 +659,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendUriFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "Uri", CoreTypes.String, "StandardUri.FormatUri(value)");
 
@@ -633,6 +678,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendUriFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "Uri", "value.GetUri();")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "Uri", useInForSourceType: true);
@@ -648,6 +698,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendUriFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         return AppendCommonUriFormatPublicMethods(generator);
     }
 
@@ -659,6 +714,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendUriReferenceFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "Uri", CoreTypes.String, "StandardUri.FormatUri(value)");
 
@@ -673,6 +733,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendUriReferenceFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "Uri", "value.GetUri();")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "Uri", useInForSourceType: true);
@@ -688,6 +753,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendUriReferenceFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         return AppendCommonUriReferenceFormatPublicMethods(generator);
     }
 
@@ -699,6 +769,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIriFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "Uri", CoreTypes.String, "StandardUri.FormatUri(value)");
 
@@ -713,6 +788,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIriFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "Uri", "value.GetUri();")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "Uri", useInForSourceType: true);
@@ -728,6 +808,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIriFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         return AppendCommonUriFormatPublicMethods(generator);
     }
 
@@ -739,6 +824,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIriReferenceFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "Uri", CoreTypes.String, "StandardUri.FormatUri(value)");
 
@@ -753,6 +843,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIriReferenceFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "Uri", "value.GetUri();")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "Uri", useInForSourceType: true);
@@ -768,6 +863,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIriReferenceFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         return AppendCommonUriReferenceFormatPublicMethods(generator);
     }
 
@@ -779,6 +879,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendUuidFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "Guid", CoreTypes.String, "StandardUuid.FormatGuid(value)");
 
@@ -793,6 +898,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendUuidFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "Guid", "value.GetGuid();")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "Guid", useInForSourceType: true);
@@ -808,6 +918,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendUuidFormatEqualsTBody(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendBlockIndent(
             """
@@ -847,6 +962,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendUuidFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("GetGuid")
@@ -915,6 +1035,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIpV6FormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "System.Net.IPAddress", CoreTypes.String, "value.ToString()");
 
@@ -929,6 +1054,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIpV6FormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "System.Net.IPAddress", "value.GetIPAddress();")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "System.Net.IPAddress", useInForSourceType: true);
@@ -944,6 +1074,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIpV6FormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("GetIPAddress")
@@ -1012,6 +1147,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendRegexFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(
                 typeDeclaration,
@@ -1030,6 +1170,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendRegexFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "System.Text.RegularExpressions.Regex", "value.GetRegex();")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "System.Text.RegularExpressions.Regex");
@@ -1045,6 +1190,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendRegexFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("GetRegex")
@@ -1107,6 +1257,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIpV4FormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "System.Net.IPAddress", CoreTypes.String, "value.ToString()");
 
@@ -1121,6 +1276,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIpV4FormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "System.Net.IPAddress", "value.GetIPAddress();")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "System.Net.IPAddress", useInForSourceType: true);
@@ -1136,6 +1296,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendIpV4FormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("GetIPAddress")
@@ -1204,6 +1369,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDurationFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "Period", CoreTypes.String, "StandardDateFormat.FormatPeriod(value)")
             .AppendPublicConvertedValueConstructor(typeDeclaration, "NodaTime.Period", CoreTypes.String, "StandardDateFormat.FormatPeriod(value)");
@@ -1219,6 +1389,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDurationFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "NodaTime.Period", "(NodaTime.Period)value.GetPeriod()")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "NodaTime.Period", useInForSourceType: true)
@@ -1236,6 +1411,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDurationFormatEqualsTBody(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendBlockIndent(
             """
@@ -1275,6 +1455,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDurationFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("GetPeriod")
@@ -1356,6 +1541,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendTimeFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "NodaTime.OffsetTime", CoreTypes.String, "StandardDateFormat.FormatTime(value)")
             .AppendSeparatorLine()
@@ -1374,6 +1564,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendTimeFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "NodaTime.OffsetTime", "value.GetTime()")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "NodaTime.OffsetTime", useInForSourceType: true)
@@ -1394,6 +1589,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendTimeFormatEqualsTBody(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendBlockIndent(
             """
@@ -1433,6 +1633,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendTimeFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("GetTime")
@@ -1493,6 +1698,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDateTimeFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "NodaTime.OffsetDateTime", CoreTypes.String, "StandardDateFormat.FormatDateTime(value)")
             .AppendPublicConvertedValueConstructor(typeDeclaration, "DateTimeOffset", CoreTypes.String, "StandardDateFormat.FormatDateTime(NodaTime.OffsetDateTime.FromDateTimeOffset(value))");
@@ -1507,6 +1717,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDateTimeFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "NodaTime.OffsetDateTime", "value.GetDateTime()")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "NodaTime.OffsetDateTime", useInForSourceType: true);
@@ -1522,6 +1737,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDateTimeFormatEqualsTBody(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendBlockIndent(
             """
@@ -1561,6 +1781,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDateTimeFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("GetDateTime")
@@ -1621,6 +1846,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDateFormatEqualsTBody(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendBlockIndent(
             """
@@ -1660,6 +1890,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDateFormatConstructors(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, "NodaTime.LocalDate", CoreTypes.String, "StandardDateFormat.FormatDate(value)")
             .AppendPublicConvertedValueConstructor(typeDeclaration, "DateTime", CoreTypes.String, "StandardDateFormat.FormatDate(NodaTime.LocalDate.FromDateTime(value))")
@@ -1675,6 +1910,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDateFormatConversionOperators(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendImplicitConversionToType(typeDeclaration, "NodaTime.LocalDate", "value.GetDate()")
             .AppendImplicitConversionFromTypeUsingConstructor(typeDeclaration, "NodaTime.LocalDate", useInForSourceType: true);
@@ -1690,6 +1930,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A <see langword="true"/> if this handled the format for the type declaration.</returns>
     public static bool AppendDateFormatPublicMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("GetDate")
@@ -1744,6 +1989,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static bool AppendCommonUriReferenceFormatPublicMethods(CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("GetUri")
@@ -1788,6 +2038,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static bool AppendCommonUriFormatPublicMethods(CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return true;
+        }
+
         generator
             .AppendSeparatorLine()
             .ReserveNameIfNotReserved("GetUri")

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.cs
@@ -30,6 +30,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendOperator(this CodeGenerator generator, Operator op)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         switch (op)
         {
             case Operator.Equals:
@@ -58,6 +63,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendTextForOperator(this CodeGenerator generator, Operator op)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         switch (op)
         {
             case Operator.Equals:
@@ -91,6 +101,11 @@ internal static partial class CodeGeneratorExtensions
     /// </remarks>
     public static CodeGenerator AppendTextForInverseOperator(this CodeGenerator generator, Operator op)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         switch (op)
         {
             case Operator.Equals:
@@ -131,6 +146,11 @@ internal static partial class CodeGeneratorExtensions
         string reasonText,
         bool useInterpolatedString = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendIndent(validationContextIdentifier)
             .Append(" = ")
@@ -171,6 +191,11 @@ internal static partial class CodeGeneratorExtensions
         Action<CodeGenerator> appendReasonText,
         bool useInterpolatedString = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendIndent(validationContextIdentifier)
             .Append(" = ")
@@ -204,6 +229,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendUsings(this CodeGenerator generator, params ConditionalCodeSpecification[] namespaces)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         ConditionalCodeSpecification.AppendConditionalsInOrder(
             generator,
             namespaces,
@@ -226,6 +256,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendSeparatorLine(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if ((generator.ScopeType == ScopeType.Type && generator.EndsWith($";{Environment.NewLine}")) ||
             generator.EndsWith($"}}{Environment.NewLine}") ||
             generator.EndsWith($"#endif{Environment.NewLine}"))
@@ -245,6 +280,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator BeginNamespace(this CodeGenerator generator, string ns)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .Append("namespace ")
             .Append(ns)
@@ -259,6 +299,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator EndNamespace(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .PopMemberScope();
     }
@@ -273,6 +318,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator BeginPublicReadOnlyPropertyDeclaration(this CodeGenerator generator, string propertyType, string propertyName, bool nullable = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendLineIndent("public ", propertyType, nullable ? "? " : " ", propertyName)
             .AppendLineIndent("{")
@@ -289,6 +339,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator EndReadOnlyPropertyDeclaration(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .PopIndent()
             .AppendLineIndent("}")
@@ -312,6 +367,11 @@ internal static partial class CodeGeneratorExtensions
         string methodName,
         params MethodParameter[] parameters)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendIndent(visibilityAndModifiers)
@@ -341,6 +401,11 @@ internal static partial class CodeGeneratorExtensions
         string methodName,
         params MethodParameter[] parameters)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendIndent(visibilityAndModifiers)
@@ -371,6 +436,11 @@ internal static partial class CodeGeneratorExtensions
         MemberName methodName,
         params MethodParameter[] parameters)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string realisedMethodName = generator.GetOrAddMemberName(methodName);
 
         return generator
@@ -393,6 +463,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendBackingFields(this CodeGenerator generator, CoreTypes impliedCoreTypes)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendBackingField("Backing", "backing")
             .AppendBackingField("JsonElement", "jsonElementBacking")
@@ -411,6 +486,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendSchemaLocationStaticProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("SchemaLocation")
             .AppendSeparatorLine()
@@ -433,6 +513,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNullInstanceStaticProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("Null")
             .AppendSeparatorLine()
@@ -455,6 +540,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendUndefinedInstanceStaticProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("Undefined")
             .AppendSeparatorLine()
@@ -477,6 +567,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendDefaultInstanceStaticProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveName("DefaultInstance")
             .AppendSeparatorLine()
@@ -514,6 +609,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendConstInstanceStaticProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Keywords().OfType<ISingleConstantValidationKeyword>().FirstOrDefault()
             is ISingleConstantValidationKeyword keyword)
         {
@@ -560,10 +660,20 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAnyOfConstantValuesClasses(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.AnyOfConstantValues() is IReadOnlyDictionary<IAnyOfConstantValidationKeyword, JsonElement[]> constantValues)
         {
             foreach (IAnyOfConstantValidationKeyword keyword in constantValues.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 JsonElement[] constants = constantValues[keyword];
                 string className = generator.GetUniqueClassNameInScope(keyword.Keyword, suffix: "Values");
 
@@ -593,6 +703,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendAnyOfConstantValue(CodeGenerator generator, TypeDeclaration typeDeclaration, IKeyword keyword, JsonElement[] constants, int i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             bool requiresIndex = constants.Length > 1;
             JsonElement constantValue = constants[i];
 
@@ -622,6 +737,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendStringProperties(CodeGenerator generator, TypeDeclaration typeDeclaration, IKeyword keyword, string? index, JsonElement constantValue)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             if (constantValue.GetString() is string stringValue)
             {
                 string constField =
@@ -669,6 +789,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendNumberProperties(CodeGenerator generator, TypeDeclaration typeDeclaration, IKeyword keyword, string? index, JsonElement constantValue)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string numberValue = constantValue.GetRawText();
             string constField =
                 generator.GetPropertyNameInScope(
@@ -698,6 +823,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendBooleanProperties(CodeGenerator generator, TypeDeclaration typeDeclaration, IKeyword keyword, string? index, JsonElement constantValue)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string booleanValue = constantValue.GetRawText();
             string constField =
                 generator.GetPropertyNameInScope(
@@ -729,6 +859,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendNullProperties(CodeGenerator generator, TypeDeclaration typeDeclaration, string? index, JsonElement constantValue)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string booleanValue = constantValue.GetRawText();
             string propertyName = index is string i ? $"Item{index}" : "Item1";
 
@@ -749,6 +884,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendObjectProperties(CodeGenerator generator, TypeDeclaration typeDeclaration, IKeyword keyword, string? index, JsonElement constantValue)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string objectValue = constantValue.GetRawText();
             string constField =
                 generator.GetPropertyNameInScope(
@@ -780,6 +920,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendArrayProperties(CodeGenerator generator, TypeDeclaration typeDeclaration, IKeyword keyword, string? index, JsonElement constantValue)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string arrayValue = constantValue.GetRawText();
             string constField =
                 generator.GetPropertyNameInScope(
@@ -818,6 +963,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsAnyProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveName("AsAny")
             .AppendSeparatorLine()
@@ -888,6 +1038,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsJsonElementProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("AsJsonElement")
             .AppendSeparatorLine()
@@ -963,6 +1118,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsStringProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveName("AsString")
             .AppendSeparatorLine()
@@ -1019,6 +1179,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsBooleanProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveName("AsBoolean")
             .AppendSeparatorLine()
@@ -1075,6 +1240,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsNumberProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveName("AsNumber")
             .AppendSeparatorLine()
@@ -1131,6 +1301,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsObjectProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveName("AsObject")
             .AppendSeparatorLine()
@@ -1187,6 +1362,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsArrayProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveName("AsArray")
             .AppendSeparatorLine()
@@ -1242,6 +1422,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendHasJsonElementBackingProperty(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("HasJsonElementBacking")
             .AppendSeparatorLine()
@@ -1268,6 +1453,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendHasDotnetBackingProperty(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("HasDotnetBacking")
             .AppendSeparatorLine()
@@ -1295,6 +1485,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendValueKindProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("ValueKind")
             .AppendSeparatorLine()
@@ -1358,6 +1553,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendPublicDefaultConstructor(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.SingleConstantValue().ValueKind != JsonValueKind.Undefined)
         {
             // Don't emit this for a type that has a single constant value.
@@ -1397,6 +1597,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendPublicJsonElementConstructor(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         CoreTypes impliedCoreTypes = typeDeclaration.ImpliedCoreTypesOrAny();
 
         return generator
@@ -1438,6 +1643,11 @@ internal static partial class CodeGeneratorExtensions
         string sourceType,
         bool useInForSourceType = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string targetType = typeDeclaration.DotnetTypeName();
 
         if (targetType == sourceType)
@@ -1484,6 +1694,11 @@ internal static partial class CodeGeneratorExtensions
         JsonValueKind sourceValueKind,
         string dotnetTypeConversion)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return AppendImplicitConversionFromJsonValueTypeUsingConstructor(
             generator,
             typeDeclaration,
@@ -1502,6 +1717,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendBlockIndent(
@@ -1541,6 +1761,11 @@ internal static partial class CodeGeneratorExtensions
         JsonValueKind[] sourceValueKinds,
         string dotnetTypeConversion)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string targetType = typeDeclaration.DotnetTypeName();
 
         if (targetType == sourceType)
@@ -1598,6 +1823,11 @@ internal static partial class CodeGeneratorExtensions
         CoreTypes forCoreTypes,
         string dotnetTypeConversion)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if ((typeDeclaration.ImpliedCoreTypesOrAny() & forCoreTypes) == 0)
         {
             return generator;
@@ -1644,6 +1874,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         string typeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .Append("<see cref=\"");
 
@@ -1683,6 +1918,11 @@ internal static partial class CodeGeneratorExtensions
         string targetType,
         string dotnetTypeConversion)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -1720,6 +1960,11 @@ internal static partial class CodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         string sourceType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string targetType = typeDeclaration.DotnetTypeName();
 
         if (targetType == sourceType)
@@ -1762,6 +2007,11 @@ internal static partial class CodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         string targetType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string sourceType = typeDeclaration.DotnetTypeName();
         if (sourceType == targetType)
         {
@@ -1801,6 +2051,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string sourceType = typeDeclaration.DotnetTypeName();
         if (sourceType == "JsonAny")
         {
@@ -1836,10 +2091,20 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration rootDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         HashSet<string> visitedTypes = [];
 
         foreach (TypeDeclaration t in rootDeclaration.CompositionTypeDeclarations())
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (!visitedTypes.Add(t.FullyQualifiedDotnetTypeName()))
             {
                 continue;
@@ -1894,10 +2159,20 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration rootDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         HashSet<string> visitedTypes = [];
 
         foreach (TypeDeclaration t in rootDeclaration.CompositionTypeDeclarations())
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (!visitedTypes.Add(t.FullyQualifiedDotnetTypeName()))
             {
                 continue;
@@ -1934,6 +2209,11 @@ internal static partial class CodeGeneratorExtensions
     this CodeGenerator generator,
     TypeDeclaration rootDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         HashSet<TypeDeclaration> appliedConversions = [];
         Queue<(TypeDeclaration Target, bool AllowsImplicitFrom, bool AllowsImplicitTo)> typesToProcess = [];
 
@@ -1941,6 +2221,11 @@ internal static partial class CodeGeneratorExtensions
 
         while (typesToProcess.Count > 0)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             (TypeDeclaration subschema, bool allowsImplicitFrom, bool allowsImplicitTo) = typesToProcess.Dequeue();
             AppendConversions(generator, appliedConversions, rootDeclaration, subschema, allowsImplicitFrom, allowsImplicitTo);
             AppendCompositionConversions(generator, appliedConversions, typesToProcess, rootDeclaration, subschema, allowsImplicitFrom: allowsImplicitFrom, allowsImplicitTo: allowsImplicitTo);
@@ -1957,6 +2242,11 @@ internal static partial class CodeGeneratorExtensions
             bool allowsImplicitFrom,
             bool allowsImplicitTo)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             if (sourceType.AllOfCompositionTypes() is IReadOnlyDictionary<IAllOfSubschemaValidationKeyword, IReadOnlyCollection<TypeDeclaration>> allOf)
             {
                 AppendSubschemaConversions(generator, appliedConversions, typesToProcess, rootType, allOf.SelectMany(k => k.Value).ToList(), isImplicitFrom: false, isImplicitTo: allowsImplicitTo);
@@ -1967,6 +2257,11 @@ internal static partial class CodeGeneratorExtensions
                 // Defer any of until all the AllOf have been processed so we prefer an implicit to the allOf types
                 foreach (TypeDeclaration subschema in anyOf.SelectMany(k => k.Value))
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
                     typesToProcess.Enqueue((subschema.ReducedTypeDeclaration().ReducedType, allowsImplicitFrom, false));
                 }
             }
@@ -1976,6 +2271,11 @@ internal static partial class CodeGeneratorExtensions
                 // Defer any of until all the AllOf have been processed so we prefer an implicit to the allOf types
                 foreach (TypeDeclaration subschema in oneOf.SelectMany(k => k.Value))
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return;
+                    }
+
                     typesToProcess.Enqueue((subschema.ReducedTypeDeclaration().ReducedType, allowsImplicitFrom, false));
                 }
             }
@@ -1992,6 +2292,11 @@ internal static partial class CodeGeneratorExtensions
         {
             foreach (TypeDeclaration candidate in subschemas)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 TypeDeclaration subschema = candidate.ReducedTypeDeclaration().ReducedType;
                 if (!AppendConversions(generator, appliedConversions, rootDeclaration, subschema, isImplicitFrom, isImplicitTo))
                 {
@@ -2011,6 +2316,11 @@ internal static partial class CodeGeneratorExtensions
             bool isImplicitFrom,
             bool isImplicitTo)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (rootDeclaration == subschema)
             {
                 return false;
@@ -2068,6 +2378,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendCreateFromSerializedInstanceFactoryMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.IsCorvusJsonExtendedJsonAny())
         {
             return generator
@@ -2105,6 +2420,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendFromJsonFactoryMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("FromJson")
             .AppendSeparatorLine()
@@ -2139,6 +2459,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendFromAnyFactoryMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveName("FromAny")
             .AppendSeparatorLine()
@@ -2189,6 +2514,11 @@ internal static partial class CodeGeneratorExtensions
         CoreTypes forCoreTypes,
         string jsonValueTypeBaseName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if ((typeDeclaration.ImpliedCoreTypesOrAny() & forCoreTypes) != 0)
         {
             return generator
@@ -2276,6 +2606,11 @@ internal static partial class CodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         string sourceType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("Parse")
             .AppendSeparatorLine()
@@ -2307,6 +2642,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAsTMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveNameIfNotReserved("As")
             .AppendSeparatorLine()
@@ -2372,6 +2712,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendWriteToMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .ReserveName("WriteTo")
             .AppendSeparatorLine()
@@ -2440,6 +2785,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendEqualsOverloads(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveNameIfNotReserved("Equals")
             .AppendSeparatorLine()
@@ -2507,6 +2857,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendComparer(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendLineIndent("JsonValueKind thisKind = this.ValueKind;")
             .AppendLineIndent("JsonValueKind otherKind = other.ValueKind;")
@@ -2551,6 +2906,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendArrayComparer(CodeGenerator generator, TypeDeclaration typeDeclaration)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string? arrayItemsType = typeDeclaration.ArrayItemsType()?.ReducedType.FullyQualifiedDotnetTypeName();
             generator
                 .AppendSeparatorLine()
@@ -2602,6 +2962,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendBooleanComparer(CodeGenerator generator)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendSeparatorLine()
                 .AppendLineIndent("if (thisKind == JsonValueKind.True || thisKind == JsonValueKind.False)")
@@ -2614,6 +2979,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendNumberComparer(CodeGenerator generator)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string backing = generator.GetFieldNameInScope("backing");
             string numberBacking = generator.GetFieldNameInScope("numberBacking");
             string jsonElementBacking = generator.GetFieldNameInScope("jsonElementBacking");
@@ -2673,6 +3043,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendNullOrUndefinedComparer(CodeGenerator generator)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendSeparatorLine()
                 .AppendLineIndent("if (thisKind == JsonValueKind.Null || thisKind == JsonValueKind.Undefined)")
@@ -2685,6 +3060,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendObjectComparer(CodeGenerator generator, TypeDeclaration typeDeclaration)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string? propertyTypeName = null;
             if (typeDeclaration.FallbackObjectPropertyType() is FallbackObjectPropertyType propertyType && !propertyType.ReducedType.IsBuiltInJsonAnyType())
             {
@@ -2752,6 +3132,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendStringComparer(CodeGenerator generator)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string backing = generator.GetFieldNameInScope("backing");
             string stringBacking = generator.GetFieldNameInScope("stringBacking");
             string jsonElementBacking = generator.GetFieldNameInScope("jsonElementBacking");
@@ -2819,6 +3204,11 @@ internal static partial class CodeGeneratorExtensions
         string sourceType,
         bool byRef = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .ReserveNameIfNotReserved("ParseValue")
             .AppendSeparatorLine()
@@ -2890,6 +3280,11 @@ internal static partial class CodeGeneratorExtensions
         string operatorBody,
         string returnValueDocumentation)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -2926,6 +3321,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendOrdinalName(this CodeGenerator generator, int number)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
                 .Append(number);
 
@@ -2957,6 +3357,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendShortcircuitingOr<T>(this CodeGenerator generator, T[] values, Action<CodeGenerator, T> appendCallback, bool includeParensIfMultiple)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         bool includeParens = values.Length > 1 && includeParensIfMultiple;
 
         if (includeParens)
@@ -2966,6 +3371,11 @@ internal static partial class CodeGeneratorExtensions
 
         for (int i = 0; i < values.Length; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (i > 0)
             {
                 generator.Append(" || ");
@@ -2994,6 +3404,11 @@ internal static partial class CodeGeneratorExtensions
         string lhs,
         JsonValueKind jsonValueKind)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .Append(lhs)
             .Append(".ValueKind == ")
@@ -3008,6 +3423,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendJsonValueKind(this CodeGenerator generator, JsonValueKind valueKind)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .Append("JsonValueKind.")
             .Append(valueKind.ToString());
@@ -3031,6 +3451,11 @@ internal static partial class CodeGeneratorExtensions
         CoreTypes valueCoreType,
         string valueConverter)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         CoreTypes impliedCoreTypes = typeDeclaration.ImpliedCoreTypesOrAny();
 
         if ((impliedCoreTypes & valueCoreType) == 0)
@@ -3084,6 +3509,11 @@ internal static partial class CodeGeneratorExtensions
         CoreTypes valueCoreType,
         string valueConverter)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         CoreTypes impliedCoreTypes = typeDeclaration.ImpliedCoreTypesOrAny();
 
         if ((impliedCoreTypes & valueCoreType) == 0)
@@ -3134,6 +3564,11 @@ internal static partial class CodeGeneratorExtensions
         CoreTypes valueCoreType,
         AppendConstructorBackingFieldAssignmentCallback appendAssignment)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         CoreTypes impliedCoreTypes = typeDeclaration.ImpliedCoreTypesOrAny();
 
         if ((impliedCoreTypes & valueCoreType) == 0)
@@ -3182,6 +3617,11 @@ internal static partial class CodeGeneratorExtensions
         string valueType,
         CoreTypes valueCoreType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendPublicConvertedValueConstructor(typeDeclaration, valueType, valueCoreType, "value");
     }
@@ -3193,6 +3633,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator EndMethodDeclaration(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .PopMemberScope()
             .PopIndent()
@@ -3210,6 +3655,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         params MethodParameter[] parameters)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (parameters.Length < 3)
         {
             return AppendParameterListSingleLine(generator, parameters);
@@ -3226,6 +3676,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendParameterListSingleLine(CodeGenerator generator, MethodParameter[] parameters)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (parameters.Length == 0)
         {
             // If we have no parameters, just emit the brackets.
@@ -3237,6 +3692,11 @@ internal static partial class CodeGeneratorExtensions
 
         foreach (MethodParameter parameter in parameters)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (first)
             {
                 first = false;
@@ -3261,6 +3721,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendParameterListIndent(CodeGenerator generator, MethodParameter[] parameters)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (parameters.Length == 0)
         {
             // If we have no parameters, just emit the brackets.
@@ -3273,6 +3738,11 @@ internal static partial class CodeGeneratorExtensions
 
         foreach (MethodParameter parameter in parameters)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (first)
             {
                 first = false;
@@ -3300,6 +3770,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         MethodParameter parameter)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string name = parameter.GetName(generator, isDeclaration: true);
 
         if (!string.IsNullOrEmpty(parameter.Modifiers))
@@ -3345,6 +3820,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         MethodParameter parameter)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string name = parameter.GetName(generator, isDeclaration: true);
 
         if (!string.IsNullOrEmpty(parameter.Modifiers))
@@ -3387,6 +3867,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Stack<TypeDeclaration> parentTypes = new();
 
         TypeDeclaration? current = typeDeclaration.Parent();
@@ -3394,6 +3879,11 @@ internal static partial class CodeGeneratorExtensions
         // We need to reverse the order, so we push them onto a stack...
         while (current is not null)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             parentTypes.Push(current);
             current = current.Parent();
         }
@@ -3401,6 +3891,11 @@ internal static partial class CodeGeneratorExtensions
         // ...and then pop them off again.
         while (parentTypes.Count > 0)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             TypeDeclaration parent = parentTypes.Pop();
             generator
                 .AppendSeparatorLine()
@@ -3420,9 +3915,19 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator EndTypeDeclarationNesting(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         TypeDeclaration? current = typeDeclaration.Parent();
         while (current is not null)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator.EndClassOrStructDeclaration();
             current = current.Parent();
         }
@@ -3437,6 +3942,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator EndClassOrStructDeclaration(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .PopMemberScope()
             .PopIndent()
@@ -3451,6 +3961,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendNumericLiteral(this CodeGenerator generator, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.Number, "The value must be a number.");
 
         generator.Append(value.GetRawText());
@@ -3472,6 +3987,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendIntegerLiteral(this CodeGenerator generator, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.Number, "The value must be a number.");
 
         if (value.TryGetInt64(out long result))
@@ -3498,6 +4018,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendQuotedStringLiteral(this CodeGenerator generator, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.String, "The value must be a string.");
 
         generator.Append(SymbolDisplay.FormatLiteral(value.GetRawText(), true));
@@ -3513,6 +4038,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendSerializedBooleanLiteral(this CodeGenerator generator, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.True || value.ValueKind == JsonValueKind.False, "The value must be a boolean.");
 
         generator.Append(SymbolDisplay.FormatLiteral(value.GetRawText(), true));
@@ -3528,6 +4058,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendQuotedStringLiteral(this CodeGenerator generator, string value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .Append(SymbolDisplay.FormatLiteral(value, true));
     }
@@ -3540,6 +4075,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendSerializedObjectStringLiteral(this CodeGenerator generator, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.Object, "The value must be an object.");
 
         return generator
@@ -3554,6 +4094,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendSerializedArrayStringLiteral(this CodeGenerator generator, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.Array, "The value must be an array.");
 
         return generator
@@ -3572,6 +4117,11 @@ internal static partial class CodeGeneratorExtensions
         string genericTypeName,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
                 .Append(genericTypeName)
                 .Append('<')
@@ -3594,6 +4144,11 @@ internal static partial class CodeGeneratorExtensions
         TypeDeclaration typeDeclaration1,
         TypeDeclaration typeDeclaration2)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
                 .Append(genericTypeName)
                 .Append('<')
@@ -3620,6 +4175,11 @@ internal static partial class CodeGeneratorExtensions
         TypeDeclaration typeDeclaration2,
         TypeDeclaration typeDeclaration3)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
                 .Append(genericTypeName)
                 .Append('<')
@@ -3643,6 +4203,11 @@ internal static partial class CodeGeneratorExtensions
         string dotnetTypeName,
         ConditionalCodeSpecification[]? interfaces = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.ReserveNameIfNotReserved(dotnetTypeName);
         generator
             .AppendIndent("public readonly partial struct ")
@@ -3663,6 +4228,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendInterface(CodeGenerator generator, Action<CodeGenerator> appendFunction, int elementIndexInConditionalBlock)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             if (elementIndexInConditionalBlock == 0)
             {
                 generator.AppendIndent(": ");
@@ -3686,6 +4256,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator BeginPrivateStaticClassDeclaration(this CodeGenerator generator, string dotnetTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string name = generator.GetTypeNameInScope(dotnetTypeName);
         return generator
             .AppendIndent("private static class ")
@@ -3704,6 +4279,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator BeginPrivateStaticPartialClassDeclaration(this CodeGenerator generator, string dotnetTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .BeginReservedPrivateStaticPartialClassDeclaration(dotnetTypeName);
     }
@@ -3716,6 +4296,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator BeginReservedPrivateStaticPartialClassDeclaration(this CodeGenerator generator, string dotnetTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendIndent("private static partial class ")
             .AppendLine(dotnetTypeName)
@@ -3733,6 +4318,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator BeginPublicStaticPartialClassDeclaration(this CodeGenerator generator, string dotnetTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .BeginReservedPublicStaticPartialClassDeclaration(dotnetTypeName);
     }
@@ -3745,6 +4335,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator BeginReservedPublicStaticPartialClassDeclaration(this CodeGenerator generator, string dotnetTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendIndent("public static partial class ")
             .AppendLine(dotnetTypeName)
@@ -3762,6 +4357,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator BeginPublicStaticClassDeclaration(this CodeGenerator generator, string dotnetTypeName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string name = generator.GetTypeNameInScope(dotnetTypeName);
         return generator
             .AppendIndent("public static class ")
@@ -3779,6 +4379,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendAutoGeneratedHeader(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendLine(
             """
@@ -3801,6 +4406,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendJsonConverterAttribute(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendIndent("[System.Text.Json.Serialization.JsonConverter(typeof(Corvus.Json.Internal.JsonValueConverter<")
             .Append(typeDeclaration.DotnetTypeName())
@@ -3815,9 +4425,19 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendParagraphs(this CodeGenerator generator, string paragraphs)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string[] lines = NormalizeAndSplitBlockIntoLines(paragraphs, removeBlankLines: true);
         foreach (string line in lines)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendLineIndent("/// <para>")
                 .AppendIndent("/// ")
@@ -3839,10 +4459,20 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendBlockIndent(this CodeGenerator generator, string block, bool trimWhitespaceOnlyLines = true, bool omitLastLineEnd = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string[] lines = NormalizeAndSplitBlockIntoLines(block);
 
         for (int i = 0; i < lines.Length; i++)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             string line = lines[i];
             if (omitLastLineEnd && i == lines.Length - 1)
             {
@@ -3870,10 +4500,20 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendBlockIndentWithHashOutdent(this CodeGenerator generator, string block, bool trimWhitespaceOnlyLines = true, bool omitLastLineEnd = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string[] lines = NormalizeAndSplitBlockIntoLines(block);
 
         for (int i = 0; i < lines.Length; i++)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             string line = lines[i];
             if (omitLastLineEnd && i == lines.Length - 1)
             {
@@ -3913,9 +4553,19 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendBlockIndentWithPrefix(this CodeGenerator generator, string block, string linePrefix)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string[] lines = NormalizeAndSplitBlockIntoLines(block);
         foreach (string line in lines)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendIndent(linePrefix)
                 .AppendLine(line);
@@ -3938,6 +4588,11 @@ internal static partial class CodeGeneratorExtensions
         string name,
         string? value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendIndent("public static readonly ")
             .Append(type)
@@ -3973,6 +4628,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetOrAddMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4000,6 +4660,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetUniqueMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4027,6 +4692,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetOrAddMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4054,6 +4724,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetUniqueMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4081,6 +4756,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetOrAddMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4108,6 +4788,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetUniqueMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4135,6 +4820,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetOrAddMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4162,6 +4852,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetUniqueMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4189,6 +4884,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetOrAddMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4216,6 +4916,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetUniqueMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4243,6 +4948,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetUniqueMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4270,6 +4980,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator.ReserveName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4297,6 +5012,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator.ReserveNameIfNotReserved(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4324,6 +5044,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return false;
+        }
+
         return generator.TryReserveName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4351,6 +5076,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetOrAddMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4378,6 +5108,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetUniqueMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4405,6 +5140,11 @@ internal static partial class CodeGeneratorExtensions
         string? prefix = null,
         string? suffix = null)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return string.Empty;
+        }
+
         return generator.GetOrAddMemberName(
             new CSharpMemberName(
                 generator.GetChildScope(childScope, rootScope),
@@ -4422,6 +5162,11 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendValidateMethodForNoValidation(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ValidationKeywords().Count == 0)
         {
             generator
@@ -4459,11 +5204,21 @@ internal static partial class CodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendMatchMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         int matchOverloadIndex = 0;
         if (typeDeclaration.AllOfCompositionTypes() is IReadOnlyDictionary<IAllOfSubschemaValidationKeyword, IReadOnlyCollection<TypeDeclaration>> allOf)
         {
             foreach (IAllOfSubschemaValidationKeyword keyword in allOf.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 var subschema = allOf[keyword].Distinct().ToList();
                 if (subschema.Count > 1)
                 {
@@ -4477,6 +5232,11 @@ internal static partial class CodeGeneratorExtensions
         {
             foreach (IAnyOfSubschemaValidationKeyword keyword in anyOf.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 var subschema = anyOf[keyword].Distinct().ToList();
                 if (subschema.Count > 1)
                 {
@@ -4490,6 +5250,11 @@ internal static partial class CodeGeneratorExtensions
         {
             foreach (IOneOfSubschemaValidationKeyword keyword in oneOf.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 var subschema = oneOf[keyword].Distinct().ToList();
                 if (subschema.Count > 1)
                 {
@@ -4503,6 +5268,11 @@ internal static partial class CodeGeneratorExtensions
         {
             foreach (IAnyOfConstantValidationKeyword keyword in anyOfConstant.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 JsonElement[] constantValues = anyOfConstant[keyword].Distinct().ToArray();
                 if (constantValues.Length > 1)
                 {
@@ -4522,6 +5292,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendMatchCompositionMethod(CodeGenerator generator, TypeDeclaration typeDeclaration, IReadOnlyCollection<TypeDeclaration> subschema, bool includeContext, int matchOverloadIndex)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string scopeName = $"Match{matchOverloadIndex}";
 
             generator
@@ -4559,6 +5334,11 @@ internal static partial class CodeGeneratorExtensions
             int i = 0;
             foreach (TypeDeclaration match in subschema)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 // This is the parameter name for the match match method.
                 string matchTypeName = match.ReducedTypeDeclaration().ReducedType.FullyQualifiedDotnetTypeName();
                 string matchParamName = generator.GetUniqueParameterNameInScope(match.ReducedTypeDeclaration().ReducedType.DotnetTypeName(), childScope: scopeName, prefix: "match");
@@ -4585,6 +5365,11 @@ internal static partial class CodeGeneratorExtensions
             i = 0;
             foreach (TypeDeclaration match in subschema)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 if (i > 0 || includeContext)
                 {
                     generator
@@ -4614,6 +5399,11 @@ internal static partial class CodeGeneratorExtensions
             i = 0;
             foreach (TypeDeclaration match in subschema)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 string matchTypeName = match.ReducedTypeDeclaration().ReducedType.FullyQualifiedDotnetTypeName();
                 generator
                     .AppendSeparatorLine()
@@ -4643,6 +5433,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendMatchConstantMethod(CodeGenerator generator, IAnyOfConstantValidationKeyword keyword, JsonElement[] constValues, bool includeContext, int matchOverloadIndex)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string scopeName = $"Match{matchOverloadIndex}";
 
             generator
@@ -4681,6 +5476,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 1; i <= count; ++i)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 JsonElement constValue = constValues[i - 1];
 
                 string matchParamName = GetUniqueParameterName(generator, scopeName, constValue, i);
@@ -4714,6 +5514,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 0; i < count; ++i)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 if (i > 0 || includeContext)
                 {
                     generator
@@ -4740,6 +5545,11 @@ internal static partial class CodeGeneratorExtensions
 
             for (int i = 0; i < count; ++i)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 generator
                     .AppendSeparatorLine()
                     .AppendLineIndent("if (this.Equals(", generator.ValidationClassName(), ".", constFields[i], "))")
@@ -4760,6 +5570,11 @@ internal static partial class CodeGeneratorExtensions
 
         static string GetUniqueParameterName(CodeGenerator generator, string scopeName, JsonElement constValue, int index)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return string.Empty;
+            }
+
             return constValue.ValueKind switch
             {
                 JsonValueKind.Object => generator.GetUniqueParameterNameInScope("matchObjectValue", childScope: scopeName, suffix: index.ToString()),
@@ -4775,6 +5590,11 @@ internal static partial class CodeGeneratorExtensions
 
         static void AppendMatchIfMethod(CodeGenerator generator, TypeDeclaration typeDeclaration, SingleSubschemaKeywordTypeDeclaration ifSubschema, bool includeContext, int matchOverloadIndex)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             SingleSubschemaKeywordTypeDeclaration? thenDeclaration = typeDeclaration.ThenSubschemaType();
             SingleSubschemaKeywordTypeDeclaration? elseDeclaration = typeDeclaration.ElseSubschemaType();
 
@@ -4991,6 +5811,11 @@ internal static partial class CodeGeneratorExtensions
         CoreTypes forTypes,
         bool requiresAs = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendIndent("if (")
             .Append(identifierName)
@@ -5063,6 +5888,11 @@ internal static partial class CodeGeneratorExtensions
         CoreTypes impliedCoreTypes = CoreTypes.Any,
         CoreTypes forCoreTypes = CoreTypes.Any)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if ((impliedCoreTypes & forCoreTypes) != 0)
         {
             string localBackingFieldName = generator.GetFieldNameInScope(fieldName);
@@ -5084,6 +5914,11 @@ internal static partial class CodeGeneratorExtensions
         CoreTypes impliedCoreTypes = CoreTypes.Any,
         CoreTypes forCoreTypes = CoreTypes.Any)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if ((impliedCoreTypes & forCoreTypes) != 0)
         {
             string localBackingFieldName = generator.GetFieldNameInScope(fieldName);
@@ -5106,6 +5941,11 @@ internal static partial class CodeGeneratorExtensions
     CoreTypes impliedCoreTypes = CoreTypes.Any,
     CoreTypes forCoreTypes = CoreTypes.Any)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if ((impliedCoreTypes & forCoreTypes) != 0)
         {
             generator
@@ -5175,6 +6015,11 @@ internal static partial class CodeGeneratorExtensions
     CoreTypes forCoreTypes = CoreTypes.Any,
     bool returnFromClause = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if ((impliedCoreTypes & forCoreTypes) != 0)
         {
             string localBackingFieldName = generator.GetFieldNameInScope(fieldName);
@@ -5220,6 +6065,11 @@ internal static partial class CodeGeneratorExtensions
     CoreTypes forCoreTypes = CoreTypes.Any,
     bool returnFromClause = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if ((impliedCoreTypes & forCoreTypes) != 0)
         {
             string localBackingFieldName = generator.GetFieldNameInScope(fieldName);
@@ -5263,6 +6113,11 @@ internal static partial class CodeGeneratorExtensions
         CoreTypes forCoreTypes = CoreTypes.Any,
         bool returnFromClause = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if ((impliedCoreTypes & forCoreTypes) != 0)
         {
             string backingName = generator.GetFieldNameInScope("backing");
@@ -5307,6 +6162,11 @@ internal static partial class CodeGeneratorExtensions
         CoreTypes forCoreTypes = CoreTypes.Any,
         bool returnFromClause = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if ((impliedCoreTypes & forCoreTypes) != 0)
         {
             string backingName = generator.GetFieldNameInScope("backing");
@@ -5338,6 +6198,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendWriteJsonElementBacking(this CodeGenerator generator, string fieldName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendIndent("if (this.")
             .Append(fieldName)
@@ -5361,6 +6226,11 @@ internal static partial class CodeGeneratorExtensions
         CoreTypes forCoreTypes = CoreTypes.Any,
         bool returnFromClause = false)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if ((impliedCoreTypes & forCoreTypes) != 0)
         {
             string backingName = generator.GetFieldNameInScope("backing");
@@ -5396,6 +6266,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendReturnNullInstanceIfNull(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendIndent("if (")
@@ -5410,6 +6285,11 @@ internal static partial class CodeGeneratorExtensions
 
     private static CodeGenerator AppendReturnNullJsonElementIfNull(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendIndent("if (")
             .AppendTestBacking("Backing.Null")
@@ -5425,6 +6305,11 @@ internal static partial class CodeGeneratorExtensions
         this CodeGenerator generator,
         string backingType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string backingName = generator.GetFieldNameInScope("backing");
         return generator
             .Append("(this.")
@@ -5439,6 +6324,11 @@ internal static partial class CodeGeneratorExtensions
         string fieldName,
         string fieldValue)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string localBackingFieldName = generator.GetFieldNameInScope(fieldName);
         return generator
             .AppendIndent("this.")
@@ -5452,6 +6342,11 @@ internal static partial class CodeGeneratorExtensions
     {
         for (int i = 0; i < count; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (i > 0)
             {
                 generator
@@ -5470,6 +6365,11 @@ internal static partial class CodeGeneratorExtensions
     {
         for (int i = 0; i < count; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (i > 0)
             {
                 generator
@@ -5491,6 +6391,11 @@ internal static partial class CodeGeneratorExtensions
     {
         for (int i = 0; i < count; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (i > 0)
             {
                 generator
@@ -5517,6 +6422,11 @@ internal static partial class CodeGeneratorExtensions
     {
         for (int i = 0; i < tupleType.ItemsTypes.Length; ++i)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (i > 0)
             {
                 generator

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ConditionalCodeSpecification.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ConditionalCodeSpecification.cs
@@ -69,6 +69,11 @@ public readonly struct ConditionalCodeSpecification
         Action<CodeGenerator> conditionalCode,
         FrameworkType frameworkType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (frameworkType == FrameworkType.NotEmitted)
         {
             return generator;
@@ -114,11 +119,21 @@ public readonly struct ConditionalCodeSpecification
         ConditionalCodeSpecification[] conditionalSpecifications,
         Action<CodeGenerator, Action<CodeGenerator>, int> appendCallback)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return;
+        }
+
         FrameworkType lastFrameworkType = FrameworkType.All;
         int i = 0;
 
         foreach (ConditionalCodeSpecification spec in conditionalSpecifications)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             if (spec.condition == FrameworkType.NotEmitted)
             {
                 continue;
@@ -175,6 +190,11 @@ public readonly struct ConditionalCodeSpecification
     ConditionalCodeSpecification[] conditionalSpecifications,
     Action<CodeGenerator, Action<CodeGenerator>, int> appendCallback)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return;
+        }
+
         if (conditionalSpecifications.Length == 0)
         {
             return;
@@ -196,6 +216,11 @@ public readonly struct ConditionalCodeSpecification
             // If we have no conditionals, just append the "all".
             for (int i = 0; i < all.Count; i++)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 ConditionalCodeSpecification spec = all[i];
                 appendCallback(generator, spec.Append, i);
             }
@@ -217,6 +242,11 @@ public readonly struct ConditionalCodeSpecification
                         .Concat(net80)
                         .Concat(net80OrGreater))
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 appendCallback(generator, spec.Append, i);
                 i++;
             }
@@ -234,6 +264,11 @@ public readonly struct ConditionalCodeSpecification
                     all
                         .Concat(net80))
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 appendCallback(generator, spec.Append, i);
                 i++;
             }
@@ -263,6 +298,11 @@ public readonly struct ConditionalCodeSpecification
                         all
                             .Concat(preNet80))
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 appendCallback(generator, spec.Append, i);
                 i++;
             }
@@ -276,6 +316,11 @@ public readonly struct ConditionalCodeSpecification
             int i = 0;
             foreach (ConditionalCodeSpecification spec in all)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 appendCallback(generator, spec.Append, i);
                 i++;
             }

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/FormatHandlers/FormatHandlerExtensions.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/FormatHandlers/FormatHandlerExtensions.cs
@@ -25,6 +25,11 @@ public static class FormatHandlerExtensions
     {
         foreach (T handler in handlers)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (handler.AppendFormatEqualsTBody(generator, typeDeclaration, format))
             {
                 return true;
@@ -48,6 +53,11 @@ public static class FormatHandlerExtensions
     {
         foreach (T handler in handlers)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (handler.AppendFormatPublicStaticMethods(generator, typeDeclaration, format))
             {
                 return true;
@@ -71,6 +81,11 @@ public static class FormatHandlerExtensions
     {
         foreach (T handler in handlers)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (handler.AppendFormatPublicMethods(generator, typeDeclaration, format))
             {
                 return true;
@@ -94,6 +109,11 @@ public static class FormatHandlerExtensions
     {
         foreach (T handler in handlers)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (handler.AppendFormatPrivateStaticMethods(generator, typeDeclaration, format))
             {
                 return true;
@@ -117,6 +137,11 @@ public static class FormatHandlerExtensions
     {
         foreach (T handler in handlers)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (handler.AppendFormatPrivateMethods(generator, typeDeclaration, format))
             {
                 return true;
@@ -140,6 +165,11 @@ public static class FormatHandlerExtensions
     {
         foreach (T handler in handlers)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (handler.AppendFormatConversionOperators(generator, typeDeclaration, format))
             {
                 return true;
@@ -163,6 +193,11 @@ public static class FormatHandlerExtensions
     {
         foreach (T handler in handlers)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (handler.AppendFormatPublicStaticProperties(generator, typeDeclaration, format))
             {
                 return true;
@@ -186,6 +221,11 @@ public static class FormatHandlerExtensions
     {
         foreach (T handler in handlers)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (handler.AppendFormatPublicProperties(generator, typeDeclaration, format))
             {
                 return true;
@@ -209,6 +249,11 @@ public static class FormatHandlerExtensions
     {
         foreach (T handler in handlers)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (handler.AppendFormatConstructors(generator, typeDeclaration, format))
             {
                 return true;
@@ -349,6 +394,11 @@ public static class FormatHandlerExtensions
     {
         foreach (T handler in handlers)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return false;
+            }
+
             if (handler.AppendFormatAssertion(generator, format, valueIdentifier, validationContextIdentifier, includeType))
             {
                 return true;

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Array.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Array.cs
@@ -29,6 +29,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -67,6 +72,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendArrayEnumerator(this CodeGenerator generator, TypeDeclaration typeDeclaration, string variableName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendIndent("using ");
 
@@ -96,6 +106,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendValidateNonTupleItemsType(this CodeGenerator generator, ArrayItemsTypeDeclaration arrayItems, bool enumeratorIsCorrectType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendLineIndent("if (level > ValidationLevel.Basic)")
             .AppendLineIndent("{")
@@ -152,6 +167,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendValidateUnevaluatedItemsType(this CodeGenerator generator, ArrayItemsTypeDeclaration arrayItems, bool enumeratorIsCorrectType)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendLineIndent("if (!result.HasEvaluatedLocalOrAppliedItemIndex(length))")
             .AppendLineIndent("{")
@@ -209,6 +229,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendLineIndent("if (valueKind != JsonValueKind.Array)")
             .AppendLineIndent("{")
@@ -220,6 +245,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         foreach (IArrayValidationKeyword keyword in typeDeclaration.Keywords().OfType<IArrayValidationKeyword>())
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendLineIndent(
                     "ignoredResult = ignoredResult.PushValidationLocationProperty(",
@@ -242,6 +272,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         foreach (IChildValidationHandler child in children)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidateMethodSetup(generator, typeDeclaration);
         }
 
@@ -284,6 +319,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
             foreach (IChildArrayItemValidationHandler child in children.OfType<IChildArrayItemValidationHandler>())
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 child.AppendArrayItemValidationCode(generator, typeDeclaration);
             }
 
@@ -304,6 +344,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         foreach (IChildValidationHandler child in children)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidationCode(generator, typeDeclaration);
         }
 

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Composition.AllOf.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Composition.AllOf.cs
@@ -23,6 +23,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -60,6 +65,11 @@ public static partial class ValidationCodeGeneratorExtensions
     {
         foreach (IChildValidationHandler child in children)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidationCode(generator, typeDeclaration);
         }
 

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Composition.AnyOf.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Composition.AnyOf.cs
@@ -23,6 +23,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -56,6 +61,11 @@ public static partial class ValidationCodeGeneratorExtensions
     {
         foreach (IChildValidationHandler child in children)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidationCode(generator, typeDeclaration);
         }
 

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Composition.OneOf.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Composition.OneOf.cs
@@ -28,6 +28,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -61,6 +66,11 @@ public static partial class ValidationCodeGeneratorExtensions
     {
         foreach (IChildValidationHandler child in children)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidationCode(generator, typeDeclaration);
         }
 

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Const.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Const.cs
@@ -33,6 +33,11 @@ public static partial class ValidationCodeGeneratorExtensions
         IReadOnlyCollection<IChildValidationHandler> children,
         uint parentHandlerPriority)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -58,6 +63,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendConstValidation(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         var keywords =
             typeDeclaration.Keywords()
                 .OfType<ISingleConstantValidationKeyword>()
@@ -72,6 +82,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         foreach (ISingleConstantValidationKeyword keyword in keywords)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             string constField = generator.GetPropertyNameInScope(keyword.Keyword, rootScope: generator.ValidationClassScope());
 
             string realisedMethodName = generator.GetUniqueMethodNameInScope(keyword.Keyword, prefix: "Validate");
@@ -185,6 +200,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         static void AppendValidText(CodeGenerator generator, ISingleConstantValidationKeyword keyword, string constantValue)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("the value '{value}' matched '")
                 .Append(SymbolDisplay.FormatLiteral(constantValue, true).Trim('"'))
@@ -193,6 +213,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         static void AppendDetailedInvalidText(CodeGenerator generator, ISingleConstantValidationKeyword keyword, string constantValue)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("the value '{value}' did not match '")
                 .Append(SymbolDisplay.FormatLiteral(constantValue, true).Trim('"'))
@@ -201,6 +226,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         static void AppendInvalidText(CodeGenerator generator, ISingleConstantValidationKeyword keyword, string constantValue)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("the value did not match '")
                 .Append(SymbolDisplay.FormatLiteral(constantValue, true).Trim('"'))

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Constants.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Constants.cs
@@ -15,6 +15,11 @@ public static partial class ValidationCodeGeneratorExtensions
 {
     private static CodeGenerator AppendValidationConstantFields(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ValidationConstants() is IReadOnlyDictionary<IValidationConstantProviderKeyword, JsonElement[]> constants)
         {
             AppendValidationConstantFields(generator, constants);
@@ -25,6 +30,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendStringValidationConstantProperties(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ValidationConstants() is IReadOnlyDictionary<IValidationConstantProviderKeyword, JsonElement[]> constants)
         {
             AppendStringValidationConstantProperties(generator, constants);
@@ -35,11 +45,21 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendRegexValidationFields(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ValidationRegularExpressions() is IReadOnlyDictionary<IValidationRegexProviderKeyword, IReadOnlyList<string>> regexes)
         {
             // Ensure we have a got a stable ordering of the keywords.
             foreach (KeyValuePair<IValidationRegexProviderKeyword, IReadOnlyList<string>> constant in regexes.OrderBy(k => k.Key.Keyword))
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 if (constant.Value.Count > 0)
                 {
                     generator.AppendSeparatorLine();
@@ -65,11 +85,21 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendRegexValidationFactoryMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ValidationRegularExpressions() is IReadOnlyDictionary<IValidationRegexProviderKeyword, IReadOnlyList<string>> regexes)
         {
             // Ensure we have a got a stable ordering of the keywords.
             foreach (KeyValuePair<IValidationRegexProviderKeyword, IReadOnlyList<string>> constant in regexes.OrderBy(k => k.Key.Keyword))
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 if (constant.Value.Count == 1)
                 {
                     generator
@@ -98,6 +128,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendNumberValidationConstantField(this CodeGenerator generator, IKeyword keyword, int? index, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.Number, "The value must be a number.");
 
         string memberName = generator.GetStaticReadOnlyFieldNameInScope(keyword.Keyword, suffix: index?.ToString());
@@ -117,6 +152,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendIntegerValidationConstantField(this CodeGenerator generator, IKeyword keyword, int? index, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.Number, "The value must be a number.");
 
         string memberName = generator.GetStaticReadOnlyFieldNameInScope(keyword.Keyword, suffix: index?.ToString());
@@ -136,6 +176,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendStringValidationConstantField(this CodeGenerator generator, IKeyword keyword, int? index, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.String, "The value must be a string.");
 
         string memberName = generator.GetStaticReadOnlyFieldNameInScope(keyword.Keyword, suffix: index?.ToString());
@@ -155,6 +200,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendNullValidationConstantField(this CodeGenerator generator, IKeyword keyword, int? index, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.Null, "The value must be null.");
 
         string memberName = generator.GetStaticReadOnlyFieldNameInScope(keyword.Keyword, suffix: index?.ToString());
@@ -172,6 +222,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendBooleanValidationConstantField(this CodeGenerator generator, IKeyword keyword, int? index, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.True || value.ValueKind == JsonValueKind.False, "The value must be a boolean.");
 
         string memberName = generator.GetStaticReadOnlyFieldNameInScope(keyword.Keyword, suffix: index?.ToString());
@@ -191,6 +246,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendObjectValidationConstantField(this CodeGenerator generator, IKeyword keyword, int? index, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.Object, "The value must be an object.");
 
         string memberName = generator.GetStaticReadOnlyFieldNameInScope(keyword.Keyword, suffix: index?.ToString());
@@ -210,6 +270,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendArrayValidationConstantField(this CodeGenerator generator, IKeyword keyword, int? index, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.Array, "The value must be an array.");
 
         string memberName = generator.GetStaticReadOnlyFieldNameInScope(keyword.Keyword, suffix: index?.ToString());
@@ -229,6 +294,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendStringValidationConstantProperty(this CodeGenerator generator, IKeyword keyword, int? index, in JsonElement value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         Debug.Assert(value.ValueKind == JsonValueKind.String, "The value must be a string.");
 
         string memberName = generator.GetPropertyNameInScope(keyword.Keyword, suffix: index?.ToString());
@@ -249,6 +319,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendRegexValidationField(this CodeGenerator generator, IKeyword keyword, int? index)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string? suffix = index?.ToString();
         string memberName = generator.GetStaticReadOnlyFieldNameInScope(keyword.Keyword, suffix: suffix);
         string methodName = generator.GetMethodNameInScope(keyword.Keyword, prefix: "Create", suffix: suffix);
@@ -268,10 +343,15 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendRegexValidationFactoryMethod(this CodeGenerator generator, IKeyword keyword, int? index, string value)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string memberName = generator.GetMethodNameInScope(keyword.Keyword, prefix: "Create", suffix: index?.ToString());
 
         // TODO: Figure out how to get the SourceGenerator to run when generating code
-        // in the specs. This commented out code works fine in "real life".
+        // in the specs.
         return generator
                 .AppendLine("#if NET8_0_OR_GREATER && !SPECFLOW_BUILD")
                     .AppendIndent("[GeneratedRegex(")
@@ -294,6 +374,11 @@ public static partial class ValidationCodeGeneratorExtensions
         // Ensure we have a got a stable ordering of the keywords.
         foreach (KeyValuePair<IValidationConstantProviderKeyword, JsonElement[]> constant in constants.OrderBy(k => k.Key.Keyword))
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             int count = constant.Value.Length;
 
             if (count > 0)
@@ -303,6 +388,11 @@ public static partial class ValidationCodeGeneratorExtensions
                 int? i = count == 1 ? null : 1;
                 foreach (JsonElement value in constant.Value)
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return generator;
+                    }
+
                     switch (value.ValueKind)
                     {
                         case JsonValueKind.Array:
@@ -358,6 +448,11 @@ public static partial class ValidationCodeGeneratorExtensions
         // Ensure we have a got a stable ordering of the keywords.
         foreach (KeyValuePair<IValidationConstantProviderKeyword, JsonElement[]> constant in constants.OrderBy(k => k.Key.Keyword))
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             int count = constant.Value.Length;
 
             if (count > 0)
@@ -367,6 +462,11 @@ public static partial class ValidationCodeGeneratorExtensions
                 int i = 1;
                 foreach (JsonElement value in constant.Value)
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return generator;
+                    }
+
                     if (value.ValueKind == JsonValueKind.String)
                     {
                         if (count == 1)

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Format.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Format.cs
@@ -29,6 +29,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -59,6 +64,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ExplicitFormat() is not string explicitFormat)
         {
             return generator;
@@ -82,6 +92,11 @@ public static partial class ValidationCodeGeneratorExtensions
         // Let the children have their go, then work through he standard
         foreach (IChildValidationHandler child in children)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidationCode(generator, typeDeclaration);
         }
 
@@ -99,6 +114,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
             foreach (IFormatProviderKeyword keyword in keywords)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 generator
                     .AppendKeywordValidationResult(isValid: true, keyword, "result", g => AppendIgnoredFormat(g, explicitFormat), useInterpolatedString: true);
             }
@@ -115,6 +135,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         static void AppendIgnoredFormat(CodeGenerator generator, string format)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("ignored '")
                 .Append(format)
@@ -123,6 +148,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         static void AppendUnknownFormat(CodeGenerator generator, string format)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("ignored '")
                 .Append(format)
@@ -131,6 +161,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         static void AppendIgnoredValueKind(CodeGenerator generator, string format, JsonValueKind expectedValueKind)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("ignored '")
                 .Append(format)
@@ -141,6 +176,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         static CodeGenerator AppendUnkownFormat(CodeGenerator generator, TypeDeclaration typeDeclaration, string explicitFormat)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendLineIndent("if (level == ValidationLevel.Verbose)")
                 .AppendLineIndent("{")
@@ -151,6 +191,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
             foreach (IFormatProviderKeyword keyword in unknownKeywords)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 generator
                     .AppendKeywordValidationResult(isValid: true, keyword, "unknownResult", g => AppendUnknownFormat(g, explicitFormat));
             }
@@ -166,6 +211,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         static CodeGenerator AppendValueKindCheck(CodeGenerator generator, TypeDeclaration typeDeclaration, string explicitFormat, JsonValueKind expectedValueKind)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendLineIndent("if (valueKind != JsonValueKind.", expectedValueKind.ToString(), ")")
                 .AppendLineIndent("{")
@@ -177,6 +227,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
             foreach (IFormatProviderKeyword keyword in typeDeclaration.Keywords().OfType<IFormatProviderKeyword>())
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 generator
                     .AppendKeywordValidationResult(isValid: true, keyword, "ignoredResult", g => AppendIgnoredValueKind(g, explicitFormat, expectedValueKind), useInterpolatedString: true);
             }

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.If.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.If.cs
@@ -23,6 +23,11 @@ public static partial class ValidationCodeGeneratorExtensions
         string methodName,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -56,6 +61,11 @@ public static partial class ValidationCodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.IfSubschemaType() is SingleSubschemaKeywordTypeDeclaration ifType)
         {
             AppendIf(generator, ifType);
@@ -75,6 +85,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         static void AppendElse(CodeGenerator generator, SingleSubschemaKeywordTypeDeclaration elseType)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendSeparatorLine()
                 .AppendLineIndent("if (!ifResult.IsValid)")
@@ -143,6 +158,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         static void AppendThen(CodeGenerator generator, SingleSubschemaKeywordTypeDeclaration thenType)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendSeparatorLine()
                 .AppendLineIndent("if (ifResult.IsValid)")
@@ -211,6 +231,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         static void AppendIf(CodeGenerator generator, SingleSubschemaKeywordTypeDeclaration ifType)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendSeparatorLine()
                 .AppendLineIndent("if (level > ValidationLevel.Basic)")

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Not.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Not.cs
@@ -31,6 +31,11 @@ public static partial class ValidationCodeGeneratorExtensions
         IReadOnlyCollection<IChildValidationHandler> children,
         uint parentHandlerPriority)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -56,6 +61,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendNotValidation(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         var keywords =
             typeDeclaration.Keywords()
                 .OfType<INotValidationKeyword>()
@@ -70,6 +80,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         foreach (INotValidationKeyword keyword in keywords)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (keyword.TryGetNotType(typeDeclaration, out ReducedTypeDeclaration? value) &&
                 value is ReducedTypeDeclaration notType)
             {

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Number.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Number.cs
@@ -29,6 +29,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -59,6 +64,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendLineIndent("if (valueKind != JsonValueKind.Number)")
             .AppendLineIndent("{")
@@ -70,6 +80,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         foreach (INumberValidationKeyword keyword in typeDeclaration.Keywords().OfType<INumberValidationKeyword>())
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendLineIndent(
                     "ignoredResult = ignoredResult.PushValidationLocationProperty(",
@@ -95,6 +110,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         foreach (IChildValidationHandler child in children)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidationCode(generator, typeDeclaration);
         }
 

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Object.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Object.cs
@@ -29,6 +29,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -63,6 +68,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendEnumeratorType(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.FallbackObjectPropertyType() is FallbackObjectPropertyType propertyType && !propertyType.ReducedType.IsBuiltInJsonAnyType())
         {
             generator
@@ -85,6 +95,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendJsonObjectPropertyType(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.FallbackObjectPropertyType() is FallbackObjectPropertyType propertyType && !propertyType.ReducedType.IsBuiltInJsonAnyType())
         {
             generator
@@ -108,6 +123,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendObjectEnumerator(this CodeGenerator generator, TypeDeclaration typeDeclaration, string variableName)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendIndent("using ")
             .AppendEnumeratorType(typeDeclaration)
@@ -121,6 +141,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendLineIndent("if (valueKind != JsonValueKind.Object)")
             .AppendLineIndent("{")
@@ -132,6 +157,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         foreach (IObjectValidationKeyword keyword in typeDeclaration.Keywords().OfType<IObjectValidationKeyword>())
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendLineIndent(
                     "ignoredResult = ignoredResult.PushValidationLocationProperty(",
@@ -154,6 +184,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         foreach (IChildValidationHandler child in children)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidateMethodSetup(generator, typeDeclaration);
         }
 
@@ -198,6 +233,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
             foreach (IChildObjectPropertyValidationHandler child in children.OfType<IChildObjectPropertyValidationHandler>())
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 child.AppendObjectPropertyValidationCode(generator, typeDeclaration);
             }
 
@@ -210,6 +250,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         foreach (IChildValidationHandler child in children)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidationCode(generator, typeDeclaration);
         }
 

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.String.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.String.cs
@@ -29,6 +29,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -59,6 +64,11 @@ public static partial class ValidationCodeGeneratorExtensions
         TypeDeclaration typeDeclaration,
         IReadOnlyCollection<IChildValidationHandler> children)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendLineIndent("if (valueKind != JsonValueKind.String)")
             .AppendLineIndent("{")
@@ -70,6 +80,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
         foreach (IStringValidationKeyword keyword in typeDeclaration.Keywords().OfType<IStringValidationKeyword>())
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .AppendLineIndent(
                     "ignoredResult = ignoredResult.PushValidationLocationProperty(",
@@ -117,6 +132,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
             foreach (IChildValidationHandler child in children)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 child.AppendValidationCode(generator, typeDeclaration);
             }
 

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Type.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Type.cs
@@ -29,6 +29,11 @@ public static partial class ValidationCodeGeneratorExtensions
         IReadOnlyCollection<IChildValidationHandler> children,
         uint parentHandlerPriority)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <summary>")
@@ -91,6 +96,11 @@ public static partial class ValidationCodeGeneratorExtensions
         this CodeGenerator generator,
         CoreTypes allowedCoreTypes)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
 #if NET8_0_OR_GREATER
         CoreTypesValidationResults coreTypeResultsToMerge = default;
 #else

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.cs
@@ -166,6 +166,11 @@ public static partial class ValidationCodeGeneratorExtensions
         string validationMethodName,
         string[] parameters)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendIndent(generator.ResultIdentifierName())
@@ -187,6 +192,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendUsingEvaluatedItems(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.RequiresItemsEvaluationTracking())
         {
             generator
@@ -207,6 +217,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendUsingEvaluatedProperties(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.RequiresPropertyEvaluationTracking())
         {
             generator
@@ -233,10 +248,20 @@ public static partial class ValidationCodeGeneratorExtensions
         IReadOnlyCollection<IChildValidationHandler> children,
         uint parentHandlerPriority)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (IChildValidationHandler child in children
             .Where(c => c.ValidationHandlerPriority <= parentHandlerPriority)
             .OrderBy(c => c.ValidationHandlerPriority))
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidationSetup(generator, typeDeclaration);
         }
 
@@ -257,10 +282,20 @@ public static partial class ValidationCodeGeneratorExtensions
         IReadOnlyCollection<IChildValidationHandler> children,
         uint parentHandlerPriority)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (IChildValidationHandler child in children
             .Where(c => c.ValidationHandlerPriority > parentHandlerPriority)
             .OrderBy(c => c.ValidationHandlerPriority))
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidationSetup(generator, typeDeclaration);
         }
 
@@ -281,10 +316,20 @@ public static partial class ValidationCodeGeneratorExtensions
         IReadOnlyCollection<IChildValidationHandler> children,
         uint parentHandlerPriority)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (IChildValidationHandler child in children
             .Where(c => c.ValidationHandlerPriority <= parentHandlerPriority)
             .OrderBy(c => c.ValidationHandlerPriority))
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidationCode(generator, typeDeclaration);
         }
 
@@ -305,10 +350,20 @@ public static partial class ValidationCodeGeneratorExtensions
         IReadOnlyCollection<IChildValidationHandler> children,
         uint parentHandlerPriority)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (IChildValidationHandler child in children
             .Where(c => c.ValidationHandlerPriority > parentHandlerPriority)
             .OrderBy(c => c.ValidationHandlerPriority))
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             child.AppendValidationCode(generator, typeDeclaration);
         }
 
@@ -322,6 +377,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator PushValidationClassNameAndScope(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (!generator.TryPeekMetadata(ValidationClassNameKey, out (string, string) _))
         {
             string validationClassName = generator.GetTypeNameInScope(ValidationClassBaseName);
@@ -353,6 +413,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// </remarks>
     public static CodeGenerator PushJsonPropertyNamesClassNameAndScope(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (generator.TryPeekMetadata(JsonPropertyNamesClassNameKey, out (string, string) _))
         {
             return generator;
@@ -382,8 +447,18 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator PushValidationHandlerMethodNames(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (IKeywordValidationHandler handler in typeDeclaration.OrderedValidationHandlers(generator.LanguageProvider))
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             string validateMethodName = generator.GetMethodNameInScope(handler.GetType().Name, rootScope: generator.ValidationClassScope());
             generator
                 .PushMetadata(handler.GetType().FullName!, validateMethodName);
@@ -400,8 +475,18 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator PopValidationHandlerMethodNames(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (IKeywordValidationHandler handler in typeDeclaration.OrderedValidationHandlers(generator.LanguageProvider))
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             generator
                 .PopMetadata(handler.GetType().FullName!);
         }
@@ -417,6 +502,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendValidationClass(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .BeginValidationClass()
                 .AppendValidationConstantFields(typeDeclaration)
@@ -435,6 +525,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     public static CodeGenerator AppendValidateMethod(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator
             .AppendSeparatorLine()
             .AppendLineIndent("/// <inheritdoc/>");
@@ -557,6 +652,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     private static CodeGenerator AppendRequiresJsonValueKind(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.RequiresJsonValueKind())
         {
             generator
@@ -570,6 +670,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator PopIdentifierIfRequiresJsonValueKind(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.RequiresJsonValueKind())
         {
             generator
@@ -586,6 +691,11 @@ public static partial class ValidationCodeGeneratorExtensions
     /// <returns>A reference to the generator having completed the operation.</returns>
     private static CodeGenerator AppendShortCircuit(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         return generator
             .AppendSeparatorLine()
             .AppendIndent("if (")
@@ -613,9 +723,19 @@ public static partial class ValidationCodeGeneratorExtensions
     this CodeGenerator generator,
     string[] parameters)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         bool isFirst = true;
         foreach (string parameter in parameters)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (isFirst)
             {
                 isFirst = false;
@@ -633,6 +753,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator BeginValidationClass(this CodeGenerator generator)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         string validationClassName = generator.ValidationClassName();
 
         return generator
@@ -650,6 +775,11 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendValidationHandlerSetup(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         generator.AppendUsingEvaluatedItems(typeDeclaration);
         generator.AppendUsingEvaluatedProperties(typeDeclaration);
 
@@ -665,8 +795,18 @@ public static partial class ValidationCodeGeneratorExtensions
         this CodeGenerator generator,
         TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (IKeywordValidationHandler handler in typeDeclaration.OrderedValidationHandlers(generator.LanguageProvider))
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             handler.AppendValidationMethodCall(generator, typeDeclaration);
         }
 
@@ -675,8 +815,18 @@ public static partial class ValidationCodeGeneratorExtensions
 
     private static CodeGenerator AppendValidationMethods(this CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (IKeywordValidationHandler handler in typeDeclaration.OrderedValidationHandlers(generator.LanguageProvider))
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             handler.AppendValidationMethod(generator, typeDeclaration);
         }
 

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/AllOfChildHandlers/AllOfSubschemaValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/AllOfChildHandlers/AllOfSubschemaValidationHandler.cs
@@ -28,14 +28,29 @@ public class AllOfSubschemaValidationHandler : IChildValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.AllOfCompositionTypes() is IReadOnlyDictionary<IAllOfSubschemaValidationKeyword, IReadOnlyCollection<TypeDeclaration>> subschemaDictionary)
         {
             foreach (IAllOfSubschemaValidationKeyword keyword in subschemaDictionary.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 IReadOnlyCollection<TypeDeclaration> subschemaTypes = subschemaDictionary[keyword];
                 int i = 0;
                 foreach (TypeDeclaration subschemaType in subschemaTypes)
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return generator;
+                    }
+
                     ReducedTypeDeclaration reducedType = subschemaType.ReducedTypeDeclaration();
                     string pathModifier = keyword.GetPathModifier(reducedType, i);
                     string resultName = generator.GetUniqueVariableNameInScope("Result", prefix: keyword.Keyword, suffix: i.ToString());

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/AnyOfChildHandlers/AnyOfConstValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/AnyOfChildHandlers/AnyOfConstValidationHandler.cs
@@ -29,10 +29,20 @@ public class AnyOfConstValidationHandler : IChildValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.AnyOfConstantValues() is IReadOnlyDictionary<IAnyOfConstantValidationKeyword, JsonElement[]> constDictionary)
         {
             foreach (IAnyOfConstantValidationKeyword keyword in constDictionary.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 string localMethodName = generator.GetUniqueMethodNameInScope(keyword.Keyword, prefix: "Validate");
 
                 generator
@@ -65,6 +75,11 @@ public class AnyOfConstValidationHandler : IChildValidationHandler
                 int count = constValues.Length;
                 for (int i = 1; i <= count; ++i)
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return generator;
+                    }
+
                     string constField =
                         generator.GetPropertyNameInScope(
                             keyword.Keyword,

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/AnyOfChildHandlers/AnyOfSubschemaValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/AnyOfChildHandlers/AnyOfSubschemaValidationHandler.cs
@@ -28,10 +28,20 @@ public class AnyOfSubschemaValidationHandler : IChildValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.AnyOfCompositionTypes() is IReadOnlyDictionary<IAnyOfSubschemaValidationKeyword, IReadOnlyCollection<TypeDeclaration>> subschemaDictionary)
         {
             foreach (IAnyOfSubschemaValidationKeyword keyword in subschemaDictionary.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 string localMethodName = generator.GetUniqueMethodNameInScope(keyword.Keyword, prefix: "Validate");
 
                 generator
@@ -68,6 +78,11 @@ public class AnyOfSubschemaValidationHandler : IChildValidationHandler
 
                 foreach (TypeDeclaration subschemaType in subschemaTypes)
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return generator;
+                    }
+
                     ReducedTypeDeclaration reducedType = subschemaType.ReducedTypeDeclaration();
                     string pathModifier = keyword.GetPathModifier(reducedType, i);
                     string contextName = generator.GetUniqueVariableNameInScope("ChildContext", prefix: keyword.Keyword, suffix: i.ToString());

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ArrayChildHandlers/ArrayLengthValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ArrayChildHandlers/ArrayLengthValidationHandler.cs
@@ -34,8 +34,18 @@ public class ArrayLengthValidationHandler : IChildArrayItemValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (IArrayLengthConstantValidationKeyword keyword in typeDeclaration.Keywords().OfType<IArrayLengthConstantValidationKeyword>())
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (!keyword.TryGetOperator(typeDeclaration, out Operator op) || op == Operator.None)
             {
                 continue;
@@ -106,6 +116,11 @@ public class ArrayLengthValidationHandler : IChildArrayItemValidationHandler
 
         static void GetValidMessage(CodeGenerator generator, Operator op, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("array of length {length} ")
                 .AppendTextForOperator(op)
@@ -116,6 +131,11 @@ public class ArrayLengthValidationHandler : IChildArrayItemValidationHandler
 
         static void GetInvalidMessage(CodeGenerator generator, Operator op, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("array of length {length} ")
                 .AppendTextForInverseOperator(op)
@@ -126,6 +146,11 @@ public class ArrayLengthValidationHandler : IChildArrayItemValidationHandler
 
         static void GetSimplifiedInvalidMessage(CodeGenerator generator, Operator op)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendTextForInverseOperator(op)
                 .Append(" the required length.");

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ArrayChildHandlers/ContainsValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ArrayChildHandlers/ContainsValidationHandler.cs
@@ -25,6 +25,11 @@ public class ContainsValidationHandler : IChildArrayItemValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         IArrayContainsValidationKeyword? keywordOrDefault = typeDeclaration.Keywords().OfType<IArrayContainsValidationKeyword>().FirstOrDefault();
         if (keywordOrDefault is IArrayContainsValidationKeyword containsKeyword)
         {
@@ -37,6 +42,11 @@ public class ContainsValidationHandler : IChildArrayItemValidationHandler
 
             foreach (IArrayContainsCountConstantValidationKeyword keyword in typeDeclaration.Keywords().OfType<IArrayContainsCountConstantValidationKeyword>())
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 if (!keyword.TryGetOperator(typeDeclaration, out Operator op) || op == Operator.None)
                 {
                     continue;
@@ -167,6 +177,11 @@ public class ContainsValidationHandler : IChildArrayItemValidationHandler
 
         static void GetValidMessage(CodeGenerator generator, Operator op, string containsCountName, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("count of {")
                 .Append(containsCountName)
@@ -179,6 +194,11 @@ public class ContainsValidationHandler : IChildArrayItemValidationHandler
 
         static void GetInvalidMessage(CodeGenerator generator, Operator op, string containsCountName, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("count of {")
                 .Append(containsCountName)
@@ -200,6 +220,11 @@ public class ContainsValidationHandler : IChildArrayItemValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidateMethodSetup(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.Keywords().OfType<IArrayContainsValidationKeyword>().Any())
         {
             string containsCountName = generator.GetUniqueVariableNameInScope("containsCount");
@@ -217,6 +242,11 @@ public class ContainsValidationHandler : IChildArrayItemValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendArrayItemValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         IArrayContainsValidationKeyword? keywordOrDefault = typeDeclaration.Keywords().OfType<IArrayContainsValidationKeyword>().FirstOrDefault();
         if (keywordOrDefault is IArrayContainsValidationKeyword keyword)
         {

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ArrayChildHandlers/TupleValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ArrayChildHandlers/TupleValidationHandler.cs
@@ -34,6 +34,11 @@ public class TupleValidationHandler : IChildArrayItemValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendArrayItemValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ExplicitTupleType() is TupleTypeDeclaration tupleTypeDeclaration)
         {
             generator
@@ -45,6 +50,11 @@ public class TupleValidationHandler : IChildArrayItemValidationHandler
             int i = 0;
             foreach (ReducedTypeDeclaration item in tupleTypeDeclaration.ItemsTypes)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 generator
                     .AppendSeparatorLine()
                     .AppendIndent("case ")

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ArrayChildHandlers/UniqueItemsValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ArrayChildHandlers/UniqueItemsValidationHandler.cs
@@ -34,6 +34,11 @@ public class UniqueItemsValidationHandler : IChildArrayItemValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendArrayItemValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         IUniqueItemsArrayValidationKeyword? keywordOrDefault = typeDeclaration.Keywords().OfType<IUniqueItemsArrayValidationKeyword>().FirstOrDefault(k => k.RequiresUniqueItems(typeDeclaration));
         if (keywordOrDefault is IUniqueItemsArrayValidationKeyword keyword)
         {

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/NumberChildHandlers/NumberRangeValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/NumberChildHandlers/NumberRangeValidationHandler.cs
@@ -28,8 +28,18 @@ public class NumberRangeValidationHandler : IChildValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (INumberConstantValidationKeyword keyword in typeDeclaration.Keywords().OfType<INumberConstantValidationKeyword>())
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (!keyword.TryGetOperator(typeDeclaration, out Operator op) || op == Operator.None)
             {
                 continue;
@@ -110,6 +120,11 @@ public class NumberRangeValidationHandler : IChildValidationHandler
 
         static void GetValidMessage(CodeGenerator generator, Operator op, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("{value} ")
                 .AppendTextForOperator(op)
@@ -120,6 +135,11 @@ public class NumberRangeValidationHandler : IChildValidationHandler
 
         static void GetInvalidMessage(CodeGenerator generator, Operator op, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("{value} ")
                 .AppendTextForInverseOperator(op)
@@ -130,6 +150,11 @@ public class NumberRangeValidationHandler : IChildValidationHandler
 
         static void GetSimplifiedInvalidMessage(CodeGenerator generator, Operator op)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendTextForInverseOperator(op)
                 .Append(" the required value.");
@@ -137,6 +162,11 @@ public class NumberRangeValidationHandler : IChildValidationHandler
 
         static void AppendMultipleOf(CodeGenerator generator, INumberConstantValidationKeyword keyword, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendSeparatorLine()
                 .AppendLineIndent("if (value.HasJsonElementBacking")
@@ -148,6 +178,11 @@ public class NumberRangeValidationHandler : IChildValidationHandler
 
         static void AppendStandardOperator(CodeGenerator generator, INumberConstantValidationKeyword keyword, Operator op, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendSeparatorLine()
 

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/DependentRequiredValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/DependentRequiredValidationHandler.cs
@@ -22,12 +22,27 @@ public class DependentRequiredValidationHandler : IChildValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.DependentRequired() is IReadOnlyDictionary<IObjectDependentRequiredValidationKeyword, IReadOnlyCollection<DependentRequiredDeclaration>> properties)
         {
             foreach (IObjectDependentRequiredValidationKeyword keyword in properties.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 foreach (DependentRequiredDeclaration dependentRequired in properties[keyword])
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return generator;
+                    }
+
                     string propertyNameAsQuotedString = SymbolDisplay.FormatLiteral(dependentRequired.JsonPropertyName, true);
 
                     generator
@@ -41,6 +56,11 @@ public class DependentRequiredValidationHandler : IChildValidationHandler
                     int i = 0;
                     foreach (string dependency in dependentRequired.Dependencies)
                     {
+                        if (generator.IsCancellationRequested)
+                        {
+                            return generator;
+                        }
+
                         string quotedDependency = SymbolDisplay.FormatLiteral(dependency, true);
                         string quotedPathModifier = SymbolDisplay.FormatLiteral(keyword.GetPathModifier(dependentRequired, i), true);
                         generator
@@ -67,6 +87,11 @@ public class DependentRequiredValidationHandler : IChildValidationHandler
                     i = 0;
                     foreach (string dependency in dependentRequired.Dependencies)
                     {
+                        if (generator.IsCancellationRequested)
+                        {
+                            return generator;
+                        }
+
                         string quotedDependency = SymbolDisplay.FormatLiteral(dependency, true);
                         string quotedPathModifier = SymbolDisplay.FormatLiteral(keyword.GetPathModifier(dependentRequired, i), true);
                         generator
@@ -91,6 +116,11 @@ public class DependentRequiredValidationHandler : IChildValidationHandler
 
         static void AppendErrorText(CodeGenerator generator, string quotedPropertyName, string quotedDependency)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("the property '")
                 .Append(quotedPropertyName.Trim('"'))
@@ -101,6 +131,11 @@ public class DependentRequiredValidationHandler : IChildValidationHandler
 
         static void AppendValidText(CodeGenerator generator, string quotedPropertyName, string quotedDependency)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("the property '")
                 .Append(quotedPropertyName.Trim('"'))
@@ -111,6 +146,11 @@ public class DependentRequiredValidationHandler : IChildValidationHandler
 
         static void AppendBody(CodeGenerator generator, IObjectDependentRequiredValidationKeyword keyword, string propertyNameAsQuotedString, string quotedDependency, string quotedPathModifier)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("{")
                 .PushIndent()

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/DependentSchemasValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/DependentSchemasValidationHandler.cs
@@ -34,15 +34,30 @@ public class DependentSchemasValidationHandler : IChildObjectPropertyValidationH
     /// <inheritdoc/>
     public CodeGenerator AppendObjectPropertyValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.DependentSchemasSubschemaTypes()
             is IReadOnlyDictionary<IObjectPropertyDependentSchemasValidationKeyword, IReadOnlyCollection<DependentSchemaDeclaration>> dependentSchemas)
         {
             foreach (IObjectPropertyDependentSchemasValidationKeyword keyword in dependentSchemas.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 int i = 0;
 
                 foreach (DependentSchemaDeclaration dependentSchema in dependentSchemas[keyword])
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return generator;
+                    }
+
                     string resultName = generator.GetUniqueVariableNameInScope("Result", prefix: keyword.Keyword, suffix: i.ToString());
                     string quotedPropertyName = SymbolDisplay.FormatLiteral(dependentSchema.JsonPropertyName, true);
                     generator

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PatternPropertiesValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PatternPropertiesValidationHandler.cs
@@ -34,6 +34,11 @@ public class PatternPropertiesValidationHandler : IChildObjectPropertyValidation
     /// <inheritdoc/>
     public CodeGenerator AppendObjectPropertyValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.PatternProperties() is IReadOnlyDictionary<IObjectPatternPropertyValidationKeyword, IReadOnlyCollection<PatternPropertyDeclaration>> patternProperties)
         {
             generator
@@ -42,6 +47,11 @@ public class PatternPropertiesValidationHandler : IChildObjectPropertyValidation
 
             foreach (IReadOnlyCollection<PatternPropertyDeclaration> patternPropertyCollection in patternProperties.Values)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 int index = 1;
                 bool hasIndex = patternPropertyCollection.Count > 1;
                 foreach (PatternPropertyDeclaration patternProperty in patternPropertyCollection)
@@ -56,6 +66,11 @@ public class PatternPropertiesValidationHandler : IChildObjectPropertyValidation
 
         static void AppendPatternPropertyValidation(CodeGenerator generator, PatternPropertyDeclaration property, int? index)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             string regexAccessor =
                 generator.GetStaticReadOnlyFieldNameInScope(
                     property.Keyword.Keyword,

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PropertiesValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PropertiesValidationHandler.cs
@@ -34,6 +34,11 @@ public class PropertiesValidationHandler : IChildObjectPropertyValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendObjectPropertyValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ExplicitProperties() is IReadOnlyCollection<PropertyDeclaration> properties)
         {
             generator
@@ -72,6 +77,11 @@ public class PropertiesValidationHandler : IChildObjectPropertyValidationHandler
 
         static void AppendPropertyValidation(CodeGenerator generator, PropertyDeclaration property)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLine(
                     "if (property.NameEquals(",
@@ -132,6 +142,11 @@ public class PropertiesValidationHandler : IChildObjectPropertyValidationHandler
 
         static void AppendLocalEvaluatedProperty(CodeGenerator generator, FallbackObjectPropertyType fallbackProperty, bool enumeratorIsCorrectType)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("if (!result.HasEvaluatedLocalProperty(propertyCount))")
                 .AppendLineIndent("{")
@@ -146,6 +161,11 @@ public class PropertiesValidationHandler : IChildObjectPropertyValidationHandler
 
         static void AppendLocalAndAppliedEvaluatedProperty(CodeGenerator generator, FallbackObjectPropertyType fallbackProperty, bool enumeratorIsCorrectType)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendLineIndent("if (!result.HasEvaluatedLocalOrAppliedProperty(propertyCount))")
                 .AppendLineIndent("{")
@@ -160,6 +180,11 @@ public class PropertiesValidationHandler : IChildObjectPropertyValidationHandler
 
         static void AppendFallbackPropertyValidation(CodeGenerator generator, FallbackObjectPropertyType fallbackPropertyType, bool enumeratorIsCorrectType)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                     .AppendLineIndent("if (level > ValidationLevel.Basic)")
                     .AppendLineIndent("{")

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PropertyCountValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PropertyCountValidationHandler.cs
@@ -36,6 +36,11 @@ public class PropertyCountValidationHandler : IChildArrayItemValidationHandler
     {
         foreach (IPropertyCountConstantValidationKeyword keyword in typeDeclaration.Keywords().OfType<IPropertyCountConstantValidationKeyword>())
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (!keyword.TryGetOperator(typeDeclaration, out Operator op) || op == Operator.None)
             {
                 continue;
@@ -107,6 +112,11 @@ public class PropertyCountValidationHandler : IChildArrayItemValidationHandler
 
         static void GetValidMessage(CodeGenerator generator, Operator op, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("property count {propertyCount} ")
                 .AppendTextForOperator(op)
@@ -117,6 +127,11 @@ public class PropertyCountValidationHandler : IChildArrayItemValidationHandler
 
         static void GetInvalidMessage(CodeGenerator generator, Operator op, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("array of length {propertyCount} ")
                 .AppendTextForInverseOperator(op)
@@ -127,6 +142,11 @@ public class PropertyCountValidationHandler : IChildArrayItemValidationHandler
 
         static void GetSimplifiedInvalidMessage(CodeGenerator generator, Operator op)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendTextForInverseOperator(op)
                 .Append(" the required count.");

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PropertyNamesValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PropertyNamesValidationHandler.cs
@@ -34,6 +34,11 @@ public class PropertyNamesValidationHandler : IChildObjectPropertyValidationHand
     /// <inheritdoc/>
     public CodeGenerator AppendObjectPropertyValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.PropertyNamesSubschemaType() is SingleSubschemaKeywordTypeDeclaration propertyNameType)
         {
             generator

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/RequiredValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/RequiredValidationHandler.cs
@@ -23,10 +23,20 @@ public class RequiredValidationHandler : IChildObjectPropertyValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ExplicitRequiredProperties() is IReadOnlyCollection<PropertyDeclaration> properties)
         {
             foreach (PropertyDeclaration property in properties)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 // Don't bother with properties that have default values.
                 if (property.ReducedPropertyType.HasDefaultValue() || property.RequiredKeyword is not IObjectRequiredPropertyValidationKeyword keyword)
                 {
@@ -85,6 +95,11 @@ public class RequiredValidationHandler : IChildObjectPropertyValidationHandler
 
         static void AppendErrorText(CodeGenerator generator, PropertyDeclaration property)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("the required property '")
                 .Append(SymbolDisplay.FormatLiteral(property.JsonPropertyName, true).Trim('"'))
@@ -93,6 +108,11 @@ public class RequiredValidationHandler : IChildObjectPropertyValidationHandler
 
         static void AppendValidText(CodeGenerator generator, PropertyDeclaration property)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("the required property '")
                 .Append(SymbolDisplay.FormatLiteral(property.JsonPropertyName, true).Trim('"'))
@@ -103,6 +123,11 @@ public class RequiredValidationHandler : IChildObjectPropertyValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidateMethodSetup(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.ExplicitRequiredProperties() is IReadOnlyCollection<PropertyDeclaration> properties)
         {
             generator
@@ -110,6 +135,11 @@ public class RequiredValidationHandler : IChildObjectPropertyValidationHandler
 
             foreach (PropertyDeclaration property in properties)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 // Don't bother with properties that have default values.
                 if (property.ReducedPropertyType.HasDefaultValue())
                 {

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/OneOfChildHandlers/OneOfSubschemaValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/OneOfChildHandlers/OneOfSubschemaValidationHandler.cs
@@ -28,10 +28,20 @@ public class OneOfSubschemaValidationHandler : IChildValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         if (typeDeclaration.OneOfCompositionTypes() is IReadOnlyDictionary<IOneOfSubschemaValidationKeyword, IReadOnlyCollection<TypeDeclaration>> subschemaDictionary)
         {
             foreach (IOneOfSubschemaValidationKeyword keyword in subschemaDictionary.Keys)
             {
+                if (generator.IsCancellationRequested)
+                {
+                    return generator;
+                }
+
                 string localMethodName = generator.GetUniqueMethodNameInScope(keyword.Keyword, prefix: "Validate");
 
                 generator
@@ -69,6 +79,11 @@ public class OneOfSubschemaValidationHandler : IChildValidationHandler
 
                 foreach (TypeDeclaration subschemaType in subschemaTypes)
                 {
+                    if (generator.IsCancellationRequested)
+                    {
+                        return generator;
+                    }
+
                     ReducedTypeDeclaration reducedType = subschemaType.ReducedTypeDeclaration();
                     string pathModifier = keyword.GetPathModifier(reducedType, i);
                     string contextName = generator.GetUniqueVariableNameInScope("ChildContext", prefix: keyword.Keyword, suffix: i.ToString());

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/StringChildHandlers/StringLengthValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/StringChildHandlers/StringLengthValidationHandler.cs
@@ -28,8 +28,18 @@ public class StringLengthValidationHandler : IChildValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (IStringLengthConstantValidationKeyword keyword in typeDeclaration.Keywords().OfType<IStringLengthConstantValidationKeyword>())
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             if (!keyword.TryGetOperator(typeDeclaration, out Operator op) || op == Operator.None)
             {
                 continue;
@@ -103,6 +113,11 @@ public class StringLengthValidationHandler : IChildValidationHandler
 
         static void GetValidMessage(CodeGenerator generator, Operator op, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("{input.ToString()} of {length} ")
                 .AppendTextForOperator(op)
@@ -113,6 +128,11 @@ public class StringLengthValidationHandler : IChildValidationHandler
 
         static void GetInvalidMessage(CodeGenerator generator, Operator op, string memberName)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("{input.ToString()} of {length} ")
                 .AppendTextForInverseOperator(op)
@@ -123,6 +143,11 @@ public class StringLengthValidationHandler : IChildValidationHandler
 
         static void GetSimplifiedInvalidMessage(CodeGenerator generator, Operator op)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .AppendTextForInverseOperator(op)
                 .Append(" the required length.");

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/StringChildHandlers/StringRegexValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/StringChildHandlers/StringRegexValidationHandler.cs
@@ -28,8 +28,18 @@ public class StringRegexValidationHandler : IChildValidationHandler
     /// <inheritdoc/>
     public CodeGenerator AppendValidationCode(CodeGenerator generator, TypeDeclaration typeDeclaration)
     {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
         foreach (IStringRegexValidationProviderKeyword keyword in typeDeclaration.Keywords().OfType<IStringRegexValidationProviderKeyword>())
         {
+            if (generator.IsCancellationRequested)
+            {
+                return generator;
+            }
+
             // Gets the field name for the validation constant.
             string memberName = generator.GetStaticReadOnlyFieldNameInScope(keyword.Keyword);
             if (keyword.TryGetValidationRegularExpressions(typeDeclaration, out IReadOnlyList<string>? regularExpressions))
@@ -99,6 +109,11 @@ public class StringRegexValidationHandler : IChildValidationHandler
 
         static void GetValidMessage(CodeGenerator generator, string expression)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("{input.ToString()} matched ")
                 .Append(" '")
@@ -108,6 +123,11 @@ public class StringRegexValidationHandler : IChildValidationHandler
 
         static void GetInvalidMessage(CodeGenerator generator, string expression)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("{input.ToString()} did not match ")
                 .Append(" '")
@@ -117,6 +137,11 @@ public class StringRegexValidationHandler : IChildValidationHandler
 
         static void GetSimplifiedInvalidMessage(CodeGenerator generator, string expression)
         {
+            if (generator.IsCancellationRequested)
+            {
+                return;
+            }
+
             generator
                 .Append("The value did not match ")
                 .Append(" '")

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/CustomKeywords/CustomKeywords.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/CustomKeywords/CustomKeywords.cs
@@ -18,9 +18,10 @@ public static class CustomKeywords
     /// <param name="schemaValue">The current schema value.</param>
     /// <param name="currentLocation">The current location.</param>
     /// <param name="vocabulary">The current vocabulary.</param>
-    public static void ApplyBeforeScope(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static void ApplyBeforeScope(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
-        Apply<IApplyBeforeScopeCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary);
+        Apply<IApplyBeforeScopeCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary, cancellationToken);
     }
 
     /// <summary>
@@ -28,9 +29,10 @@ public static class CustomKeywords
     /// </summary>
     /// <param name="typeBuilderContext">The current type builder context.</param>
     /// <param name="typeDeclaration">The type declaration.</param>
-    public static void ApplyBeforeScope(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static void ApplyBeforeScope(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
-        Apply<IApplyBeforeScopeCustomKeyword>(typeBuilderContext, typeDeclaration);
+        Apply<IApplyBeforeScopeCustomKeyword>(typeBuilderContext, typeDeclaration, cancellationToken);
     }
 
     /// <summary>
@@ -40,9 +42,10 @@ public static class CustomKeywords
     /// <param name="schemaValue">The current schema value.</param>
     /// <param name="currentLocation">The current location.</param>
     /// <param name="vocabulary">The current vocabulary.</param>
-    public static void ApplyBeforeEnteringScope(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static void ApplyBeforeEnteringScope(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
-        Apply<IApplyBeforeEnteringScopeCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary);
+        Apply<IApplyBeforeEnteringScopeCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary, cancellationToken);
     }
 
     /// <summary>
@@ -50,9 +53,10 @@ public static class CustomKeywords
     /// </summary>
     /// <param name="typeBuilderContext">The current type builder context.</param>
     /// <param name="typeDeclaration">The type declaration.</param>
-    public static void ApplyBeforeEnteringScope(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static void ApplyBeforeEnteringScope(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
-        Apply<IApplyBeforeEnteringScopeCustomKeyword>(typeBuilderContext, typeDeclaration);
+        Apply<IApplyBeforeEnteringScopeCustomKeyword>(typeBuilderContext, typeDeclaration, cancellationToken);
     }
 
     /// <summary>
@@ -62,9 +66,10 @@ public static class CustomKeywords
     /// <param name="schemaValue">The current schema value.</param>
     /// <param name="currentLocation">The current location.</param>
     /// <param name="vocabulary">The current vocabulary.</param>
-    public static void ApplyAfterEnteringScope(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static void ApplyAfterEnteringScope(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
-        Apply<IApplyAfterEnteringScopeCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary);
+        Apply<IApplyAfterEnteringScopeCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary, cancellationToken);
     }
 
     /// <summary>
@@ -72,9 +77,10 @@ public static class CustomKeywords
     /// </summary>
     /// <param name="typeBuilderContext">The current type builder context.</param>
     /// <param name="typeDeclaration">The type declaration.</param>
-    public static void ApplyAfterEnteringScope(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static void ApplyAfterEnteringScope(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
-        Apply<IApplyAfterEnteringScopeCustomKeyword>(typeBuilderContext, typeDeclaration);
+        Apply<IApplyAfterEnteringScopeCustomKeyword>(typeBuilderContext, typeDeclaration, cancellationToken);
     }
 
     /// <summary>
@@ -84,9 +90,10 @@ public static class CustomKeywords
     /// <param name="schemaValue">The current schema value.</param>
     /// <param name="currentLocation">The current location.</param>
     /// <param name="vocabulary">The current vocabulary.</param>
-    public static void ApplyBeforeAnchors(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static void ApplyBeforeAnchors(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
-        Apply<IApplyBeforeAnchorsCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary);
+        Apply<IApplyBeforeAnchorsCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary, cancellationToken);
     }
 
     /// <summary>
@@ -96,9 +103,10 @@ public static class CustomKeywords
     /// <param name="schemaValue">The current schema value.</param>
     /// <param name="currentLocation">The current location.</param>
     /// <param name="vocabulary">The current vocabulary.</param>
-    public static void ApplyBeforeSubschemas(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static void ApplyBeforeSubschemas(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
-        Apply<IApplyBeforeSubschemasCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary);
+        Apply<IApplyBeforeSubschemasCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary, cancellationToken);
     }
 
     /// <summary>
@@ -106,9 +114,10 @@ public static class CustomKeywords
     /// </summary>
     /// <param name="typeBuilderContext">The current type builder context.</param>
     /// <param name="typeDeclaration">The type declaration.</param>
-    public static void ApplyBeforeSubschemas(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static void ApplyBeforeSubschemas(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
-        Apply<IApplyBeforeSubschemasCustomKeyword>(typeBuilderContext, typeDeclaration);
+        Apply<IApplyBeforeSubschemasCustomKeyword>(typeBuilderContext, typeDeclaration, cancellationToken);
     }
 
     /// <summary>
@@ -118,9 +127,10 @@ public static class CustomKeywords
     /// <param name="schemaValue">The current schema value.</param>
     /// <param name="currentLocation">The current location.</param>
     /// <param name="vocabulary">The current vocabulary.</param>
-    public static void ApplyAfterSubschemas(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static void ApplyAfterSubschemas(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
-        Apply<IApplyAfterSubschemasCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary);
+        Apply<IApplyAfterSubschemasCustomKeyword>(schemaRegistry, schemaValue, currentLocation, vocabulary, cancellationToken);
     }
 
     /// <summary>
@@ -128,26 +138,27 @@ public static class CustomKeywords
     /// </summary>
     /// <param name="typeBuilderContext">The current type builder context.</param>
     /// <param name="typeDeclaration">The type declaration.</param>
-    public static void ApplyAfterSubschemas(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    /// <param name="cancellationToken">The cancellation token.</param>
+    public static void ApplyAfterSubschemas(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
-        Apply<IApplyAfterSubschemasCustomKeyword>(typeBuilderContext, typeDeclaration);
+        Apply<IApplyAfterSubschemasCustomKeyword>(typeBuilderContext, typeDeclaration, cancellationToken);
     }
 
-    private static void Apply<T>(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary)
+    private static void Apply<T>(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
         where T : notnull, ISchemaRegistrationCustomKeyword
     {
         foreach (T keyword in vocabulary.Keywords.OfType<T>())
         {
-            keyword.Apply(schemaRegistry, schemaValue, currentLocation, vocabulary);
+            keyword.Apply(schemaRegistry, schemaValue, currentLocation, vocabulary, cancellationToken);
         }
     }
 
-    private static void Apply<T>(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    private static void Apply<T>(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
         where T : notnull, ITypeBuilderCustomKeyword
     {
         foreach (T keyword in typeDeclaration.Keywords().OfType<T>())
         {
-            keyword.Apply(typeBuilderContext, typeDeclaration);
+            keyword.Apply(typeBuilderContext, typeDeclaration, cancellationToken);
         }
     }
 }

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/DocumentResolvers/CompoundDocumentResolver.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/DocumentResolvers/CompoundDocumentResolver.cs
@@ -50,7 +50,7 @@ public class CompoundDocumentResolver : IDocumentResolver
 
         foreach (IDocumentResolver resolver in this.documentResolvers)
         {
-            JsonElement? element = await resolver.TryResolve(reference).ConfigureAwait(false);
+            JsonElement? element = await resolver.TryResolve(reference);
             if (element is JsonElement je)
             {
                 return je;

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/DocumentResolvers/FileSystemDocumentResolver.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/DocumentResolvers/FileSystemDocumentResolver.cs
@@ -70,7 +70,7 @@ public class FileSystemDocumentResolver : IDocumentResolver
 #else
             using Stream stream = File.OpenRead(path);
 #endif
-            result = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
+            result = await JsonDocument.ParseAsync(stream);
             this.documents.Add(path, result);
             return JsonPointerUtilities.ResolvePointer(result, reference.Fragment);
         }

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/DocumentResolvers/HttpClientDocumentResolver.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/DocumentResolvers/HttpClientDocumentResolver.cs
@@ -68,11 +68,11 @@ public class HttpClientDocumentResolver : IDocumentResolver
         try
         {
 #if NET8_0_OR_GREATER
-            await using Stream stream = await this.httpClient.GetStreamAsync(uri).ConfigureAwait(false);
+            await using Stream stream = await this.httpClient.GetStreamAsync(uri);
 #else
-            using Stream stream = await this.httpClient.GetStreamAsync(uri).ConfigureAwait(false);
+            using Stream stream = await this.httpClient.GetStreamAsync(uri);
 #endif
-            result = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
+            result = await JsonDocument.ParseAsync(stream);
             this.documents.Add(uri, result);
             if (JsonPointerUtilities.TryResolvePointer(result, reference.Fragment, out JsonElement? element))
             {

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/ILocalSubschemaRegistrationKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/ILocalSubschemaRegistrationKeyword.cs
@@ -18,5 +18,6 @@ public interface ILocalSubschemaRegistrationKeyword : IKeyword
     /// <param name="schema">The parent schema containing the keyword.</param>
     /// <param name="currentLocation">The current location in the tree.</param>
     /// <param name="vocabulary">The current vocabulary.</param>
-    void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary);
+    /// <param name="cancellationToken">The cancellation token.</param>
+    void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken);
 }

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/IPropertyProviderKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/IPropertyProviderKeyword.cs
@@ -21,9 +21,11 @@ public interface IPropertyProviderKeyword : IKeyword
     /// <param name="target">The target for the properties.</param>
     /// <param name="visitedTypeDeclarations">The type declarations we have already seen.</param>
     /// <param name="treatRequiredAsOptional">Whether to treat the required properties as optional.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     void CollectProperties(
         TypeDeclaration source,
         TypeDeclaration target,
         HashSet<TypeDeclaration> visitedTypeDeclarations,
-        bool treatRequiredAsOptional);
+        bool treatRequiredAsOptional,
+        CancellationToken cancellationToken);
 }

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/ISchemaRegistrationCustomKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/ISchemaRegistrationCustomKeyword.cs
@@ -22,5 +22,6 @@ public interface ISchemaRegistrationCustomKeyword
     /// <param name="schemaValue">The current schema value.</param>
     /// <param name="currentLocation">The current location.</param>
     /// <param name="vocabulary">The current vocabulary.</param>
-    void Apply(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary);
+    /// <param name="cancellationToken">The cancellation token.</param>
+    void Apply(JsonSchemaRegistry schemaRegistry, in JsonElement schemaValue, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken);
 }

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/ISubschemaTypeBuilderKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/ISubschemaTypeBuilderKeyword.cs
@@ -14,6 +14,7 @@ public interface ISubschemaTypeBuilderKeyword : IKeyword
     /// </summary>
     /// <param name="typeBuilderContext">The type builder context.</param>
     /// <param name="typeDeclaration">The type declaration.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="ValueTask"/> which completes once the types are built.</returns>
-    ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration);
+    ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken);
 }

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/ITypeBuilderCustomKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/ITypeBuilderCustomKeyword.cs
@@ -18,5 +18,6 @@ public interface ITypeBuilderCustomKeyword
     /// </summary>
     /// <param name="typeBuilderContext">The current type builder context.</param>
     /// <param name="typeDeclaration">The type declaration.</param>
-    void Apply(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration);
+    /// <param name="cancellationToken">The cancellation token.</param>
+    void Apply(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken);
 }

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/AdditionalItemsKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/AdditionalItemsKeyword.cs
@@ -38,24 +38,24 @@ public sealed class AdditionalItemsKeyword
     public uint ValidationPriority => ValidationPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         // The 2019-09 and earlier additionalItems keyword only applies if the schema is also has an array-of-schema Items keyword.
         if (schema.TryGetKeyword(this, out JsonElement value) &&
             schema.TryGetKeyword(ItemsWithSchemaOrArrayOfSchemaKeyword.Instance, out JsonElement itemsKeywordValue) &&
             itemsKeywordValue.ValueKind == JsonValueKind.Array)
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         // The 2019-09 and earlier additionalItems keyword only applies if the schema is also has an array-of-schema Items keyword.
         if (this.HasKeyword(typeDeclaration) && AllowsAdditionalItems(typeDeclaration))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/AdditionalPropertiesKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/AdditionalPropertiesKeyword.cs
@@ -37,20 +37,20 @@ public sealed class AdditionalPropertiesKeyword
     public uint ValidationPriority => ValidationPriorities.Last;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.HasKeyword(this))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/AnyOfKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/AnyOfKeyword.cs
@@ -34,20 +34,20 @@ public sealed class AnyOfKeyword
     public uint ValidationPriority => ValidationPriorities.Composition;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForArrayOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForArrayOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.TryGetKeyword(this, out JsonElement value))
         {
-            await Subschemas.BuildSubschemaTypesForArrayOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForArrayOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ContainsKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ContainsKeyword.cs
@@ -35,20 +35,20 @@ public sealed class ContainsKeyword
     public uint ValidationPriority => ValidationPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.HasKeyword(this))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ContentSchemaKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ContentSchemaKeyword.cs
@@ -31,20 +31,20 @@ public sealed class ContentSchemaKeyword
     public ReadOnlySpan<byte> KeywordUtf8 => "contentSchema"u8;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.HasKeyword(this))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DefinitionsKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DefinitionsKeyword.cs
@@ -27,16 +27,16 @@ public sealed class DefinitionsKeyword : IDefinitionsKeyword, INonStructuralKeyw
     public ReadOnlySpan<byte> KeywordUtf8 => "definitions"u8;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForMapOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForMapOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         // We do not build types for definitions by default, unless they are referenced from elsewhere.
 #if NET8_0_OR_GREATER

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DependenciesKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DependenciesKeyword.cs
@@ -37,20 +37,20 @@ public sealed class DependenciesKeyword
     public uint ValidationPriority => ValidationPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForMapOfSchemaIfValueIsSchemaLikeProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForMapOfSchemaIfValueIsSchemaLikeProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.TryGetKeyword(this, out JsonElement value))
         {
-            await Subschemas.BuildSubschemaTypesForMapOfSchemaIfValueIsSchemaLikeProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForMapOfSchemaIfValueIsSchemaLikeProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value, cancellationToken);
         }
     }
 
@@ -58,14 +58,15 @@ public sealed class DependenciesKeyword
     public bool CanReduce(in JsonElement schemaValue) => Reduction.CanReduceNonReducingKeyword(schemaValue, this.KeywordUtf8);
 
     /// <inheritdoc />
-    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional)
+    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional, CancellationToken cancellationToken)
     {
         PropertyProvider.CollectPropertiesForMapOfPropertyNameToSchema(
             KeywordPath,
             source,
             target,
             visitedTypeDeclarations,
-            true);
+            true,
+            cancellationToken);
     }
 
     /// <inheritdoc />

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DependentSchemasKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DependentSchemasKeyword.cs
@@ -37,20 +37,20 @@ public sealed class DependentSchemasKeyword
     public uint ValidationPriority => ValidationPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForMapOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForMapOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.TryGetKeyword(this, out JsonElement value))
         {
-            await Subschemas.BuildSubschemaTypesForMapOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForMapOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value, cancellationToken);
         }
     }
 
@@ -58,14 +58,15 @@ public sealed class DependentSchemasKeyword
     public bool CanReduce(in JsonElement schemaValue) => Reduction.CanReduceNonReducingKeyword(schemaValue, this.KeywordUtf8);
 
     /// <inheritdoc />
-    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional)
+    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional, CancellationToken cancellationToken)
     {
         PropertyProvider.CollectPropertiesForMapOfPropertyNameToSchema(
             KeywordPath,
             source,
             target,
             visitedTypeDeclarations,
-            true);
+            true,
+            cancellationToken);
     }
 
     /// <inheritdoc />

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DollarDefsKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DollarDefsKeyword.cs
@@ -27,16 +27,16 @@ public sealed class DollarDefsKeyword : IDefinitionsKeyword, INonStructuralKeywo
     public ReadOnlySpan<byte> KeywordUtf8 => "$defs"u8;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForMapOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForMapOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         // We do not build types for $defs by default, unless they are referenced from elsewhere.
 #if NET8_0_OR_GREATER

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DollarDynamicRefKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DollarDynamicRefKeyword.cs
@@ -36,7 +36,7 @@ public sealed class DollarDynamicRefKeyword : IDynamicReferenceKeyword, IComposi
     public bool CanReduce(in JsonElement schemaValue) => true;
 
     /// <inheritdoc/>
-    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional)
+    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional, CancellationToken cancellationToken)
     {
         if (source.SubschemaTypeDeclarations.TryGetValue(KeywordPath, out TypeDeclaration? subschema))
         {
@@ -44,7 +44,8 @@ public sealed class DollarDynamicRefKeyword : IDynamicReferenceKeyword, IComposi
                 subschema,
                 target,
                 visitedTypeDeclarations,
-                treatRequiredAsOptional);
+                treatRequiredAsOptional,
+                cancellationToken);
         }
     }
 
@@ -66,14 +67,14 @@ public sealed class DollarDynamicRefKeyword : IDynamicReferenceKeyword, IComposi
             : CoreTypes.None;
 
     /// <inheritdoc/>
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         LocatedSchema schema = typeDeclaration.LocatedSchema;
 
         if (schema.Schema.ValueKind == JsonValueKind.Object && schema.Schema.TryGetProperty(this.KeywordUtf8, out JsonElement value))
         {
             string referencePath = value.GetString() ?? throw new InvalidOperationException("The reference path cannot be null.");
-            await References.ResolveDynamicReference(typeBuilderContext, typeDeclaration, KeywordPathReference, referencePath).ConfigureAwait(false);
+            await References.ResolveDynamicReference(typeBuilderContext, typeDeclaration, KeywordPathReference, referencePath, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DollarRecursiveRefKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DollarRecursiveRefKeyword.cs
@@ -36,7 +36,7 @@ public sealed class DollarRecursiveRefKeyword : IRecursiveReferenceKeyword, ICom
     public bool CanReduce(in JsonElement schemaValue) => true;
 
     /// <inheritdoc/>
-    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional)
+    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional, CancellationToken cancellationToken)
     {
         if (source.SubschemaTypeDeclarations.TryGetValue(KeywordPath, out TypeDeclaration? subschema))
         {
@@ -44,7 +44,8 @@ public sealed class DollarRecursiveRefKeyword : IRecursiveReferenceKeyword, ICom
                 subschema,
                 target,
                 visitedTypeDeclarations,
-                treatRequiredAsOptional);
+                treatRequiredAsOptional,
+                cancellationToken);
         }
     }
 
@@ -66,14 +67,14 @@ public sealed class DollarRecursiveRefKeyword : IRecursiveReferenceKeyword, ICom
             : CoreTypes.None;
 
     /// <inheritdoc/>
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         LocatedSchema schema = typeDeclaration.LocatedSchema;
 
         if (schema.Schema.ValueKind == JsonValueKind.Object && schema.Schema.TryGetProperty(this.KeywordUtf8, out JsonElement value))
         {
             string referencePath = value.GetString() ?? throw new InvalidOperationException("The reference path cannot be null.");
-            await References.ResolveRecursiveReference(typeBuilderContext, typeDeclaration, KeywordPathReference, referencePath).ConfigureAwait(false);
+            await References.ResolveRecursiveReference(typeBuilderContext, typeDeclaration, KeywordPathReference, referencePath, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DollarRefHidesSiblingsKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DollarRefHidesSiblingsKeyword.cs
@@ -36,7 +36,7 @@ public sealed class DollarRefHidesSiblingsKeyword : IReferenceKeyword, IHidesSib
     public bool CanReduce(in JsonElement schemaValue) => true;
 
     /// <inheritdoc/>
-    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional)
+    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional, CancellationToken cancellationToken)
     {
         if (source.SubschemaTypeDeclarations.TryGetValue(KeywordPath, out TypeDeclaration? subschema))
         {
@@ -44,7 +44,8 @@ public sealed class DollarRefHidesSiblingsKeyword : IReferenceKeyword, IHidesSib
                 subschema,
                 target,
                 visitedTypeDeclarations,
-                treatRequiredAsOptional);
+                treatRequiredAsOptional,
+                cancellationToken);
         }
     }
 
@@ -55,14 +56,14 @@ public sealed class DollarRefHidesSiblingsKeyword : IReferenceKeyword, IHidesSib
             : CoreTypes.None;
 
     /// <inheritdoc/>
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         LocatedSchema schema = typeDeclaration.LocatedSchema;
 
         if (schema.Schema.ValueKind == JsonValueKind.Object && schema.Schema.TryGetProperty(this.KeywordUtf8, out JsonElement value))
         {
             string referencePath = value.GetString() ?? throw new InvalidOperationException("The reference path cannot be null.");
-            await References.ResolveStandardReference(typeBuilderContext, typeDeclaration, KeywordPathReference, referencePath).ConfigureAwait(false);
+            await References.ResolveStandardReference(typeBuilderContext, typeDeclaration, KeywordPathReference, referencePath, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DollarRefKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/DollarRefKeyword.cs
@@ -36,7 +36,7 @@ public sealed class DollarRefKeyword : IReferenceKeyword, ICompositionKeyword
     public bool CanReduce(in JsonElement schemaValue) => true;
 
     /// <inheritdoc/>
-    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional)
+    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional, CancellationToken cancellationToken)
     {
         if (source.SubschemaTypeDeclarations.TryGetValue(KeywordPath, out TypeDeclaration? subschema))
         {
@@ -44,7 +44,8 @@ public sealed class DollarRefKeyword : IReferenceKeyword, ICompositionKeyword
                 subschema,
                 target,
                 visitedTypeDeclarations,
-                treatRequiredAsOptional);
+                treatRequiredAsOptional,
+                cancellationToken);
         }
     }
 
@@ -55,14 +56,14 @@ public sealed class DollarRefKeyword : IReferenceKeyword, ICompositionKeyword
             : CoreTypes.None;
 
     /// <inheritdoc/>
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         LocatedSchema schema = typeDeclaration.LocatedSchema;
 
         if (schema.Schema.ValueKind == JsonValueKind.Object && schema.Schema.TryGetProperty(this.KeywordUtf8, out JsonElement value))
         {
             string referencePath = value.GetString() ?? throw new InvalidOperationException("The reference path cannot be null.");
-            await References.ResolveStandardReference(typeBuilderContext, typeDeclaration, KeywordPathReference, referencePath).ConfigureAwait(false);
+            await References.ResolveStandardReference(typeBuilderContext, typeDeclaration, KeywordPathReference, referencePath, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ElseKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ElseKeyword.cs
@@ -38,20 +38,20 @@ public sealed class ElseKeyword
     public uint PropertyProviderPriority => PropertyProviderPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.HasKeyword(this))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 
@@ -59,7 +59,7 @@ public sealed class ElseKeyword
     public bool CanReduce(in JsonElement schemaValue) => Reduction.CanReduceNonReducingKeyword(schemaValue, this.KeywordUtf8);
 
     /// <inheritdoc />
-    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional)
+    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional, CancellationToken cancellationToken)
     {
         if (source.SubschemaTypeDeclarations.TryGetValue(KeywordPath, out TypeDeclaration? elseTypeDeclaration))
         {
@@ -67,7 +67,8 @@ public sealed class ElseKeyword
                 elseTypeDeclaration,
                 target,
                 visitedTypeDeclarations,
-                true);
+                true,
+                cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ItemsWithSchemaKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ItemsWithSchemaKeyword.cs
@@ -38,20 +38,20 @@ public sealed class ItemsWithSchemaKeyword
     public uint ValidationPriority => ValidationPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.HasKeyword(this))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ItemsWithSchemaOrArrayOfSchemaKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ItemsWithSchemaOrArrayOfSchemaKeyword.cs
@@ -39,16 +39,16 @@ public sealed class ItemsWithSchemaOrArrayOfSchemaKeyword
     public uint ValidationPriority => ValidationPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaOrArrayOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaOrArrayOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.TryGetKeyword(this, out JsonElement value))
         {
@@ -56,7 +56,8 @@ public sealed class ItemsWithSchemaOrArrayOfSchemaKeyword
                 typeBuilderContext,
                 typeDeclaration,
                 KeywordPathReference,
-                value).ConfigureAwait(false);
+                value,
+                cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/NotKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/NotKeyword.cs
@@ -35,20 +35,20 @@ public sealed class NotKeyword
     public uint ValidationPriority => ValidationPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.HasKeyword(this))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/OneOfKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/OneOfKeyword.cs
@@ -34,20 +34,20 @@ public sealed class OneOfKeyword
     public uint ValidationPriority => ValidationPriorities.Composition;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForArrayOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForArrayOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.TryGetKeyword(this, out JsonElement value))
         {
-            await Subschemas.BuildSubschemaTypesForArrayOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForArrayOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/PatternPropertiesKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/PatternPropertiesKeyword.cs
@@ -37,20 +37,20 @@ public sealed class PatternPropertiesKeyword
     public uint ValidationPriority => ValidationPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForMapOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForMapOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.TryGetKeyword(this, out JsonElement value))
         {
-            await Subschemas.BuildSubschemaTypesForMapOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForMapOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/PrefixItemsKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/PrefixItemsKeyword.cs
@@ -39,20 +39,20 @@ public sealed class PrefixItemsKeyword
     public uint ValidationPriority => ValidationPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForArrayOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForArrayOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.TryGetKeyword(this, out JsonElement value))
         {
-            await Subschemas.BuildSubschemaTypesForArrayOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForArrayOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/PropertiesKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/PropertiesKeyword.cs
@@ -40,20 +40,20 @@ public sealed class PropertiesKeyword
     public uint ValidationPriority => ValidationPriorities.AfterComposition;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForMapOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForMapOfSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.TryGetKeyword(this, out JsonElement value))
         {
-            await Subschemas.BuildSubschemaTypesForMapOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForMapOfSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, value, cancellationToken);
         }
     }
 
@@ -61,13 +61,18 @@ public sealed class PropertiesKeyword
     public bool CanReduce(in JsonElement schemaValue) => Reduction.CanReduceNonReducingKeyword(schemaValue, this.KeywordUtf8);
 
     /// <inheritdoc />
-    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional)
+    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional, CancellationToken cancellationToken)
     {
         if (source.TryGetKeyword(this, out JsonElement properties) &&
             properties.ValueKind == JsonValueKind.Object)
         {
             foreach (JsonProperty property in properties.EnumerateObject())
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 string propertyName = property.Name;
 
                 JsonReference propertyPath = KeywordPathReference.AppendUnencodedPropertyNameToFragment(propertyName);

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/PropertyNamesKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/PropertyNamesKeyword.cs
@@ -36,20 +36,20 @@ public sealed class PropertyNamesKeyword
     public uint ValidationPriority => ValidationPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.HasKeyword(this))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/RequiredKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/RequiredKeyword.cs
@@ -39,7 +39,7 @@ public sealed class RequiredKeyword : IPropertyProviderKeyword, IObjectRequiredP
     public bool CanReduce(in JsonElement schemaValue) => Reduction.CanReduceNonReducingKeyword(schemaValue, this.KeywordUtf8);
 
     /// <inheritdoc />
-    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional)
+    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional, CancellationToken cancellationToken)
     {
         if (source.LocatedSchema.Schema.ValueKind == JsonValueKind.Object &&
             source.LocatedSchema.Schema.TryGetProperty(this.KeywordUtf8, out JsonElement value) &&
@@ -47,6 +47,11 @@ public sealed class RequiredKeyword : IPropertyProviderKeyword, IObjectRequiredP
         {
             foreach (JsonElement property in value.EnumerateArray())
             {
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return;
+                }
+
                 string propertyName = property.GetString() ?? throw new InvalidOperationException("The required properties must be strings.");
                 target.AddOrUpdatePropertyDeclaration(
                     new PropertyDeclaration(

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/TernaryIfKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/TernaryIfKeyword.cs
@@ -33,20 +33,20 @@ public sealed class TernaryIfKeyword : ISubschemaTypeBuilderKeyword, ILocalSubsc
     public uint ValidationPriority => ValidationPriorities.Composition;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.HasKeyword(this))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ThenKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/ThenKeyword.cs
@@ -38,20 +38,20 @@ public sealed class ThenKeyword
     public uint PropertyProviderPriority => PropertyProviderPriorities.Default;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.HasKeyword(this))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 
@@ -59,7 +59,7 @@ public sealed class ThenKeyword
     public bool CanReduce(in JsonElement schemaValue) => Reduction.CanReduceNonReducingKeyword(schemaValue, this.KeywordUtf8);
 
     /// <inheritdoc/>
-    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional)
+    public void CollectProperties(TypeDeclaration source, TypeDeclaration target, HashSet<TypeDeclaration> visitedTypeDeclarations, bool treatRequiredAsOptional, CancellationToken cancellationToken)
     {
         if (source.SubschemaTypeDeclarations.TryGetValue(KeywordPath, out TypeDeclaration? thenTypeDeclaration))
         {
@@ -67,7 +67,8 @@ public sealed class ThenKeyword
                 thenTypeDeclaration,
                 target,
                 visitedTypeDeclarations,
-                true);
+                true,
+                cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/UnevaluatedItemsKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/UnevaluatedItemsKeyword.cs
@@ -39,20 +39,20 @@ public sealed class UnevaluatedItemsKeyword
     public uint ValidationPriority => ValidationPriorities.Last;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.HasKeyword(this))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/UnevaluatedPropertiesKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/UnevaluatedPropertiesKeyword.cs
@@ -42,20 +42,20 @@ public sealed class UnevaluatedPropertiesKeyword
     public uint ValidationPriority => ValidationPriorities.Last;
 
     /// <inheritdoc />
-    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary)
+    public void RegisterLocalSubschema(JsonSchemaRegistry registry, JsonElement schema, JsonReference currentLocation, IVocabulary vocabulary, CancellationToken cancellationToken)
     {
         if (schema.TryGetKeyword(this, out JsonElement value))
         {
-            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary);
+            Subschemas.AddSubschemasForSchemaProperty(registry, this.Keyword, value, currentLocation, vocabulary, cancellationToken);
         }
     }
 
     /// <inheritdoc />
-    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration)
+    public async ValueTask BuildSubschemaTypes(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken)
     {
         if (typeDeclaration.HasKeyword(this))
         {
-            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference).ConfigureAwait(false);
+            await Subschemas.BuildSubschemaTypesForSchemaProperty(typeBuilderContext, typeDeclaration, KeywordPathReference, cancellationToken);
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/LanguageProvider/ILanguageProvider.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/LanguageProvider/ILanguageProvider.cs
@@ -45,12 +45,13 @@ public interface ILanguageProvider
     /// Generates code for one or more type declarations.
     /// </summary>
     /// <param name="typeDeclarations">The type declarations for which to generate code.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The generated code files.</returns>
     /// <remarks>
     /// The type declarations passed to this method should be reduced, and ready to be generated.
-    /// Typically, they will be provided by a call to <see cref="JsonSchemaTypeBuilder.GenerateCodeUsing(ILanguageProvider, TypeDeclaration[])"/>.
+    /// Typically, they will be provided by a call to <see cref="JsonSchemaTypeBuilder.GenerateCodeUsing(ILanguageProvider, CancellationToken, TypeDeclaration[])"/>.
     /// </remarks>
-    IReadOnlyCollection<GeneratedCodeFile> GenerateCodeFor(IEnumerable<TypeDeclaration> typeDeclarations);
+    IReadOnlyCollection<GeneratedCodeFile> GenerateCodeFor(IEnumerable<TypeDeclaration> typeDeclarations, CancellationToken cancellationToken);
 
     /// <summary>
     /// Gets a value indicating whether the type should be generated in this language.
@@ -67,18 +68,21 @@ public interface ILanguageProvider
     /// because it is a built-ins) and mark them appropriately.
     /// </summary>
     /// <param name="typeDeclaration">The type declaration to test.</param>
-    void IdentifyNonGeneratedType(TypeDeclaration typeDeclaration);
+    /// <param name="cancellationToken">The cancellation token.</param>
+    void IdentifyNonGeneratedType(TypeDeclaration typeDeclaration, CancellationToken cancellationToken);
 
     /// <summary>
     /// Set the name for the type declaration, and any outstanding properties, after its subschema names have been set.
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to set the name.</param>
     /// <param name="fallbackName">The name to use as a fallback for the type declaration.</param>
-    void SetNamesBeforeSubschema(TypeDeclaration typeDeclaration, string fallbackName);
+    /// <param name="cancellationToken">The cancellation token.</param>
+    void SetNamesBeforeSubschema(TypeDeclaration typeDeclaration, string fallbackName, CancellationToken cancellationToken);
 
     /// <summary>
     /// Set the name for the type declaration, and any outstanding properties, after its subschema names have been set.
     /// </summary>
     /// <param name="typeDeclaration">The type declaration for which to set the name.</param>
-    void SetNamesAfterSubschema(TypeDeclaration typeDeclaration);
+    /// <param name="cancellationToken">The cancellation token.</param>
+    void SetNamesAfterSubschema(TypeDeclaration typeDeclaration, CancellationToken cancellationToken);
 }

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/References/References.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/References/References.cs
@@ -47,8 +47,14 @@ public static class References
     /// <param name="typeDeclaration">The type declaration.</param>
     /// <param name="subschemaPath">The subschema path.</param>
     /// <param name="referenceValue">The reference value.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="ValueTask"/> which completes when the reference is resolved.</returns>
-    public static async ValueTask ResolveStandardReference(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, JsonReference subschemaPath, string referenceValue)
+    public static async ValueTask ResolveStandardReference(
+        TypeBuilderContext typeBuilderContext,
+        TypeDeclaration typeDeclaration,
+        JsonReference subschemaPath,
+        string referenceValue,
+        CancellationToken cancellationToken)
     {
         JsonReference reference = new(HttpUtility.UrlDecode(referenceValue));
 
@@ -56,7 +62,13 @@ public static class References
             await typeBuilderContext.SchemaRegistry.ResolveBaseReference(
                 typeBuilderContext.Scope.Location,
                 typeBuilderContext.Scope.LocatedSchema,
-                reference);
+                reference,
+                cancellationToken);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
 
         // Now, figure out the pointer or anchor if we have one
         JsonReference schemaForRefPointer;
@@ -66,16 +78,37 @@ public static class References
         if (referenceHasAnchor)
         {
             // The fragment is an anchor
-            (baseSchemaForReferenceLocation, schemaForRefPointer) = Anchors.GetLocationAndPointerForAnchor(baseSchemaForReferenceLocation, baseSchemaForReference, fragmentWithoutLeadingHash);
+            (baseSchemaForReferenceLocation, schemaForRefPointer) =
+                Anchors.GetLocationAndPointerForAnchor(
+                    baseSchemaForReferenceLocation,
+                    baseSchemaForReference,
+                    fragmentWithoutLeadingHash);
         }
         else
         {
             // The fragment is a reference
-            (baseSchemaForReferenceLocation, schemaForRefPointer) = References.GetPointerForReference(typeBuilderContext.SchemaRegistry, baseSchemaForReference, baseSchemaForReferenceLocation, reference);
+            (baseSchemaForReferenceLocation, schemaForRefPointer) =
+                References.GetPointerForReference(
+                    typeBuilderContext.SchemaRegistry,
+                    baseSchemaForReference,
+                    baseSchemaForReferenceLocation,
+                    reference,
+                    cancellationToken);
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
         }
 
         typeBuilderContext.EnterReferenceScope(baseSchemaForReferenceLocation, baseSchemaForReference, schemaForRefPointer);
-        TypeDeclaration subschemaTypeDeclaration = await typeBuilderContext.BuildTypeDeclarationForCurrentScope().ConfigureAwait(false);
+        TypeDeclaration subschemaTypeDeclaration = await typeBuilderContext.BuildTypeDeclarationForCurrentScope(cancellationToken);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
         typeDeclaration.AddSubschemaTypeDeclaration(subschemaPath, subschemaTypeDeclaration);
         typeBuilderContext.LeaveScope();
     }
@@ -87,8 +120,14 @@ public static class References
     /// <param name="typeDeclaration">The type declaration.</param>
     /// <param name="subschemaPath">The subschema path.</param>
     /// <param name="referenceValue">The reference value.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="ValueTask"/> which completes when the reference is resolved.</returns>
-    public static async ValueTask ResolveRecursiveReference(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, JsonReference subschemaPath, string referenceValue)
+    public static async ValueTask ResolveRecursiveReference(
+        TypeBuilderContext typeBuilderContext,
+        TypeDeclaration typeDeclaration,
+        JsonReference subschemaPath,
+        string referenceValue,
+        CancellationToken cancellationToken)
     {
         JsonReference reference = new(HttpUtility.UrlDecode(referenceValue));
 
@@ -96,7 +135,13 @@ public static class References
             await typeBuilderContext.SchemaRegistry.ResolveBaseReference(
                 typeBuilderContext.Scope.Location,
                 typeBuilderContext.Scope.LocatedSchema,
-                reference);
+                reference,
+                cancellationToken);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
 
         // Now, figure out the pointer or anchor if we have one
         JsonReference schemaForRefPointer;
@@ -122,16 +167,37 @@ public static class References
         if (referenceHasAnchor)
         {
             // The fragment is an anchor
-            (baseSchemaForReferenceLocation, schemaForRefPointer) = Anchors.GetLocationAndPointerForAnchor(baseSchemaForReferenceLocation, baseSchemaForReference, fragmentWithoutLeadingHash);
+            (baseSchemaForReferenceLocation, schemaForRefPointer) =
+                Anchors.GetLocationAndPointerForAnchor(
+                    baseSchemaForReferenceLocation,
+                    baseSchemaForReference,
+                    fragmentWithoutLeadingHash);
         }
         else
         {
             // The fragment is a reference
-            (baseSchemaForReferenceLocation, schemaForRefPointer) = References.GetPointerForReference(typeBuilderContext.SchemaRegistry, baseSchemaForReference, baseSchemaForReferenceLocation, reference);
+            (baseSchemaForReferenceLocation, schemaForRefPointer) =
+                References.GetPointerForReference(
+                    typeBuilderContext.SchemaRegistry,
+                    baseSchemaForReference,
+                    baseSchemaForReferenceLocation,
+                    reference,
+                    cancellationToken);
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
         }
 
         typeBuilderContext.EnterReferenceScope(baseSchemaForReferenceLocation, baseSchemaForReference, schemaForRefPointer);
-        TypeDeclaration subschemaTypeDeclaration = await typeBuilderContext.BuildTypeDeclarationForCurrentScope().ConfigureAwait(false);
+        TypeDeclaration subschemaTypeDeclaration = await typeBuilderContext.BuildTypeDeclarationForCurrentScope(cancellationToken);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
         typeDeclaration.AddSubschemaTypeDeclaration(subschemaPath, subschemaTypeDeclaration);
         typeBuilderContext.LeaveScope();
     }
@@ -143,8 +209,14 @@ public static class References
     /// <param name="typeDeclaration">The type declaration.</param>
     /// <param name="subschemaPath">The subschema path.</param>
     /// <param name="referenceValue">The reference value.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>A <see cref="ValueTask"/> which completes when the reference is resolved.</returns>
-    public static async ValueTask ResolveDynamicReference(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, JsonReference subschemaPath, string referenceValue)
+    public static async ValueTask ResolveDynamicReference(
+        TypeBuilderContext typeBuilderContext,
+        TypeDeclaration typeDeclaration,
+        JsonReference subschemaPath,
+        string referenceValue,
+        CancellationToken cancellationToken)
     {
         JsonReference reference = new(HttpUtility.UrlDecode(referenceValue));
 
@@ -152,7 +224,13 @@ public static class References
             await typeBuilderContext.SchemaRegistry.ResolveBaseReference(
                 typeBuilderContext.Scope.Location,
                 typeBuilderContext.Scope.LocatedSchema,
-                reference);
+                reference,
+                cancellationToken);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
 
         // Now, figure out the pointer or anchor if we have one
         JsonReference schemaForRefPointer;
@@ -182,16 +260,34 @@ public static class References
         if (referenceHasAnchor)
         {
             // The fragment is an anchor
-            (baseSchemaForReferenceLocation, schemaForRefPointer) = Anchors.GetLocationAndPointerForAnchor(baseSchemaForReferenceLocation, baseSchemaForReference, fragmentWithoutLeadingHash);
+            (baseSchemaForReferenceLocation, schemaForRefPointer) =
+                Anchors.GetLocationAndPointerForAnchor(baseSchemaForReferenceLocation, baseSchemaForReference, fragmentWithoutLeadingHash);
         }
         else
         {
             // The fragment is a reference
-            (baseSchemaForReferenceLocation, schemaForRefPointer) = References.GetPointerForReference(typeBuilderContext.SchemaRegistry, baseSchemaForReference, baseSchemaForReferenceLocation, reference);
+            (baseSchemaForReferenceLocation, schemaForRefPointer) =
+                References.GetPointerForReference(
+                    typeBuilderContext.SchemaRegistry,
+                    baseSchemaForReference,
+                    baseSchemaForReferenceLocation,
+                    reference,
+                    cancellationToken);
+        }
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
         }
 
         typeBuilderContext.EnterReferenceScope(baseSchemaForReferenceLocation, baseSchemaForReference, schemaForRefPointer);
-        TypeDeclaration subschemaTypeDeclaration = await typeBuilderContext.BuildTypeDeclarationForCurrentScope().ConfigureAwait(false);
+        TypeDeclaration subschemaTypeDeclaration = await typeBuilderContext.BuildTypeDeclarationForCurrentScope(cancellationToken);
+
+        if (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+
         typeDeclaration.AddSubschemaTypeDeclaration(subschemaPath, subschemaTypeDeclaration);
         typeBuilderContext.LeaveScope();
     }
@@ -203,9 +299,15 @@ public static class References
     /// <param name="baseSchemaForReference">The base schema for the reference.</param>
     /// <param name="baseSchemaForReferenceLocation">The base schema location for the reference.</param>
     /// <param name="reference">The reference.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The location and pointer for the reference, as applied to the base schema location.</returns>
     /// <exception cref="InvalidOperationException">It was not possible to resolve the schema from the base element using the reference fragment.</exception>
-    public static (JsonReference Location, JsonReference Pointer) GetPointerForReference(JsonSchemaRegistry schemaRegistry, LocatedSchema baseSchemaForReference, JsonReference baseSchemaForReferenceLocation, JsonReference reference)
+    public static (JsonReference Location, JsonReference Pointer) GetPointerForReference(
+        JsonSchemaRegistry schemaRegistry,
+        LocatedSchema baseSchemaForReference,
+        JsonReference baseSchemaForReferenceLocation,
+        JsonReference reference,
+        CancellationToken cancellationToken)
     {
         JsonReference schemaForRefPointer;
         if (reference.HasFragment)
@@ -218,9 +320,20 @@ public static class References
             else
             {
                 // Resolve the pointer, and add the type
-                if (TryResolvePointer(schemaRegistry, baseSchemaForReferenceLocation, baseSchemaForReference, reference.Fragment, out (JsonReference Location, JsonReference Pointer)? result))
+                if (TryResolvePointer(
+                        schemaRegistry,
+                        baseSchemaForReferenceLocation,
+                        baseSchemaForReference,
+                        reference.Fragment,
+                        cancellationToken,
+                        out (JsonReference Location, JsonReference Pointer)? result))
                 {
                     return result.Value;
+                }
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    return default;
                 }
 
                 throw new InvalidOperationException($"Unable to resolve the schema from the base element '{baseSchemaForReferenceLocation}' with the pointer '{reference.Fragment.ToString()}'");
@@ -321,6 +434,7 @@ public static class References
         JsonReference baseSchemaForReferenceLocation,
         LocatedSchema baseSchemaFoReference,
         ReadOnlySpan<char> fragment,
+        CancellationToken cancellationToken,
         [NotNullWhen(true)] out (JsonReference Location, JsonReference Pointer)? result)
     {
         JsonElement rootElement = baseSchemaFoReference.Schema;
@@ -369,7 +483,14 @@ public static class References
             {
                 var pointerRef = new JsonReference([], fragment);
                 JsonReference location = baseSchemaForReferenceLocation.Apply(pointerRef);
-                schemaRegistry.AddSchemaAndSubschema(location, resolvedElement.Value, currentSchema.Vocabulary);
+                schemaRegistry.AddSchemaAndSubschema(location, resolvedElement.Value, currentSchema.Vocabulary, cancellationToken);
+
+                if (cancellationToken.IsCancellationRequested)
+                {
+                    result = null;
+                    return false;
+                }
+
                 result = (baseSchemaForReferenceLocation, pointerRef);
                 return true;
             }

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Scope/Scope.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Scope/Scope.cs
@@ -30,10 +30,11 @@ public static class Scope
     /// </summary>
     /// <param name="typeBuilderContext">The type builder context.</param>
     /// <param name="typeDeclaration">The type declaration.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <param name="existingTypeDeclaration">The existing type declaration for the scope,
     /// if a scope was entered and a type declaration was built for the scope.</param>
     /// <returns><see langword="true"/> if the scope was entered.</returns>
-    public static bool TryEnterScope(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, out TypeDeclaration? existingTypeDeclaration)
+    public static bool TryEnterScope(TypeBuilderContext typeBuilderContext, TypeDeclaration typeDeclaration, CancellationToken cancellationToken, out TypeDeclaration? existingTypeDeclaration)
     {
         if (!ShouldEnterScope(typeDeclaration.LocatedSchema.Schema, typeDeclaration.LocatedSchema.Vocabulary, out string? scopeName, out IScopeKeyword? scopeKeyword))
         {
@@ -41,13 +42,13 @@ public static class Scope
             return false;
         }
 
-        CustomKeywords.ApplyBeforeEnteringScope(typeBuilderContext, typeDeclaration);
+        CustomKeywords.ApplyBeforeEnteringScope(typeBuilderContext, typeDeclaration, cancellationToken);
 
         bool result = scopeKeyword.TryEnterScope(typeBuilderContext, typeDeclaration, scopeName, out existingTypeDeclaration);
 
         if (result)
         {
-            CustomKeywords.ApplyAfterEnteringScope(typeBuilderContext, existingTypeDeclaration ?? typeDeclaration);
+            CustomKeywords.ApplyAfterEnteringScope(typeBuilderContext, existingTypeDeclaration ?? typeDeclaration, cancellationToken);
         }
 
         return result;

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/TypeDeclarations/TypeDeclaration.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/TypeDeclarations/TypeDeclaration.cs
@@ -12,8 +12,8 @@ namespace Corvus.Json.CodeGeneration;
 
 /// <summary>
 /// A type declaration built from a JSON schema, by calling
-/// <see cref="JsonSchemaTypeBuilder.AddTypeDeclarationsAsync(JsonReference, IVocabulary, bool)"/>
-/// or <see cref="JsonSchemaTypeBuilder.AddTypeDeclarations(Corvus.Json.JsonReference, Corvus.Json.CodeGeneration.IVocabulary, bool)"/>.
+/// <see cref="JsonSchemaTypeBuilder.AddTypeDeclarationsAsync(Corvus.Json.JsonReference, Corvus.Json.CodeGeneration.IVocabulary, bool, CancellationToken?)"/>
+/// or <see cref="JsonSchemaTypeBuilder.AddTypeDeclarations(Corvus.Json.JsonReference, Corvus.Json.CodeGeneration.IVocabulary, bool, CancellationToken?)"/>.
 /// </summary>
 /// <remarks>
 /// <para>

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Vocabularies/VocabularyRegistry.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Vocabularies/VocabularyRegistry.cs
@@ -64,7 +64,7 @@ public class VocabularyRegistry
     {
         foreach (IVocabularyAnalyser analyser in this.analysers)
         {
-            if (await analyser.TryGetVocabulary(schemaElement).ConfigureAwait(false) is IVocabulary vocabulary)
+            if (await analyser.TryGetVocabulary(schemaElement) is IVocabulary vocabulary)
             {
                 return vocabulary;
             }

--- a/Solutions/Corvus.Json.CodeGenerator/GenerationDriver.cs
+++ b/Solutions/Corvus.Json.CodeGenerator/GenerationDriver.cs
@@ -138,6 +138,7 @@ public static class GenerationDriver
         IReadOnlyCollection<GeneratedCodeFile> generatedCode =
             typeBuilder.GenerateCodeUsing(
                 languageProvider,
+                CancellationToken.None,
                 typesToGenerate);
         currentTask.Increment(100);
         currentTask.StopTask();

--- a/Solutions/Corvus.Json.CodeGenerator/ListNamingHeuristicsCommand.cs
+++ b/Solutions/Corvus.Json.CodeGenerator/ListNamingHeuristicsCommand.cs
@@ -1,7 +1,4 @@
-﻿using System.ComponentModel;
-using System.Diagnostics.CodeAnalysis;
-using Corvus.Json.CodeGeneration.CSharp;
-using Microsoft.CSharp;
+﻿using Corvus.Json.CodeGeneration.CSharp;
 using Spectre.Console;
 using Spectre.Console.Cli;
 

--- a/Solutions/Corvus.Json.CodeGenerator/Metaschema.cs
+++ b/Solutions/Corvus.Json.CodeGenerator/Metaschema.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-using System.IO;
 using System.Reflection;
 using System.Text.Json;
 

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/FromNodaTime/ValueCursor.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/FromNodaTime/ValueCursor.cs
@@ -10,7 +10,6 @@
 #if NET8_0_OR_GREATER
 
 using System.Diagnostics;
-using System.Globalization;
 
 namespace NodaTime.Text;
 

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/StandardDateFormat.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/StandardDateFormat.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-using System;
 using NodaTime;
 using NodaTime.Calendars;
 using NodaTime.Text;

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonValueExtensions.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonValueExtensions.cs
@@ -8,7 +8,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Text;
 using System.Text.Json;
-using Corvus.Json.Internal;
 
 namespace Corvus.Json;
 

--- a/Solutions/Corvus.Json.Patch.SpecGenerator/Corvus.Json.Patch.SpecGenerator.csproj
+++ b/Solutions/Corvus.Json.Patch.SpecGenerator/Corvus.Json.Patch.SpecGenerator.csproj
@@ -15,7 +15,7 @@
 			<PrivateAssets>all</PrivateAssets>
 			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
 		</PackageReference>
-		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.10.0" />
+		<PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.12.0-1.final" />
 		<PackageReference Include="Mono.TextTemplating" Version="2.3.1" />
 	</ItemGroup>
 

--- a/Solutions/Corvus.Json.Patch.SpecGenerator/Generated/Benchmark.cs
+++ b/Solutions/Corvus.Json.Patch.SpecGenerator/Generated/Benchmark.cs
@@ -131,7 +131,7 @@ namespace Benchmarks
         #line hidden
         
         #line 39 "Benchmark.tt"
-        this.Write(@""").ConfigureAwait(false);
+        this.Write(@""");
         }
 
         /// <summary>

--- a/Solutions/Corvus.Json.Patch.SpecGenerator/Templates/Benchmark.tt
+++ b/Solutions/Corvus.Json.Patch.SpecGenerator/Templates/Benchmark.tt
@@ -36,7 +36,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("<#= Escape(Scenario.Patch.ToString()) #>");
 
-            await this.GlobalSetupJson("<#= Escape(Scenario.Doc.ToString()) #>").ConfigureAwait(false);
+            await this.GlobalSetupJson("<#= Escape(Scenario.Doc.ToString()) #>");
         }
 
         /// <summary>

--- a/Solutions/Corvus.Json.Patch.SpecGenerator/packages.lock.json
+++ b/Solutions/Corvus.Json.Patch.SpecGenerator/packages.lock.json
@@ -14,12 +14,12 @@
       },
       "Microsoft.CodeAnalysis.CSharp": {
         "type": "Direct",
-        "requested": "[4.10.0, )",
-        "resolved": "4.10.0",
-        "contentHash": "iifqKy3KvCgPABHFbFlSxjEoE+OItZGuZ191NM/TWV750m1jMypr7BtrP65ET+OK2KNVupO8S8xCtxbNqw056A==",
+        "requested": "[4.12.0-1.final, )",
+        "resolved": "4.12.0-1.final",
+        "contentHash": "QAx0RVmtb9MSLyPn4pWwgtw25i4cgoE70wlgW51neEVD9CHZCh8u/LLSkw7c74aPcD2pr8LL9SfcAvjPcs51aA==",
         "dependencies": {
           "Microsoft.CodeAnalysis.Analyzers": "3.3.4",
-          "Microsoft.CodeAnalysis.Common": "[4.10.0]",
+          "Microsoft.CodeAnalysis.Common": "[4.12.0-1.final]",
           "System.Collections.Immutable": "8.0.0",
           "System.Reflection.Metadata": "8.0.0"
         }
@@ -84,8 +84,8 @@
       },
       "Microsoft.CodeAnalysis.Common": {
         "type": "Transitive",
-        "resolved": "4.10.0",
-        "contentHash": "7O4+dn0fNKykPpEB1i8/5EKzwD3fuu/shdbbnnsBmdiHMaBz6telOubDFwPwLQQ/PvOAWTFIWWTyAOmWvXRD2g==",
+        "resolved": "4.12.0-1.final",
+        "contentHash": "dRq4TITxaycboU1bSv7RBLlniKSXXJ2OfSVdKTKOcNOsXez5O6Z3gqECU9feboN06qicoIGnb5SbS+wmbXHCfg==",
         "dependencies": {
           "Microsoft.CodeAnalysis.Analyzers": "3.3.4",
           "System.Collections.Immutable": "8.0.0",

--- a/Solutions/Corvus.Json.Specs/Drivers/JsonSchemaBuilderDriver.cs
+++ b/Solutions/Corvus.Json.Specs/Drivers/JsonSchemaBuilderDriver.cs
@@ -323,6 +323,7 @@ public class JsonSchemaBuilderDriver : IDisposable
         IReadOnlyCollection<GeneratedCodeFile> generatedCode =
             this.builder.GenerateCodeUsing(
             languageProvider,
+            CancellationToken.None,
             rootType);
 
 #if NET8_0_OR_GREATER
@@ -358,6 +359,7 @@ public class JsonSchemaBuilderDriver : IDisposable
         IReadOnlyCollection<GeneratedCodeFile> generatedCode =
             this.builder.GenerateCodeUsing(
             languageProvider,
+            CancellationToken.None,
             rootType);
 
 #if NET8_0_OR_GREATER
@@ -401,6 +403,7 @@ public class JsonSchemaBuilderDriver : IDisposable
         IReadOnlyCollection<GeneratedCodeFile> generatedCode =
             this.builder.GenerateCodeUsing(
             languageProvider,
+            CancellationToken.None,
             rootType);
 
 #if NET8_0_OR_GREATER
@@ -437,6 +440,7 @@ public class JsonSchemaBuilderDriver : IDisposable
         IReadOnlyCollection<GeneratedCodeFile> generatedCode =
             this.builder.GenerateCodeUsing(
             languageProvider,
+            CancellationToken.None,
             rootType);
 
 #if NET8_0_OR_GREATER

--- a/Solutions/Corvus.Json.Specs/Fakes/FakeWebDocumentResolver.cs
+++ b/Solutions/Corvus.Json.Specs/Fakes/FakeWebDocumentResolver.cs
@@ -101,7 +101,7 @@ public class FakeWebDocumentResolver : IDocumentResolver
 #else
             using Stream stream = File.OpenRead(path);
 #endif
-            result = await JsonDocument.ParseAsync(stream).ConfigureAwait(false);
+            result = await JsonDocument.ParseAsync(stream);
             return JsonPointerUtilities.ResolvePointer(result, reference.Fragment);
         }
         catch (Exception)

--- a/Solutions/Corvus.Json.Specs/Steps/JsonSchemaSteps.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/JsonSchemaSteps.cs
@@ -111,7 +111,7 @@ public class JsonSchemaSteps
     [Given(@"the input data at ""(.*)""")]
     public async Task GivenTheInputDataAt(string referenceFragment)
     {
-        JsonElement? element = await this.driver.GetElementFromLocalFile(this.scenarioContext.Get<string>(InputJsonFileName), referenceFragment).ConfigureAwait(false);
+        JsonElement? element = await this.driver.GetElementFromLocalFile(this.scenarioContext.Get<string>(InputJsonFileName), referenceFragment);
         Assert.NotNull(
             element,
             $"Failed to load input data at {this.scenarioContext.Get<string>(InputJsonFileName)}, ref {referenceFragment}, jsonSchemaBuilder201909DriverSettings:testBaseDirectory: '{this.configuration["jsonSchemaBuilder201909DriverSettings:testBaseDirectory"]}', jsonSchemaBuilder202012DriverSettings: '{this.configuration["jsonSchemaBuilder202012DriverSettings:testBaseDirectory"]}' CWD: '{Environment.CurrentDirectory}'");
@@ -632,7 +632,7 @@ After:
                     featureName,
                     scenarioName,
                     validateFormat,
-                    this.scenarioContext.TryGetValue(NullablePropertiesKey, out bool optionalAsNullable) && optionalAsNullable).ConfigureAwait(false);
+                    this.scenarioContext.TryGetValue(NullablePropertiesKey, out bool optionalAsNullable) && optionalAsNullable);
             }
             else
             {
@@ -643,7 +643,7 @@ After:
                     featureName,
                     scenarioName,
                     validateFormat,
-                    this.scenarioContext.TryGetValue(NullablePropertiesKey, out bool optionalAsNullable) && optionalAsNullable).ConfigureAwait(false);
+                    this.scenarioContext.TryGetValue(NullablePropertiesKey, out bool optionalAsNullable) && optionalAsNullable);
             }
 
             this.featureContext.Set(type, key);

--- a/Solutions/Corvus.Json.Specs/Steps/JsonValueSteps.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/JsonValueSteps.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-using System.Buffers;
 using System.Collections.Immutable;
 using System.Net;
 using System.Text;

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark0.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark0.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/baz\",\"value\":\"qux\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":\"bar\"}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":\"bar\"}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark1.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark1.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/foo/1\",\"value\":\"qux\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":[\"bar\",\"baz\"]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":[\"bar\",\"baz\"]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark10.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark10.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"test\",\"path\":\"/~01\",\"value\":10}]");
 
-            await this.GlobalSetupJson("{\"/\":9,\"~1\":10}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"/\":9,\"~1\":10}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark11.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark11.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/foo/-\",\"value\":[\"abc\",\"def\"]}]");
 
-            await this.GlobalSetupJson("{\"foo\":[\"bar\"]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":[\"bar\"]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark12.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark12.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[]");
 
-            await this.GlobalSetupJson("{}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark13.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark13.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[]");
 
-            await this.GlobalSetupJson("{\"foo\":1}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark14.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark14.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[]");
 
-            await this.GlobalSetupJson("{\"foo\":1,\"bar\":2}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1,\"bar\":2}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark15.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark15.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[]");
 
-            await this.GlobalSetupJson("[{\"foo\":1,\"bar\":2}]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[{\"foo\":1,\"bar\":2}]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark16.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark16.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[]");
 
-            await this.GlobalSetupJson("{\"foo\":{\"foo\":1,\"bar\":2}}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":{\"foo\":1,\"bar\":2}}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark17.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark17.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/foo\",\"value\":1}]");
 
-            await this.GlobalSetupJson("{\"foo\":null}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":null}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark18.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark18.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/0\",\"value\":\"foo\"}]");
 
-            await this.GlobalSetupJson("[]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark19.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark19.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[]");
 
-            await this.GlobalSetupJson("[\"foo\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"foo\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark2.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark2.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"remove\",\"path\":\"/baz\"}]");
 
-            await this.GlobalSetupJson("{\"baz\":\"qux\",\"foo\":\"bar\"}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"baz\":\"qux\",\"foo\":\"bar\"}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark20.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark20.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/foo\",\"value\":\"1\"}]");
 
-            await this.GlobalSetupJson("{}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark21.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark21.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/foo\",\"value\":1}]");
 
-            await this.GlobalSetupJson("{}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark22.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark22.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"\",\"value\":[]}]");
 
-            await this.GlobalSetupJson("{}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark23.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark23.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"\",\"value\":{}}]");
 
-            await this.GlobalSetupJson("[]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark24.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark24.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/-\",\"value\":\"hi\"}]");
 
-            await this.GlobalSetupJson("[]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark25.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark25.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/\",\"value\":1}]");
 
-            await this.GlobalSetupJson("{}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark26.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark26.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/foo/\",\"value\":1}]");
 
-            await this.GlobalSetupJson("{\"foo\":{}}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":{}}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark27.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark27.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/bar\",\"value\":[1,2]}]");
 
-            await this.GlobalSetupJson("{\"foo\":1}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark28.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark28.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/baz/0/foo\",\"value\":\"world\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":1,\"baz\":[{\"qux\":\"hello\"}]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1,\"baz\":[{\"qux\":\"hello\"}]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark29.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark29.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/bar\",\"value\":true}]");
 
-            await this.GlobalSetupJson("{\"foo\":1}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark3.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark3.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"remove\",\"path\":\"/foo/1\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":[\"bar\",\"qux\",\"baz\"]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":[\"bar\",\"qux\",\"baz\"]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark30.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark30.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/bar\",\"value\":false}]");
 
-            await this.GlobalSetupJson("{\"foo\":1}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark31.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark31.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/bar\",\"value\":null}]");
 
-            await this.GlobalSetupJson("{\"foo\":1}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark32.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark32.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/0\",\"value\":\"bar\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":1}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark33.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark33.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/1\",\"value\":\"bar\"}]");
 
-            await this.GlobalSetupJson("[\"foo\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"foo\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark34.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark34.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/1\",\"value\":\"bar\"}]");
 
-            await this.GlobalSetupJson("[\"foo\",\"sil\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"foo\",\"sil\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark35.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark35.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/0\",\"value\":\"bar\"}]");
 
-            await this.GlobalSetupJson("[\"foo\",\"sil\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"foo\",\"sil\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark36.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark36.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/2\",\"value\":\"bar\"}]");
 
-            await this.GlobalSetupJson("[\"foo\",\"sil\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"foo\",\"sil\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark37.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark37.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"test\",\"path\":\"/1e0\",\"value\":\"foo\"}]");
 
-            await this.GlobalSetupJson("{\"1e0\":\"foo\"}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"1e0\":\"foo\"}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark38.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark38.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/1\",\"value\":[\"bar\",\"baz\"]}]");
 
-            await this.GlobalSetupJson("[\"foo\",\"sil\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"foo\",\"sil\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark39.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark39.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"remove\",\"path\":\"/bar\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":1,\"bar\":[1,2,3,4]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1,\"bar\":[1,2,3,4]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark4.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark4.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"/baz\",\"value\":\"boo\"}]");
 
-            await this.GlobalSetupJson("{\"baz\":\"qux\",\"foo\":\"bar\"}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"baz\":\"qux\",\"foo\":\"bar\"}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark40.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark40.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"remove\",\"path\":\"/baz/0/qux\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":1,\"baz\":[{\"qux\":\"hello\"}]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1,\"baz\":[{\"qux\":\"hello\"}]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark41.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark41.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"/foo\",\"value\":[1,2,3,4]}]");
 
-            await this.GlobalSetupJson("{\"foo\":1,\"baz\":[{\"qux\":\"hello\"}]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1,\"baz\":[{\"qux\":\"hello\"}]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark42.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark42.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"/baz/0/qux\",\"value\":\"world\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":[1,2,3,4],\"baz\":[{\"qux\":\"hello\"}]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":[1,2,3,4],\"baz\":[{\"qux\":\"hello\"}]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark43.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark43.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"/0\",\"value\":\"bar\"}]");
 
-            await this.GlobalSetupJson("[\"foo\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"foo\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark44.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark44.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"/0\",\"value\":0}]");
 
-            await this.GlobalSetupJson("[\"\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark45.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark45.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"/0\",\"value\":true}]");
 
-            await this.GlobalSetupJson("[\"\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark46.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark46.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"/0\",\"value\":false}]");
 
-            await this.GlobalSetupJson("[\"\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark47.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark47.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"/0\",\"value\":null}]");
 
-            await this.GlobalSetupJson("[\"\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark48.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark48.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"/1\",\"value\":[\"bar\",\"baz\"]}]");
 
-            await this.GlobalSetupJson("[\"foo\",\"sil\"]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[\"foo\",\"sil\"]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark49.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark49.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"\",\"value\":{\"baz\":\"qux\"}}]");
 
-            await this.GlobalSetupJson("{\"foo\":\"bar\"}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":\"bar\"}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark5.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark5.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"move\",\"from\":\"/foo/waldo\",\"path\":\"/qux/thud\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":{\"bar\":\"baz\",\"waldo\":\"fred\"},\"qux\":{\"corge\":\"grault\"}}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":{\"bar\":\"baz\",\"waldo\":\"fred\"},\"qux\":{\"corge\":\"grault\"}}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark50.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark50.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"test\",\"path\":\"/foo\",\"value\":1,\"spurious\":1}]");
 
-            await this.GlobalSetupJson("{\"foo\":1}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark51.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark51.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"test\",\"path\":\"/foo\",\"value\":null}]");
 
-            await this.GlobalSetupJson("{\"foo\":null}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":null}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark52.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark52.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"/foo\",\"value\":\"truthy\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":null}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":null}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark53.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark53.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"move\",\"from\":\"/foo\",\"path\":\"/bar\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":null}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":null}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark54.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark54.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"copy\",\"from\":\"/foo\",\"path\":\"/bar\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":null}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":null}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark55.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark55.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"remove\",\"path\":\"/foo\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":null}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":null}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark56.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark56.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"replace\",\"path\":\"/foo\",\"value\":null}]");
 
-            await this.GlobalSetupJson("{\"foo\":\"bar\"}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":\"bar\"}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark57.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark57.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"test\",\"path\":\"/foo\",\"value\":{\"bar\":2,\"foo\":1}}]");
 
-            await this.GlobalSetupJson("{\"foo\":{\"foo\":1,\"bar\":2}}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":{\"foo\":1,\"bar\":2}}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark58.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark58.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"test\",\"path\":\"/foo\",\"value\":[{\"bar\":2,\"foo\":1}]}]");
 
-            await this.GlobalSetupJson("{\"foo\":[{\"foo\":1,\"bar\":2}]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":[{\"foo\":1,\"bar\":2}]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark59.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark59.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"test\",\"path\":\"/foo\",\"value\":{\"bar\":[1,2,5,4]}}]");
 
-            await this.GlobalSetupJson("{\"foo\":{\"bar\":[1,2,5,4]}}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":{\"bar\":[1,2,5,4]}}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark6.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark6.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"move\",\"from\":\"/foo/1\",\"path\":\"/foo/3\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":[\"all\",\"grass\",\"cows\",\"eat\"]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":[\"all\",\"grass\",\"cows\",\"eat\"]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark60.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark60.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"test\",\"path\":\"/\",\"value\":1}]");
 
-            await this.GlobalSetupJson("{\"\":1}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"\":1}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark61.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark61.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"test\",\"path\":\"/foo\",\"value\":[\"bar\",\"baz\"]},{\"op\":\"test\",\"path\":\"/foo/0\",\"value\":\"bar\"},{\"op\":\"test\",\"path\":\"/\",\"value\":0},{\"op\":\"test\",\"path\":\"/a~1b\",\"value\":1},{\"op\":\"test\",\"path\":\"/c%d\",\"value\":2},{\"op\":\"test\",\"path\":\"/e^f\",\"value\":3},{\"op\":\"test\",\"path\":\"/g|h\",\"value\":4},{\"op\":\"test\",\"path\":\"/i\\\\j\",\"value\":5},{\"op\":\"test\",\"path\":\"/k\\u0022l\",\"value\":6},{\"op\":\"test\",\"path\":\"/ \",\"value\":7},{\"op\":\"test\",\"path\":\"/m~0n\",\"value\":8}]");
 
-            await this.GlobalSetupJson("{\"foo\":[\"bar\",\"baz\"],\"\":0,\"a/b\":1,\"c%d\":2,\"e^f\":3,\"g|h\":4,\"i\\\\j\":5,\"k\\u0022l\":6,\" \":7,\"m~n\":8}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":[\"bar\",\"baz\"],\"\":0,\"a/b\":1,\"c%d\":2,\"e^f\":3,\"g|h\":4,\"i\\\\j\":5,\"k\\u0022l\":6,\" \":7,\"m~n\":8}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark62.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark62.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"move\",\"from\":\"/foo\",\"path\":\"/foo\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":1}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark63.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark63.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"move\",\"from\":\"/foo\",\"path\":\"/bar\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":1,\"baz\":[{\"qux\":\"hello\"}]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":1,\"baz\":[{\"qux\":\"hello\"}]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark64.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark64.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"move\",\"from\":\"/baz/0/qux\",\"path\":\"/baz/1\"}]");
 
-            await this.GlobalSetupJson("{\"baz\":[{\"qux\":\"hello\"}],\"bar\":1}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"baz\":[{\"qux\":\"hello\"}],\"bar\":1}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark65.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark65.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"copy\",\"from\":\"/baz/0\",\"path\":\"/boo\"}]");
 
-            await this.GlobalSetupJson("{\"baz\":[{\"qux\":\"hello\"}],\"bar\":1}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"baz\":[{\"qux\":\"hello\"}],\"bar\":1}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark66.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark66.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"\",\"value\":{\"baz\":\"qux\"}}]");
 
-            await this.GlobalSetupJson("{\"foo\":\"bar\"}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":\"bar\"}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark67.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark67.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/-\",\"value\":{\"foo\":[\"bar\",\"baz\"]}}]");
 
-            await this.GlobalSetupJson("[1,2]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[1,2]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark68.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark68.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/2/1/-\",\"value\":{\"foo\":[\"bar\",\"baz\"]}}]");
 
-            await this.GlobalSetupJson("[1,2,[3,[4,5]]]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[1,2,[3,[4,5]]]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark69.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark69.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"remove\",\"path\":\"/0\"}]");
 
-            await this.GlobalSetupJson("[1,2,3,4]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[1,2,3,4]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark7.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark7.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"test\",\"path\":\"/baz\",\"value\":\"qux\"},{\"op\":\"test\",\"path\":\"/foo/1\",\"value\":2}]");
 
-            await this.GlobalSetupJson("{\"baz\":\"qux\",\"foo\":[\"a\",2,\"c\"]}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"baz\":\"qux\",\"foo\":[\"a\",2,\"c\"]}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark70.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark70.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"remove\",\"path\":\"/1\"},{\"op\":\"remove\",\"path\":\"/2\"}]");
 
-            await this.GlobalSetupJson("[1,2,3,4]").ConfigureAwait(false);
+            await this.GlobalSetupJson("[1,2,3,4]");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark71.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark71.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/FOO\",\"value\":\"BAR\"}]");
 
-            await this.GlobalSetupJson("{\"foo\":\"bar\"}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":\"bar\"}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark8.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark8.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/child\",\"value\":{\"grandchild\":{}}}]");
 
-            await this.GlobalSetupJson("{\"foo\":\"bar\"}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":\"bar\"}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark9.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/Generated/GeneratedBenchmark9.cs
@@ -28,7 +28,7 @@ namespace Benchmarks
                 
             this.corvusPatch = Corvus.Json.Patch.Model.JsonPatchDocument.Parse("[{\"op\":\"add\",\"path\":\"/baz\",\"value\":\"qux\",\"xyz\":123}]");
 
-            await this.GlobalSetupJson("{\"foo\":\"bar\"}").ConfigureAwait(false);
+            await this.GlobalSetupJson("{\"foo\":\"bar\"}");
         }
 
         /// <summary>

--- a/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/LargeFileBenchmark.cs
+++ b/Solutions/Corvus.JsonPatch.Benchmarking/Benchmarks/LargeFileBenchmark.cs
@@ -161,7 +161,7 @@ public class LargeFileBenchmark : BenchmarkBase
                 Corvus.Json.Patch.Model.JsonPatchDocument.CopyOperation.Create("/42/actor/id", "/45/actor/id"),
                 Corvus.Json.Patch.Model.JsonPatchDocument.CopyOperation.Create("/43/actor/id", "/46/actor/id"));
 
-        await this.GlobalSetup("large-array-file.json").ConfigureAwait(false);
+        await this.GlobalSetup("large-array-file.json");
     }
 
     /// <summary>

--- a/Solutions/Sandbox/Model/FlimFlam.cs
+++ b/Solutions/Sandbox/Model/FlimFlam.cs
@@ -1,0 +1,9 @@
+using Corvus.Json;
+
+namespace Sandbox.Model;
+
+////[JsonSchemaTypeGenerator("./test.json")]
+public readonly partial struct FlimFlam
+{
+
+}

--- a/Solutions/Sandbox/Program.cs
+++ b/Solutions/Sandbox/Program.cs
@@ -1,17 +1,1 @@
-﻿Corvus.Json.Benchmarking.ValidateLargeDocument benchmark = new();
-
-benchmark.GlobalSetup();
-
-for (int i = 0; i < 10; ++i)
-{
-    benchmark.ValidateLargeArrayCorvusV4();
-}
-
-Microsoft.DiagnosticsHub.UserMarkRange r2 = new("V4", "Corvus V4");
-
-for (int i = 0; i < 10; ++i)
-{
-    benchmark.ValidateLargeArrayCorvusV4();
-}
-
-r2.Dispose();
+﻿Console.WriteLine("Hello");

--- a/Solutions/Sandbox/Sandbox.csproj
+++ b/Solutions/Sandbox/Sandbox.csproj
@@ -1,26 +1,21 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<OutputType>Exe</OutputType>
-		<TargetFrameworks>net8.0</TargetFrameworks>
-		<LangVersion>Latest</LangVersion>
-		<ImplicitUsings>enable</ImplicitUsings>
-		<Nullable>enable</Nullable>
-		<IsPackable>false</IsPackable>
-	</PropertyGroup>
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>net8.0</TargetFrameworks>
+    <LangVersion>Latest</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<PackageReference Include="JsonPatch.Net" Version="3.1.1" />
-		<PackageReference Include="Microsoft.VisualStudio.DiagnosticsHub.UserMarks" Version="17.12.35112.1" />
-	</ItemGroup>
-	
-	<ItemGroup>
-	  <ProjectReference Include="..\Corvus.Json.Benchmarking\Corvus.Json.Benchmarking.csproj" />
-	  <ProjectReference Include="..\Corvus.Json.CodeGenerator\Corvus.Json.CodeGenerator.csproj" />
-	  <ProjectReference Include="..\Corvus.Json.ExtendedTypes\Corvus.Json.ExtendedTypes.csproj" />
-	  <ProjectReference Include="..\Corvus.Json.JsonSchema.Draft202012\Corvus.Json.JsonSchema.Draft202012.csproj" />
-	  <ProjectReference Include="..\Corvus.Json.Patch\Corvus.Json.Patch.csproj" />
-	  <ProjectReference Include="..\Corvus.JsonPatch.Benchmarking\Corvus.JsonPatch.Benchmarking.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <AdditionalFiles Include="test.json" />
+  </ItemGroup>
 
+  <ItemGroup>
+    <ProjectReference Include="..\Corvus.Json.ExtendedTypes\Corvus.Json.ExtendedTypes.csproj" />
+  </ItemGroup>
+
+  
 </Project>


### PR DESCRIPTION
You can flow a `CancellationToken `through the type build process, and send it on to the code generation through the `CodeGenerator` (which is constructed with a `CancellationToken`, and exposes an `IsCancellationRequested` property.