### PR TITLE
Fix #489: Generate multiple identifier declarations with the same name patternpropertyjsonstring

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Object.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Object.cs
@@ -505,8 +505,8 @@ internal static partial class CodeGeneratorExtensions
                             rootScope: generator.ValidationClassScope(),
                             suffix: hasIndex ? index.ToString() : null);
 
-                    string matchesPatternName = generator.GetMethodNameInScope(declaration.ReducedPatternPropertyType.DotnetTypeName(), prefix: "MatchesPattern");
-                    string tryAsPatternName = generator.GetMethodNameInScope(declaration.ReducedPatternPropertyType.DotnetTypeName(), prefix: "TryAsPattern");
+                    string matchesPatternName = generator.GetUniqueMethodNameInScope(declaration.ReducedPatternPropertyType.DotnetTypeName(), prefix: "MatchesPattern");
+                    string tryAsPatternName = generator.GetUniqueMethodNameInScope(declaration.ReducedPatternPropertyType.DotnetTypeName(), prefix: "TryAsPattern");
 
                     generator
                         .AppendSeparatorLine()
@@ -584,7 +584,7 @@ internal static partial class CodeGeneratorExtensions
                             rootScope: generator.ValidationClassScope(),
                             suffix: hasIndex ? index.ToString() : null);
 
-                    string propertyName = generator.GetPropertyNameInScope(declaration.ReducedPatternPropertyType.DotnetTypeName(), prefix: "PatternProperty");
+                    string propertyName = generator.GetUniquePropertyNameInScope(declaration.ReducedPatternPropertyType.DotnetTypeName(), prefix: "PatternProperty");
 
                     generator
                         .AppendSeparatorLine()

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/ValidationContext.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/ValidationContext.cs
@@ -3,12 +3,14 @@
 // </copyright>
 
 using System.Collections.Immutable;
+using System.Diagnostics;
 
 namespace Corvus.Json;
 
 /// <summary>
 /// The current validation context.
 /// </summary>
+[DebuggerDisplay("IsValid = {IsValid}")]
 public readonly struct ValidationContext
 {
     /// <summary>

--- a/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft7/Repro489.feature
+++ b/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft7/Repro489.feature
@@ -1,0 +1,57 @@
+@draft7
+
+Feature: Repro 489 draft7
+
+Scenario Outline: Generation error with multiple pattern properties.
+	Given a schema file
+		"""
+		{
+			"$schema": "https://json-schema.org/draft-07/schema",
+			"type": "object",
+			"patternProperties": {
+				"^(?!.*?\\$schema).*$": {
+					"type": "object",
+					"patternProperties": {
+						".*_doc$|^doc$": {
+							"type": "string"
+						},
+						".*_code$|^code$": {
+							"type": "string"
+						}
+					}
+				}
+			}
+		}
+		"""
+	And the input data value <inputData>
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance
+	Then the result will be <valid>
+
+Examples:
+	| inputData                                                                                                                                                                                                                                                                | valid |
+	| { "foo": { "a_doc": "aaa", "b_doc": "bbb" } } | true  |
+
+	Scenario Outline: Generation error with single pattern properties.
+	Given a schema file
+		"""
+		{
+			"$schema": "https://json-schema.org/draft-07/schema",
+			"type": "object",
+			"patternProperties": {
+				".*_doc$|^doc$": {
+					"type": "string"
+				}
+			}
+		}
+		"""
+	And the input data value <inputData>
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance
+	Then the result will be <valid>
+
+Examples:
+	| inputData                                                                                                                                                                                                                                                                | valid |
+	| { "a_doc": "aaa", "b_doc": "bbb" } | true  |


### PR DESCRIPTION
There was a typo in the code generator: it failed to generate a `Unique` name for the property/method corresponding to each pattern property.

This does not address the second part of the issue; I've added a passing test that illustrates what I believe to be the issue described.