### PR TITLE
Fix source generator fallback namespace and update test suite 

### DIFF
--- a/Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
+++ b/Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
@@ -3,7 +3,6 @@
 // </copyright>
 
 using System.Collections.Immutable;
-using System.Diagnostics;
 using System.Text;
 using Corvus.Json.CodeGeneration;
 using Corvus.Json.CodeGeneration.CSharp;
@@ -109,7 +108,7 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
 
             typesToGenerate.Add(rootType);
 
-            defaultNamespace = defaultNamespace ?? spec.Namespace;
+            defaultNamespace ??= spec.Namespace;
 
             namedTypes.Add(
                 new CSharpLanguageProvider.NamedType(

--- a/Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
+++ b/Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
@@ -79,6 +79,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         List<CSharpLanguageProvider.NamedType> namedTypes = [];
         JsonSchemaTypeBuilder typeBuilder = new(generationSource.DocumentResolver, VocabularyRegistry);
 
+        string? defaultNamespace = null;
+
         foreach (GenerationSpecification spec in generationSource.GenerationSpecifications)
         {
             if (context.CancellationToken.IsCancellationRequested)
@@ -107,6 +109,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
 
             typesToGenerate.Add(rootType);
 
+            defaultNamespace = defaultNamespace ?? spec.Namespace;
+
             namedTypes.Add(
                 new CSharpLanguageProvider.NamedType(
                     rootType.ReducedTypeDeclaration().ReducedType.LocatedSchema.Location,
@@ -115,7 +119,7 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         }
 
         CSharpLanguageProvider.Options options = new(
-            "GeneratedTypes",
+            defaultNamespace ?? "GeneratedTypes",
             namedTypes.ToArray(),
             disabledNamingHeuristics: generationSource.DisabledNamingHeuristics.ToArray(),
             optionalAsNullable: generationSource.OptionalAsNullable,

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/additionalItems.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/additionalItems.feature
@@ -16,7 +16,6 @@ Scenario Outline: additionalItems as schema
     Given the input JSON file "additionalItems.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -44,7 +43,6 @@ Scenario Outline: when items is schema, additionalItems does nothing
     Given the input JSON file "additionalItems.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -68,7 +66,6 @@ Scenario Outline: when items is schema, boolean additionalItems does nothing
     Given the input JSON file "additionalItems.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -90,7 +87,6 @@ Scenario Outline: array of items with no additionalItems permitted
     Given the input JSON file "additionalItems.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -119,7 +115,6 @@ Scenario Outline: additionalItems as false without items
     Given the input JSON file "additionalItems.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -142,7 +137,6 @@ Scenario Outline: additionalItems are allowed by default
     Given the input JSON file "additionalItems.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -166,7 +160,6 @@ Scenario Outline: additionalItems does not look in applicators, valid case
     Given the input JSON file "additionalItems.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -191,7 +184,6 @@ Scenario Outline: additionalItems does not look in applicators, invalid case
     Given the input JSON file "additionalItems.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -213,7 +205,6 @@ Scenario Outline: items validation adjusts the starting index for additionalItem
     Given the input JSON file "additionalItems.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -237,7 +228,6 @@ Scenario Outline: additionalItems with heterogeneous array
     Given the input JSON file "additionalItems.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -262,7 +252,6 @@ Scenario Outline: additionalItems with null instance elements
     Given the input JSON file "additionalItems.json"
     And the schema at "#/10/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/additionalProperties.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/additionalProperties.feature
@@ -17,7 +17,6 @@ Scenario Outline: additionalProperties being false does not allow other properti
     Given the input JSON file "additionalProperties.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -49,7 +48,6 @@ Scenario Outline: non-ASCII pattern with additionalProperties
     Given the input JSON file "additionalProperties.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -73,7 +71,6 @@ Scenario Outline: additionalProperties with schema
     Given the input JSON file "additionalProperties.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -98,7 +95,6 @@ Scenario Outline: additionalProperties can exist by itself
     Given the input JSON file "additionalProperties.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -121,7 +117,6 @@ Scenario Outline: additionalProperties are allowed by default
     Given the input JSON file "additionalProperties.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -145,7 +140,6 @@ Scenario Outline: additionalProperties does not look in applicators
     Given the input JSON file "additionalProperties.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -168,7 +162,6 @@ Scenario Outline: additionalProperties with null valued instance properties
     Given the input JSON file "additionalProperties.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -194,7 +187,6 @@ Scenario Outline: additionalProperties with propertyNames
     Given the input JSON file "additionalProperties.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -226,7 +218,6 @@ Scenario Outline: dependentSchemas with additionalProperties
     Given the input JSON file "additionalProperties.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/allOf.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/allOf.feature
@@ -28,7 +28,6 @@ Scenario Outline: allOf
     Given the input JSON file "allOf.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -70,7 +69,6 @@ Scenario Outline: allOf with base schema
     Given the input JSON file "allOf.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -102,7 +100,6 @@ Scenario Outline: allOf simple types
     Given the input JSON file "allOf.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -125,7 +122,6 @@ Scenario Outline: allOf with boolean schemas, all true
     Given the input JSON file "allOf.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -146,7 +142,6 @@ Scenario Outline: allOf with boolean schemas, some false
     Given the input JSON file "allOf.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -167,7 +162,6 @@ Scenario Outline: allOf with boolean schemas, all false
     Given the input JSON file "allOf.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -190,7 +184,6 @@ Scenario Outline: allOf with one empty schema
     Given the input JSON file "allOf.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -214,7 +207,6 @@ Scenario Outline: allOf with two empty schemas
     Given the input JSON file "allOf.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -238,7 +230,6 @@ Scenario Outline: allOf with the first empty schema
     Given the input JSON file "allOf.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -264,7 +255,6 @@ Scenario Outline: allOf with the last empty schema
     Given the input JSON file "allOf.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -295,7 +285,6 @@ Scenario Outline: nested allOf, to check validation semantics
     Given the input JSON file "allOf.json"
     And the schema at "#/10/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -320,7 +309,6 @@ Scenario Outline: allOf combined with anyOf, oneOf
     Given the input JSON file "allOf.json"
     And the schema at "#/11/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/anchor.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/anchor.feature
@@ -21,7 +21,6 @@ Scenario Outline: Location-independent identifier
     Given the input JSON file "anchor.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -51,7 +50,6 @@ Scenario Outline: Location-independent identifier with absolute URI
     Given the input JSON file "anchor.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -86,7 +84,6 @@ Scenario Outline: Location-independent identifier with base URI change in subsch
     Given the input JSON file "anchor.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -126,7 +123,6 @@ Scenario Outline: same $anchor with different base uri
     Given the input JSON file "anchor.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/anyOf.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/anyOf.feature
@@ -22,7 +22,6 @@ Scenario Outline: anyOf
     Given the input JSON file "anyOf.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -57,7 +56,6 @@ Scenario Outline: anyOf with base schema
     Given the input JSON file "anyOf.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -82,7 +80,6 @@ Scenario Outline: anyOf with boolean schemas, all true
     Given the input JSON file "anyOf.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -103,7 +100,6 @@ Scenario Outline: anyOf with boolean schemas, some true
     Given the input JSON file "anyOf.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -124,7 +120,6 @@ Scenario Outline: anyOf with boolean schemas, all false
     Given the input JSON file "anyOf.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -158,7 +153,6 @@ Scenario Outline: anyOf complex types
     Given the input JSON file "anyOf.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -188,7 +182,6 @@ Scenario Outline: anyOf with one empty schema
     Given the input JSON file "anyOf.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -219,7 +212,6 @@ Scenario Outline: nested anyOf, to check validation semantics
     Given the input JSON file "anyOf.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/boolean_schema.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/boolean_schema.feature
@@ -12,7 +12,6 @@ True
     Given the input JSON file "boolean_schema.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -46,7 +45,6 @@ False
     Given the input JSON file "boolean_schema.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/const.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/const.feature
@@ -15,7 +15,6 @@ Scenario Outline: const validation
     Given the input JSON file "const.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -40,7 +39,6 @@ Scenario Outline: const with object
     Given the input JSON file "const.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -67,7 +65,6 @@ Scenario Outline: const with array
     Given the input JSON file "const.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -92,7 +89,6 @@ Scenario Outline: const with null
     Given the input JSON file "const.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -115,7 +111,6 @@ Scenario Outline: const with false does not match 0
     Given the input JSON file "const.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -140,7 +135,6 @@ Scenario Outline: const with true does not match 1
     Given the input JSON file "const.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -165,7 +159,6 @@ Scenario Outline: const with array[false] does not match array[0]
     Given the input JSON file "const.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -190,7 +183,6 @@ Scenario Outline: const with array[true] does not match array[1]
     Given the input JSON file "const.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -215,7 +207,6 @@ Scenario Outline: const with {"a": false} does not match {"a": 0}
     Given the input JSON file "const.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -240,7 +231,6 @@ Scenario Outline: const with {"a": true} does not match {"a": 1}
     Given the input JSON file "const.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -265,7 +255,6 @@ Scenario Outline: const with 0 does not match other zero-like types
     Given the input JSON file "const.json"
     And the schema at "#/10/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -296,7 +285,6 @@ Scenario Outline: const with 1 does not match true
     Given the input JSON file "const.json"
     And the schema at "#/11/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -321,7 +309,6 @@ Scenario Outline: const with -2.0 matches integer and float types
     Given the input JSON file "const.json"
     And the schema at "#/12/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -350,7 +337,6 @@ Scenario Outline: float and integers are equal up to 64-bit representation limit
     Given the input JSON file "const.json"
     And the schema at "#/13/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -377,7 +363,6 @@ Scenario Outline: nul characters in strings
     Given the input JSON file "const.json"
     And the schema at "#/14/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/contains.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/contains.feature
@@ -15,7 +15,6 @@ Scenario Outline: contains keyword validation
     Given the input JSON file "contains.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -46,7 +45,6 @@ Scenario Outline: contains keyword with const keyword
     Given the input JSON file "contains.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -71,7 +69,6 @@ Scenario Outline: contains keyword with boolean schema true
     Given the input JSON file "contains.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -94,7 +91,6 @@ Scenario Outline: contains keyword with boolean schema false
     Given the input JSON file "contains.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -120,7 +116,6 @@ Scenario Outline: items + contains
     Given the input JSON file "contains.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -150,7 +145,6 @@ Scenario Outline: contains with false if subschema
     Given the input JSON file "contains.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -175,7 +169,6 @@ Scenario Outline: contains with null instance elements
     Given the input JSON file "contains.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/content.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/content.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of string-encoded content based on media type
     Given the input JSON file "content.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -40,7 +39,6 @@ Scenario Outline: validation of binary string-encoding
     Given the input JSON file "content.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -66,7 +64,6 @@ Scenario Outline: validation of binary-encoded media type documents
     Given the input JSON file "content.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -95,7 +92,6 @@ Scenario Outline: validation of binary-encoded media type documents with schema
     Given the input JSON file "content.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/default.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/default.feature
@@ -20,7 +20,6 @@ Scenario Outline: invalid type for default
     Given the input JSON file "default.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -49,7 +48,6 @@ Scenario Outline: invalid string value for default
     Given the input JSON file "default.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -79,7 +77,6 @@ Scenario Outline: the default keyword does not do anything if the property is mi
     Given the input JSON file "default.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/defs.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/defs.feature
@@ -15,7 +15,6 @@ Scenario Outline: validate definition against metaschema
     Given the input JSON file "defs.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/dependentRequired.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/dependentRequired.feature
@@ -15,7 +15,6 @@ Scenario Outline: single dependency
     Given the input JSON file "dependentRequired.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -48,7 +47,6 @@ Scenario Outline: empty dependents
     Given the input JSON file "dependentRequired.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -73,7 +71,6 @@ Scenario Outline: multiple dependents required
     Given the input JSON file "dependentRequired.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -107,7 +104,6 @@ Scenario Outline: dependencies with escaped characters
     Given the input JSON file "dependentRequired.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/dependentSchemas.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/dependentSchemas.feature
@@ -22,7 +22,6 @@ Scenario Outline: single dependency
     Given the input JSON file "dependentSchemas.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -60,7 +59,6 @@ Scenario Outline: boolean subschemas
     Given the input JSON file "dependentSchemas.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -90,7 +88,6 @@ Scenario Outline: dependencies with escaped characters
     Given the input JSON file "dependentSchemas.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -127,7 +124,6 @@ Scenario Outline: dependent subschema incompatible with root
     Given the input JSON file "dependentSchemas.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/enum.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/enum.feature
@@ -15,7 +15,6 @@ Scenario Outline: simple enum validation
     Given the input JSON file "enum.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -38,7 +37,6 @@ Scenario Outline: heterogeneous enum validation
     Given the input JSON file "enum.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -67,7 +65,6 @@ Scenario Outline: heterogeneous enum-with-null validation
     Given the input JSON file "enum.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -97,7 +94,6 @@ Scenario Outline: enums in properties
     Given the input JSON file "enum.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -128,7 +124,6 @@ Scenario Outline: enum with escaped characters
     Given the input JSON file "enum.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -153,7 +148,6 @@ Scenario Outline: enum with false does not match 0
     Given the input JSON file "enum.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -178,7 +172,6 @@ Scenario Outline: enum with array[false] does not match array[0]
     Given the input JSON file "enum.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -203,7 +196,6 @@ Scenario Outline: enum with true does not match 1
     Given the input JSON file "enum.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -228,7 +220,6 @@ Scenario Outline: enum with array[true] does not match array[1]
     Given the input JSON file "enum.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -253,7 +244,6 @@ Scenario Outline: enum with 0 does not match false
     Given the input JSON file "enum.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -278,7 +268,6 @@ Scenario Outline: enum with array[0] does not match array[false]
     Given the input JSON file "enum.json"
     And the schema at "#/10/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -303,7 +292,6 @@ Scenario Outline: enum with 1 does not match true
     Given the input JSON file "enum.json"
     And the schema at "#/11/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -328,7 +316,6 @@ Scenario Outline: enum with array[1] does not match array[true]
     Given the input JSON file "enum.json"
     And the schema at "#/12/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -353,7 +340,6 @@ Scenario Outline: nul characters in strings
     Given the input JSON file "enum.json"
     And the schema at "#/13/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/exclusiveMaximum.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/exclusiveMaximum.feature
@@ -15,7 +15,6 @@ Scenario Outline: exclusiveMaximum validation
     Given the input JSON file "exclusiveMaximum.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/exclusiveMinimum.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/exclusiveMinimum.feature
@@ -15,7 +15,6 @@ Scenario Outline: exclusiveMinimum validation
     Given the input JSON file "exclusiveMinimum.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/format.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/format.feature
@@ -15,7 +15,6 @@ Scenario Outline: email format
     Given the input JSON file "format.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -46,7 +45,6 @@ Scenario Outline: idn-email format
     Given the input JSON file "format.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -77,7 +75,6 @@ Scenario Outline: regex format
     Given the input JSON file "format.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -108,7 +105,6 @@ Scenario Outline: ipv4 format
     Given the input JSON file "format.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -139,7 +135,6 @@ Scenario Outline: ipv6 format
     Given the input JSON file "format.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -170,7 +165,6 @@ Scenario Outline: idn-hostname format
     Given the input JSON file "format.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -201,7 +195,6 @@ Scenario Outline: hostname format
     Given the input JSON file "format.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -232,7 +225,6 @@ Scenario Outline: date format
     Given the input JSON file "format.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -263,7 +255,6 @@ Scenario Outline: date-time format
     Given the input JSON file "format.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -294,7 +285,6 @@ Scenario Outline: time format
     Given the input JSON file "format.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -325,7 +315,6 @@ Scenario Outline: json-pointer format
     Given the input JSON file "format.json"
     And the schema at "#/10/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -356,7 +345,6 @@ Scenario Outline: relative-json-pointer format
     Given the input JSON file "format.json"
     And the schema at "#/11/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -387,7 +375,6 @@ Scenario Outline: iri format
     Given the input JSON file "format.json"
     And the schema at "#/12/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -418,7 +405,6 @@ Scenario Outline: iri-reference format
     Given the input JSON file "format.json"
     And the schema at "#/13/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -449,7 +435,6 @@ Scenario Outline: uri format
     Given the input JSON file "format.json"
     And the schema at "#/14/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -480,7 +465,6 @@ Scenario Outline: uri-reference format
     Given the input JSON file "format.json"
     And the schema at "#/15/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -511,7 +495,6 @@ Scenario Outline: uri-template format
     Given the input JSON file "format.json"
     And the schema at "#/16/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -542,7 +525,6 @@ Scenario Outline: uuid format
     Given the input JSON file "format.json"
     And the schema at "#/17/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -573,7 +555,6 @@ Scenario Outline: duration format
     Given the input JSON file "format.json"
     And the schema at "#/18/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/if-then-else.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/if-then-else.feature
@@ -17,7 +17,6 @@ Scenario Outline: ignore if without then or else
     Given the input JSON file "if-then-else.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -42,7 +41,6 @@ Scenario Outline: ignore then without if
     Given the input JSON file "if-then-else.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -67,7 +65,6 @@ Scenario Outline: ignore else without if
     Given the input JSON file "if-then-else.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -95,7 +92,6 @@ Scenario Outline: if and then without else
     Given the input JSON file "if-then-else.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -125,7 +121,6 @@ Scenario Outline: if and else without then
     Given the input JSON file "if-then-else.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -158,7 +153,6 @@ Scenario Outline: validate against correct branch, then vs else
     Given the input JSON file "if-then-else.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -201,7 +195,6 @@ Scenario Outline: non-interference across combined schemas
     Given the input JSON file "if-then-else.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -226,7 +219,6 @@ Scenario Outline: if with boolean schema true
     Given the input JSON file "if-then-else.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -251,7 +243,6 @@ Scenario Outline: if with boolean schema false
     Given the input JSON file "if-then-else.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -276,7 +267,6 @@ Scenario Outline: if appears at the end when serialized (keyword processing sequ
     Given the input JSON file "if-then-else.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/infinite-loop-detection.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/infinite-loop-detection.feature
@@ -31,7 +31,6 @@ Scenario Outline: evaluating the same schema location against the same data loca
     Given the input JSON file "infinite-loop-detection.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/items.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/items.feature
@@ -15,7 +15,6 @@ Scenario Outline: a schema given for items
     Given the input JSON file "items.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -45,7 +44,6 @@ Scenario Outline: an array of schemas for items
     Given the input JSON file "items.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -76,7 +74,6 @@ Scenario Outline: items with boolean schema (true)
     Given the input JSON file "items.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -99,7 +96,6 @@ Scenario Outline: items with boolean schema (false)
     Given the input JSON file "items.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -122,7 +118,6 @@ Scenario Outline: items with boolean schemas
     Given the input JSON file "items.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -167,7 +162,6 @@ Scenario Outline: items and subitems
     Given the input JSON file "items.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -210,7 +204,6 @@ Scenario Outline: nested items
     Given the input JSON file "items.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -237,7 +230,6 @@ Scenario Outline: single-form items with null instance elements
     Given the input JSON file "items.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -262,7 +254,6 @@ Scenario Outline: array-form items with null instance elements
     Given the input JSON file "items.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/maxContains.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/maxContains.feature
@@ -15,7 +15,6 @@ Scenario Outline: maxContains without contains is ignored
     Given the input JSON file "maxContains.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -39,7 +38,6 @@ Scenario Outline: maxContains with contains
     Given the input JSON file "maxContains.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -69,7 +67,6 @@ Scenario Outline: maxContains with contains, value with a decimal
     Given the input JSON file "maxContains.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -94,7 +91,6 @@ Scenario Outline: minContains  less than  maxContains
     Given the input JSON file "maxContains.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/maxItems.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/maxItems.feature
@@ -15,7 +15,6 @@ Scenario Outline: maxItems validation
     Given the input JSON file "maxItems.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -42,7 +41,6 @@ Scenario Outline: maxItems validation with a decimal
     Given the input JSON file "maxItems.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/maxLength.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/maxLength.feature
@@ -15,7 +15,6 @@ Scenario Outline: maxLength validation
     Given the input JSON file "maxLength.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -44,7 +43,6 @@ Scenario Outline: maxLength validation with a decimal
     Given the input JSON file "maxLength.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/maxProperties.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/maxProperties.feature
@@ -15,7 +15,6 @@ Scenario Outline: maxProperties validation
     Given the input JSON file "maxProperties.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -46,7 +45,6 @@ Scenario Outline: maxProperties validation with a decimal
     Given the input JSON file "maxProperties.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -69,7 +67,6 @@ Scenario Outline: maxProperties  equals  0 means the object is empty
     Given the input JSON file "maxProperties.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/maximum.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/maximum.feature
@@ -15,7 +15,6 @@ Scenario Outline: maximum validation
     Given the input JSON file "maximum.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -42,7 +41,6 @@ Scenario Outline: maximum validation with unsigned integer
     Given the input JSON file "maximum.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/minContains.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/minContains.feature
@@ -15,7 +15,6 @@ Scenario Outline: minContains without contains is ignored
     Given the input JSON file "minContains.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -39,7 +38,6 @@ Scenario Outline: minContains equals 1 with contains
     Given the input JSON file "minContains.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -69,7 +67,6 @@ Scenario Outline: minContains equals 2 with contains
     Given the input JSON file "minContains.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -101,7 +98,6 @@ Scenario Outline: minContains equals 2 with contains with a decimal value
     Given the input JSON file "minContains.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -126,7 +122,6 @@ Scenario Outline: maxContains  equals  minContains
     Given the input JSON file "minContains.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -155,7 +150,6 @@ Scenario Outline: maxContains  less than  minContains
     Given the input JSON file "minContains.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -183,7 +177,6 @@ Scenario Outline: minContains  equals  0 with no maxContains
     Given the input JSON file "minContains.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -208,7 +201,6 @@ Scenario Outline: minContains  equals  0 with maxContains
     Given the input JSON file "minContains.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/minItems.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/minItems.feature
@@ -15,7 +15,6 @@ Scenario Outline: minItems validation
     Given the input JSON file "minItems.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -42,7 +41,6 @@ Scenario Outline: minItems validation with a decimal
     Given the input JSON file "minItems.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/minLength.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/minLength.feature
@@ -15,7 +15,6 @@ Scenario Outline: minLength validation
     Given the input JSON file "minLength.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -44,7 +43,6 @@ Scenario Outline: minLength validation with a decimal
     Given the input JSON file "minLength.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/minProperties.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/minProperties.feature
@@ -15,7 +15,6 @@ Scenario Outline: minProperties validation
     Given the input JSON file "minProperties.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -46,7 +45,6 @@ Scenario Outline: minProperties validation with a decimal
     Given the input JSON file "minProperties.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/minimum.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/minimum.feature
@@ -15,7 +15,6 @@ Scenario Outline: minimum validation
     Given the input JSON file "minimum.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -42,7 +41,6 @@ Scenario Outline: minimum validation with signed integer
     Given the input JSON file "minimum.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/multipleOf.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/multipleOf.feature
@@ -15,7 +15,6 @@ Scenario Outline: by int
     Given the input JSON file "multipleOf.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -40,7 +39,6 @@ Scenario Outline: by number
     Given the input JSON file "multipleOf.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -65,7 +63,6 @@ Scenario Outline: by small number
     Given the input JSON file "multipleOf.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -88,7 +85,6 @@ Scenario Outline: float division  equals  inf
     Given the input JSON file "multipleOf.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -109,7 +105,6 @@ Scenario Outline: small multiple of large integer
     Given the input JSON file "multipleOf.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/not.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/not.feature
@@ -15,7 +15,6 @@ Scenario Outline: not
     Given the input JSON file "not.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -38,7 +37,6 @@ Scenario Outline: not multiple types
     Given the input JSON file "not.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -70,7 +68,6 @@ Scenario Outline: not more complex schema
     Given the input JSON file "not.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -99,7 +96,6 @@ Scenario Outline: forbidden property
     Given the input JSON file "not.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -122,7 +118,6 @@ Scenario Outline: forbid everything with empty schema
     Given the input JSON file "not.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -159,7 +154,6 @@ Scenario Outline: forbid everything with boolean schema true
     Given the input JSON file "not.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -196,7 +190,6 @@ Scenario Outline: allow everything with boolean schema false
     Given the input JSON file "not.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -233,7 +226,6 @@ Scenario Outline: double negation
     Given the input JSON file "not.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -261,7 +253,6 @@ Scenario Outline: collect annotations inside a 'not', even if collection is disa
     Given the input JSON file "not.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/oneOf.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/oneOf.feature
@@ -22,7 +22,6 @@ Scenario Outline: oneOf
     Given the input JSON file "oneOf.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -57,7 +56,6 @@ Scenario Outline: oneOf with base schema
     Given the input JSON file "oneOf.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -82,7 +80,6 @@ Scenario Outline: oneOf with boolean schemas, all true
     Given the input JSON file "oneOf.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -103,7 +100,6 @@ Scenario Outline: oneOf with boolean schemas, one true
     Given the input JSON file "oneOf.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -124,7 +120,6 @@ Scenario Outline: oneOf with boolean schemas, more than one true
     Given the input JSON file "oneOf.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -145,7 +140,6 @@ Scenario Outline: oneOf with boolean schemas, all false
     Given the input JSON file "oneOf.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -179,7 +173,6 @@ Scenario Outline: oneOf complex types
     Given the input JSON file "oneOf.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -209,7 +202,6 @@ Scenario Outline: oneOf with empty schema
     Given the input JSON file "oneOf.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -236,7 +228,6 @@ Scenario Outline: oneOf with required
     Given the input JSON file "oneOf.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -277,7 +268,6 @@ Scenario Outline: oneOf with missing optional property
     Given the input JSON file "oneOf.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -312,7 +302,6 @@ Scenario Outline: nested oneOf, to check validation semantics
     Given the input JSON file "oneOf.json"
     And the schema at "#/10/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-anchor.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-anchor.feature
@@ -38,7 +38,6 @@ Scenario Outline: $anchor inside an enum is not a real identifier
     Given the input JSON file "optional/anchor.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-cross-draft.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-cross-draft.feature
@@ -16,7 +16,6 @@ Scenario Outline: refs to future drafts are processed as future drafts
     Given the input JSON file "optional/cross-draft.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -42,7 +41,6 @@ Scenario Outline: refs to historic drafts are processed as historic drafts
     Given the input JSON file "optional/cross-draft.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-dependencies-compatibility.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-dependencies-compatibility.feature
@@ -15,7 +15,6 @@ Scenario Outline: single dependency
     Given the input JSON file "optional/dependencies-compatibility.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -48,7 +47,6 @@ Scenario Outline: empty dependents
     Given the input JSON file "optional/dependencies-compatibility.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -73,7 +71,6 @@ Scenario Outline: multiple dependents required
     Given the input JSON file "optional/dependencies-compatibility.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -107,7 +104,6 @@ Scenario Outline: dependencies with escaped characters
     Given the input JSON file "optional/dependencies-compatibility.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -141,7 +137,6 @@ Scenario Outline: single schema dependency
     Given the input JSON file "optional/dependencies-compatibility.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -179,7 +174,6 @@ Scenario Outline: boolean subschemas
     Given the input JSON file "optional/dependencies-compatibility.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -209,7 +203,6 @@ Scenario Outline: schema dependencies with escaped characters
     Given the input JSON file "optional/dependencies-compatibility.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-float-overflow.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-float-overflow.feature
@@ -15,7 +15,6 @@ Scenario Outline: all integers are multiples of 0.5, if overflow is handled
     Given the input JSON file "optional/float-overflow.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-date-time.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-date-time.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of date-time strings
     Given the input JSON file "optional/format/date-time.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-date.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-date.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of date strings
     Given the input JSON file "optional/format/date.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-duration.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-duration.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of duration strings
     Given the input JSON file "optional/format/duration.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-email.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-email.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of e-mail addresses
     Given the input JSON file "optional/format/email.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-hostname.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-hostname.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of host names
     Given the input JSON file "optional/format/hostname.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-idn-email.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-idn-email.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of an internationalized e-mail addresses
     Given the input JSON file "optional/format/idn-email.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-idn-hostname.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-idn-hostname.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of internationalized host names
     Given the input JSON file "optional/format/idn-hostname.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -109,7 +108,7 @@ Scenario Outline: validation of internationalized host names
         | #/000/tests/041/data | true  | KATAKANA MIDDLE DOT with Katakana                                                |
         # ・丈
         | #/000/tests/042/data | true  | KATAKANA MIDDLE DOT with Han                                                     |
-        # ٠۰
+        # ب٠۰
         | #/000/tests/043/data | false | Arabic-Indic digits mixed with Extended Arabic-Indic digits                      |
         # ب٠ب
         | #/000/tests/044/data | true  | Arabic-Indic digits not mixed with Extended Arabic-Indic digits                  |

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-ipv4.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-ipv4.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of IP addresses
     Given the input JSON file "optional/format/ipv4.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-ipv6.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-ipv6.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of IPv6 addresses
     Given the input JSON file "optional/format/ipv6.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-iri-reference.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-iri-reference.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of IRI References
     Given the input JSON file "optional/format/iri-reference.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-iri.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-iri.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of IRIs
     Given the input JSON file "optional/format/iri.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-json-pointer.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-json-pointer.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of JSON-pointers (JSON String Representation)
     Given the input JSON file "optional/format/json-pointer.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-regex.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-regex.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of regular expressions
     Given the input JSON file "optional/format/regex.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-relative-json-pointer.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-relative-json-pointer.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of Relative JSON Pointers (RJP)
     Given the input JSON file "optional/format/relative-json-pointer.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-time.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-time.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of time strings
     Given the input JSON file "optional/format/time.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-uri-reference.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-uri-reference.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of URI References
     Given the input JSON file "optional/format/uri-reference.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-uri-template.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-uri-template.feature
@@ -15,7 +15,6 @@ Scenario Outline: format: uri-template
     Given the input JSON file "optional/format/uri-template.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-uri.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-uri.feature
@@ -15,7 +15,6 @@ Scenario Outline: validation of URIs
     Given the input JSON file "optional/format/uri.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-uuid.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-format-uuid.feature
@@ -15,7 +15,6 @@ Scenario Outline: uuid format
     Given the input JSON file "optional/format/uuid.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-id.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-id.feature
@@ -38,7 +38,6 @@ Scenario Outline: $id inside an enum is not a real identifier
     Given the input JSON file "optional/id.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-no-schema.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-no-schema.feature
@@ -14,7 +14,6 @@ Scenario Outline: validation without $schema
     Given the input JSON file "optional/no-schema.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-refOfUnknownKeyword.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-refOfUnknownKeyword.feature
@@ -18,7 +18,6 @@ Scenario Outline: reference of a root arbitrary keyword
     Given the input JSON file "optional/refOfUnknownKeyword.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -44,7 +43,6 @@ Scenario Outline: reference of an arbitrary keyword of a sub-schema
     Given the input JSON file "optional/refOfUnknownKeyword.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -71,7 +69,6 @@ Scenario Outline: reference internals of known non-applicator
     Given the input JSON file "optional/refOfUnknownKeyword.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-unknownKeyword.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/optional-unknownKeyword.feature
@@ -45,7 +45,6 @@ Scenario Outline: $id inside an unknown keyword is not a real identifier
     Given the input JSON file "optional/unknownKeyword.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/pattern.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/pattern.feature
@@ -15,7 +15,6 @@ Scenario Outline: pattern validation
     Given the input JSON file "pattern.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -50,7 +49,6 @@ Scenario Outline: pattern is not anchored
     Given the input JSON file "pattern.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/patternProperties.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/patternProperties.feature
@@ -17,7 +17,6 @@ Scenario Outline: patternProperties validates properties matching a regex
     Given the input JSON file "patternProperties.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -53,7 +52,6 @@ Scenario Outline: multiple simultaneous patternProperties are validated
     Given the input JSON file "patternProperties.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -87,7 +85,6 @@ Scenario Outline: regexes are not anchored by default and are case sensitive
     Given the input JSON file "patternProperties.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -117,7 +114,6 @@ Scenario Outline: patternProperties with boolean schemas
     Given the input JSON file "patternProperties.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -148,7 +144,6 @@ Scenario Outline: patternProperties with null valued instance properties
     Given the input JSON file "patternProperties.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/properties.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/properties.feature
@@ -18,7 +18,6 @@ Scenario Outline: object properties validation
     Given the input JSON file "properties.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -54,7 +53,6 @@ Scenario Outline: properties, patternProperties, additionalProperties interactio
     Given the input JSON file "properties.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -92,7 +90,6 @@ Scenario Outline: properties with boolean schema
     Given the input JSON file "properties.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -126,7 +123,6 @@ Scenario Outline: properties with escaped characters
     Given the input JSON file "properties.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -151,7 +147,6 @@ Scenario Outline: properties with null valued instance properties
     Given the input JSON file "properties.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -178,7 +173,6 @@ Scenario Outline: properties whose names are Javascript object property names
     Given the input JSON file "properties.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/propertyNames.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/propertyNames.feature
@@ -15,7 +15,6 @@ Scenario Outline: propertyNames validation
     Given the input JSON file "propertyNames.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -46,7 +45,6 @@ Scenario Outline: propertyNames validation with pattern
     Given the input JSON file "propertyNames.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -71,7 +69,6 @@ Scenario Outline: propertyNames with boolean schema true
     Given the input JSON file "propertyNames.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -94,7 +91,6 @@ Scenario Outline: propertyNames with boolean schema false
     Given the input JSON file "propertyNames.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/recursiveRef.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/recursiveRef.feature
@@ -18,7 +18,6 @@ Scenario Outline: $recursiveRef without $recursiveAnchor works like $ref
     Given the input JSON file "recursiveRef.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -62,7 +61,6 @@ Scenario Outline: $recursiveRef without using nesting
     Given the input JSON file "recursiveRef.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -109,7 +107,6 @@ Scenario Outline: $recursiveRef with nesting
     Given the input JSON file "recursiveRef.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -156,7 +153,6 @@ Scenario Outline: $recursiveRef with $recursiveAnchor: false works like $ref
     Given the input JSON file "recursiveRef.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -202,7 +198,6 @@ Scenario Outline: $recursiveRef with no $recursiveAnchor works like $ref
     Given the input JSON file "recursiveRef.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -246,7 +241,6 @@ Scenario Outline: $recursiveRef with no $recursiveAnchor in the initial target s
     Given the input JSON file "recursiveRef.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -285,7 +279,6 @@ Scenario Outline: $recursiveRef with no $recursiveAnchor in the outer schema res
     Given the input JSON file "recursiveRef.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -338,7 +331,6 @@ Scenario Outline: multiple dynamic paths to the $recursiveRef keyword
     Given the input JSON file "recursiveRef.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -386,7 +378,6 @@ Scenario Outline: dynamic $recursiveRef destination (not predictable at schema c
     Given the input JSON file "recursiveRef.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/ref.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/ref.feature
@@ -18,7 +18,6 @@ Scenario Outline: root pointer ref
     Given the input JSON file "ref.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -48,7 +47,6 @@ Scenario Outline: relative pointer ref to object
     Given the input JSON file "ref.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -74,7 +72,6 @@ Scenario Outline: relative pointer ref to array
     Given the input JSON file "ref.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -106,7 +103,6 @@ Scenario Outline: escaped pointer ref
     Given the input JSON file "ref.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -142,7 +138,6 @@ Scenario Outline: nested refs
     Given the input JSON file "ref.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -175,7 +170,6 @@ Scenario Outline: ref applies alongside sibling keywords
     Given the input JSON file "ref.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -200,7 +194,6 @@ Scenario Outline: remote ref, containing refs itself
     Given the input JSON file "ref.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -225,7 +218,6 @@ Scenario Outline: property named $ref that is not a reference
     Given the input JSON file "ref.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -255,7 +247,6 @@ Scenario Outline: property named $ref, containing an actual $ref
     Given the input JSON file "ref.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -281,7 +272,6 @@ Scenario Outline: $ref to boolean schema true
     Given the input JSON file "ref.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -305,7 +295,6 @@ Scenario Outline: $ref to boolean schema false
     Given the input JSON file "ref.json"
     And the schema at "#/10/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -348,7 +337,6 @@ Scenario Outline: Recursive references between schemas
     Given the input JSON file "ref.json"
     And the schema at "#/11/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -376,7 +364,6 @@ Scenario Outline: refs with quote
     Given the input JSON file "ref.json"
     And the schema at "#/12/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -409,7 +396,6 @@ Scenario Outline: ref creates new scope when adjacent to keywords
     Given the input JSON file "ref.json"
     And the schema at "#/13/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -435,7 +421,6 @@ Scenario Outline: naive replacement of $ref with its destination is not correct
     Given the input JSON file "ref.json"
     And the schema at "#/14/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -474,7 +459,6 @@ Scenario Outline: refs with relative uris and defs
     Given the input JSON file "ref.json"
     And the schema at "#/15/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -513,7 +497,6 @@ Scenario Outline: relative refs with absolute uris and defs
     Given the input JSON file "ref.json"
     And the schema at "#/16/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -556,7 +539,6 @@ Scenario Outline: $id must be resolved against nearest parent, not just immediat
     Given the input JSON file "ref.json"
     And the schema at "#/17/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -593,7 +575,6 @@ Scenario Outline: order of evaluation: $id and $ref
     Given the input JSON file "ref.json"
     And the schema at "#/18/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -631,7 +612,6 @@ Scenario Outline: order of evaluation: $id and $anchor and $ref
     Given the input JSON file "ref.json"
     And the schema at "#/19/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -659,7 +639,6 @@ Scenario Outline: simple URN base URI with $ref via the URN
     Given the input JSON file "ref.json"
     And the schema at "#/20/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -689,7 +668,6 @@ Scenario Outline: simple URN base URI with JSON pointer
     Given the input JSON file "ref.json"
     And the schema at "#/21/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -719,7 +697,6 @@ Scenario Outline: URN base URI with NSS
     Given the input JSON file "ref.json"
     And the schema at "#/22/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -749,7 +726,6 @@ Scenario Outline: URN base URI with r-component
     Given the input JSON file "ref.json"
     And the schema at "#/23/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -779,7 +755,6 @@ Scenario Outline: URN base URI with q-component
     Given the input JSON file "ref.json"
     And the schema at "#/24/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -808,7 +783,6 @@ Scenario Outline: URN base URI with URN and JSON pointer ref
     Given the input JSON file "ref.json"
     And the schema at "#/25/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -840,7 +814,6 @@ Scenario Outline: URN base URI with URN and anchor ref
     Given the input JSON file "ref.json"
     And the schema at "#/26/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -870,7 +843,6 @@ Scenario Outline: URN ref with nested pointer ref
     Given the input JSON file "ref.json"
     And the schema at "#/27/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -897,7 +869,6 @@ Scenario Outline: ref to if
     Given the input JSON file "ref.json"
     And the schema at "#/28/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -924,7 +895,6 @@ Scenario Outline: ref to then
     Given the input JSON file "ref.json"
     And the schema at "#/29/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -951,7 +921,6 @@ Scenario Outline: ref to else
     Given the input JSON file "ref.json"
     And the schema at "#/30/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -985,7 +954,6 @@ Scenario Outline: ref with absolute-path-reference
     Given the input JSON file "ref.json"
     And the schema at "#/31/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1014,7 +982,6 @@ Scenario Outline: $id with file URI still resolves pointers - *nix
     Given the input JSON file "ref.json"
     And the schema at "#/32/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1043,7 +1010,6 @@ Scenario Outline: $id with file URI still resolves pointers - windows
     Given the input JSON file "ref.json"
     And the schema at "#/33/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1077,7 +1043,6 @@ Scenario Outline: empty tokens in $ref json-pointer
     Given the input JSON file "ref.json"
     And the schema at "#/34/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1119,7 +1084,6 @@ Scenario Outline: $ref with $recursiveAnchor
     Given the input JSON file "ref.json"
     And the schema at "#/35/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/refRemote.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/refRemote.feature
@@ -15,7 +15,6 @@ Scenario Outline: remote ref
     Given the input JSON file "refRemote.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -38,7 +37,6 @@ Scenario Outline: fragment within remote ref
     Given the input JSON file "refRemote.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -61,7 +59,6 @@ Scenario Outline: anchor within remote ref
     Given the input JSON file "refRemote.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -84,7 +81,6 @@ Scenario Outline: ref within remote ref
     Given the input JSON file "refRemote.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -111,7 +107,6 @@ Scenario Outline: base URI change
     Given the input JSON file "refRemote.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -143,7 +138,6 @@ Scenario Outline: base URI change - change folder
     Given the input JSON file "refRemote.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -179,7 +173,6 @@ Scenario Outline: base URI change - change folder in subschema
     Given the input JSON file "refRemote.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -206,7 +199,6 @@ Scenario Outline: root ref in remote ref
     Given the input JSON file "refRemote.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -232,7 +224,6 @@ Scenario Outline: remote ref with ref to defs
     Given the input JSON file "refRemote.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -255,7 +246,6 @@ Scenario Outline: Location-independent identifier in remote ref
     Given the input JSON file "refRemote.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -281,7 +271,6 @@ Scenario Outline: retrieved nested refs resolve relative to their URI not $id
     Given the input JSON file "refRemote.json"
     And the schema at "#/10/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -304,7 +293,6 @@ Scenario Outline: remote HTTP ref with different $id
     Given the input JSON file "refRemote.json"
     And the schema at "#/11/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -327,7 +315,6 @@ Scenario Outline: remote HTTP ref with different URN $id
     Given the input JSON file "refRemote.json"
     And the schema at "#/12/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -350,7 +337,6 @@ Scenario Outline: remote HTTP ref with nested absolute ref
     Given the input JSON file "refRemote.json"
     And the schema at "#/13/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -373,7 +359,6 @@ Scenario Outline: $ref to $ref finds detached $anchor
     Given the input JSON file "refRemote.json"
     And the schema at "#/14/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/required.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/required.feature
@@ -19,7 +19,6 @@ Scenario Outline: required validation
     Given the input JSON file "required.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -50,7 +49,6 @@ Scenario Outline: required default validation
     Given the input JSON file "required.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -74,7 +72,6 @@ Scenario Outline: required with empty array
     Given the input JSON file "required.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -102,7 +99,6 @@ Scenario Outline: required with escaped characters
     Given the input JSON file "required.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -125,7 +121,6 @@ Scenario Outline: required properties whose names are Javascript object property
     Given the input JSON file "required.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/type.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/type.feature
@@ -15,7 +15,6 @@ Scenario Outline: integer type matches integers
     Given the input JSON file "type.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -52,7 +51,6 @@ Scenario Outline: number type matches numbers
     Given the input JSON file "type.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -89,7 +87,6 @@ Scenario Outline: string type matches strings
     Given the input JSON file "type.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -126,7 +123,6 @@ Scenario Outline: object type matches objects
     Given the input JSON file "type.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -159,7 +155,6 @@ Scenario Outline: array type matches arrays
     Given the input JSON file "type.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -192,7 +187,6 @@ Scenario Outline: boolean type matches booleans
     Given the input JSON file "type.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -231,7 +225,6 @@ Scenario Outline: null type matches only the null object
     Given the input JSON file "type.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -270,7 +263,6 @@ Scenario Outline: multiple types can be specified in an array
     Given the input JSON file "type.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -303,7 +295,6 @@ Scenario Outline: type as array with one item
     Given the input JSON file "type.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -326,7 +317,6 @@ Scenario Outline: type: array or object
     Given the input JSON file "type.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -355,7 +345,6 @@ Scenario Outline: type: array, object or null
     Given the input JSON file "type.json"
     And the schema at "#/10/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/unevaluatedItems.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/unevaluatedItems.feature
@@ -15,7 +15,6 @@ Scenario Outline: unevaluatedItems true
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -38,7 +37,6 @@ Scenario Outline: unevaluatedItems false
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -61,7 +59,6 @@ Scenario Outline: unevaluatedItems as schema
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -87,7 +84,6 @@ Scenario Outline: unevaluatedItems with uniform items
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -111,7 +107,6 @@ Scenario Outline: unevaluatedItems with tuple
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -138,7 +133,6 @@ Scenario Outline: unevaluatedItems with items and additionalItems
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -160,7 +154,6 @@ Scenario Outline: unevaluatedItems with ignored additionalItems
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -184,7 +177,6 @@ Scenario Outline: unevaluatedItems with ignored applicator additionalItems
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -218,7 +210,6 @@ Scenario Outline: unevaluatedItems with nested tuple
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -245,7 +236,6 @@ Scenario Outline: unevaluatedItems with nested items
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -278,7 +268,6 @@ Scenario Outline: unevaluatedItems with nested items and additionalItems
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/10/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -309,7 +298,6 @@ Scenario Outline: unevaluatedItems with nested unevaluatedItems
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/11/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -350,7 +338,6 @@ Scenario Outline: unevaluatedItems with anyOf
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/12/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -394,7 +381,6 @@ Scenario Outline: unevaluatedItems with oneOf
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/13/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -428,7 +414,6 @@ Scenario Outline: unevaluatedItems with not
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/14/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -471,7 +456,6 @@ Scenario Outline: unevaluatedItems with if/then/else
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/15/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -499,7 +483,6 @@ Scenario Outline: unevaluatedItems with boolean schemas
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/16/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -534,7 +517,6 @@ Scenario Outline: unevaluatedItems with $ref
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/17/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -569,7 +551,6 @@ Scenario Outline: unevaluatedItems before $ref
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/18/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -618,7 +599,6 @@ Scenario Outline: unevaluatedItems with $recursiveRef
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/19/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -646,7 +626,6 @@ Scenario Outline: unevaluatedItems can't see inside cousins
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/20/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -686,7 +665,6 @@ Scenario Outline: item is evaluated in an uncle schema to unevaluatedItems
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/21/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -709,7 +687,6 @@ Scenario Outline: non-array instances are valid
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/22/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -742,7 +719,6 @@ Scenario Outline: unevaluatedItems with null instance elements
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/23/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -766,7 +742,6 @@ Scenario Outline: unevaluatedItems can see annotations from if without then and 
     Given the input JSON file "unevaluatedItems.json"
     And the schema at "#/24/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/unevaluatedProperties.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/unevaluatedProperties.feature
@@ -16,7 +16,6 @@ Scenario Outline: unevaluatedProperties true
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -43,7 +42,6 @@ Scenario Outline: unevaluatedProperties schema
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -69,7 +67,6 @@ Scenario Outline: unevaluatedProperties false
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -96,7 +93,6 @@ Scenario Outline: unevaluatedProperties with adjacent properties
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -123,7 +119,6 @@ Scenario Outline: unevaluatedProperties with adjacent patternProperties
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -151,7 +146,6 @@ Scenario Outline: unevaluatedProperties with adjacent additionalProperties
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -185,7 +179,6 @@ Scenario Outline: unevaluatedProperties with nested properties
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/6/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -219,7 +212,6 @@ Scenario Outline: unevaluatedProperties with nested patternProperties
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/7/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -251,7 +243,6 @@ Scenario Outline: unevaluatedProperties with nested additionalProperties
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/8/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -286,7 +277,6 @@ Scenario Outline: unevaluatedProperties with nested unevaluatedProperties
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/9/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -333,7 +323,6 @@ Scenario Outline: unevaluatedProperties with anyOf
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/10/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -378,7 +367,6 @@ Scenario Outline: unevaluatedProperties with oneOf
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/11/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -413,7 +401,6 @@ Scenario Outline: unevaluatedProperties with not
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/12/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -453,7 +440,6 @@ Scenario Outline: unevaluatedProperties with if/then/else
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/13/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -493,7 +479,6 @@ Scenario Outline: unevaluatedProperties with if/then/else, then not defined
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/14/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -533,7 +518,6 @@ Scenario Outline: unevaluatedProperties with if/then/else, else not defined
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/15/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -572,7 +556,6 @@ Scenario Outline: unevaluatedProperties with dependentSchemas
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/16/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -600,7 +583,6 @@ Scenario Outline: unevaluatedProperties with boolean schemas
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/17/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -635,7 +617,6 @@ Scenario Outline: unevaluatedProperties with $ref
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/18/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -670,7 +651,6 @@ Scenario Outline: unevaluatedProperties before $ref
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/19/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -718,7 +698,6 @@ Scenario Outline: unevaluatedProperties with $recursiveRef
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/20/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -750,7 +729,6 @@ Scenario Outline: unevaluatedProperties can't see inside cousins
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/21/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -780,7 +758,6 @@ Scenario Outline: unevaluatedProperties can't see inside cousins (reverse order)
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/22/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -810,7 +787,6 @@ Scenario Outline: nested unevaluatedProperties, outer false, inner true, propert
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/23/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -842,7 +818,6 @@ Scenario Outline: nested unevaluatedProperties, outer false, inner true, propert
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/24/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -874,7 +849,6 @@ Scenario Outline: nested unevaluatedProperties, outer true, inner false, propert
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/25/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -906,7 +880,6 @@ Scenario Outline: nested unevaluatedProperties, outer true, inner false, propert
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/26/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -940,7 +913,6 @@ Scenario Outline: cousin unevaluatedProperties, true and false, true with proper
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/27/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -974,7 +946,6 @@ Scenario Outline: cousin unevaluatedProperties, true and false, false with prope
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/28/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1021,7 +992,6 @@ Scenario Outline: property is evaluated in an uncle schema to unevaluatedPropert
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/29/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1059,7 +1029,6 @@ Scenario Outline: in-place applicator siblings, allOf has unevaluated
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/30/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1099,7 +1068,6 @@ Scenario Outline: in-place applicator siblings, anyOf has unevaluated
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/31/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1128,7 +1096,6 @@ Scenario Outline: unevaluatedProperties + single cyclic ref
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/32/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1183,7 +1150,6 @@ Scenario Outline: unevaluatedProperties + ref inside allOf / oneOf
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/33/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1238,7 +1204,6 @@ Scenario Outline: dynamic evalation inside nested refs
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/34/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1299,7 +1264,6 @@ Scenario Outline: non-object instances are valid
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/35/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1332,7 +1296,6 @@ Scenario Outline: unevaluatedProperties with null valued instance properties
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/36/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1356,7 +1319,6 @@ Scenario Outline: unevaluatedProperties not affected by propertyNames
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/37/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1386,7 +1348,6 @@ Scenario Outline: unevaluatedProperties can see annotations from if without then
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/38/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -1418,7 +1379,6 @@ Scenario Outline: dependentSchemas with unevaluatedProperties
     Given the input JSON file "unevaluatedProperties.json"
     And the schema at "#/39/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/uniqueItems.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/uniqueItems.feature
@@ -15,7 +15,6 @@ Scenario Outline: uniqueItems validation
     Given the input JSON file "uniqueItems.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -91,7 +90,6 @@ Scenario Outline: uniqueItems with an array of items
     Given the input JSON file "uniqueItems.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -128,7 +126,6 @@ Scenario Outline: uniqueItems with an array of items and additionalItems equals 
     Given the input JSON file "uniqueItems.json"
     And the schema at "#/2/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -157,7 +154,6 @@ Scenario Outline: uniqueItems equals false validation
     Given the input JSON file "uniqueItems.json"
     And the schema at "#/3/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -207,7 +203,6 @@ Scenario Outline: uniqueItems equals false with an array of items
     Given the input JSON file "uniqueItems.json"
     And the schema at "#/4/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -244,7 +239,6 @@ Scenario Outline: uniqueItems equals false with an array of items and additional
     Given the input JSON file "uniqueItems.json"
     And the schema at "#/5/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/vocabulary.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft201909/vocabulary.feature
@@ -21,7 +21,6 @@ Scenario Outline: schema that uses custom metaschema with with no validation voc
     Given the input JSON file "vocabulary.json"
     And the schema at "#/0/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance
@@ -46,7 +45,6 @@ Scenario Outline: ignore unrecognized optional vocabulary
     Given the input JSON file "vocabulary.json"
     And the schema at "#/1/schema"
     And the input data at "<inputDataReference>"
-    And I assert format
     And I generate a type for the schema
     And I construct an instance of the schema type from the data
     When I validate the instance

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft2020212/optional-format-idn-hostname.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft2020212/optional-format-idn-hostname.feature
@@ -109,7 +109,7 @@ Scenario Outline: validation of internationalized host names
         | #/000/tests/041/data | true  | KATAKANA MIDDLE DOT with Katakana                                                |
         # ・丈
         | #/000/tests/042/data | true  | KATAKANA MIDDLE DOT with Han                                                     |
-        # ٠۰
+        # ب٠۰
         | #/000/tests/043/data | false | Arabic-Indic digits mixed with Extended Arabic-Indic digits                      |
         # ب٠ب
         | #/000/tests/044/data | true  | Arabic-Indic digits not mixed with Extended Arabic-Indic digits                  |

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft4/refRemote.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft4/refRemote.feature
@@ -27,7 +27,7 @@ Scenario Outline: remote ref
 
 Scenario Outline: fragment within remote ref
 /* Schema: 
-{"$ref": "http://localhost:1234/subSchemas.json#/definitions/integer"}
+{"$ref": "http://localhost:1234/draft4/subSchemas.json#/definitions/integer"}
 */
     Given the input JSON file "refRemote.json"
     And the schema at "#/1/schema"
@@ -48,7 +48,7 @@ Scenario Outline: fragment within remote ref
 Scenario Outline: ref within remote ref
 /* Schema: 
 {
-            "$ref": "http://localhost:1234/subSchemas.json#/definitions/refToInteger"
+            "$ref": "http://localhost:1234/draft4/subSchemas.json#/definitions/refToInteger"
         }
 */
     Given the input JSON file "refRemote.json"
@@ -169,7 +169,7 @@ Scenario Outline: root ref in remote ref
             "id": "http://localhost:1234/object",
             "type": "object",
             "properties": {
-                "name": {"$ref": "name.json#/definitions/orNull"}
+                "name": {"$ref": "draft4/name.json#/definitions/orNull"}
             }
         }
 */
@@ -194,7 +194,7 @@ Scenario Outline: root ref in remote ref
 Scenario Outline: Location-independent identifier in remote ref
 /* Schema: 
 {
-            "$ref": "http://localhost:1234/locationIndependentIdentifierDraft4.json#/definitions/refToInteger"
+            "$ref": "http://localhost:1234/draft4/locationIndependentIdentifier.json#/definitions/refToInteger"
         }
 */
     Given the input JSON file "refRemote.json"

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft6/refRemote.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft6/refRemote.feature
@@ -27,7 +27,7 @@ Scenario Outline: remote ref
 
 Scenario Outline: fragment within remote ref
 /* Schema: 
-{"$ref": "http://localhost:1234/subSchemas.json#/definitions/integer"}
+{"$ref": "http://localhost:1234/draft6/subSchemas.json#/definitions/integer"}
 */
     Given the input JSON file "refRemote.json"
     And the schema at "#/1/schema"
@@ -48,7 +48,7 @@ Scenario Outline: fragment within remote ref
 Scenario Outline: ref within remote ref
 /* Schema: 
 {
-            "$ref": "http://localhost:1234/subSchemas.json#/definitions/refToInteger"
+            "$ref": "http://localhost:1234/draft6/subSchemas.json#/definitions/refToInteger"
         }
 */
     Given the input JSON file "refRemote.json"
@@ -169,7 +169,7 @@ Scenario Outline: root ref in remote ref
             "$id": "http://localhost:1234/object",
             "type": "object",
             "properties": {
-                "name": {"$ref": "name.json#/definitions/orNull"}
+                "name": {"$ref": "draft6/name.json#/definitions/orNull"}
             }
         }
 */
@@ -196,7 +196,7 @@ Scenario Outline: remote ref with ref to definitions
 {
             "$id": "http://localhost:1234/schema-remote-ref-ref-defs1.json",
             "allOf": [
-                { "$ref": "ref-and-definitions.json" }
+                { "$ref": "draft6/ref-and-definitions.json" }
             ]
         }
 */
@@ -219,7 +219,7 @@ Scenario Outline: remote ref with ref to definitions
 Scenario Outline: Location-independent identifier in remote ref
 /* Schema: 
 {
-            "$ref": "http://localhost:1234/locationIndependentIdentifierPre2019.json#/definitions/refToInteger"
+            "$ref": "http://localhost:1234/draft6/locationIndependentIdentifier.json#/definitions/refToInteger"
         }
 */
     Given the input JSON file "refRemote.json"

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft7/optional-format-idn-hostname.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft7/optional-format-idn-hostname.feature
@@ -106,7 +106,7 @@ Scenario Outline: validation of internationalized host names
         | #/000/tests/041/data | true  | KATAKANA MIDDLE DOT with Katakana                                                |
         # ・丈
         | #/000/tests/042/data | true  | KATAKANA MIDDLE DOT with Han                                                     |
-        # ٠۰
+        # ب٠۰
         | #/000/tests/043/data | false | Arabic-Indic digits mixed with Extended Arabic-Indic digits                      |
         # ب٠ب
         | #/000/tests/044/data | true  | Arabic-Indic digits not mixed with Extended Arabic-Indic digits                  |

--- a/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft7/refRemote.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonSchema/Draft7/refRemote.feature
@@ -27,7 +27,7 @@ Scenario Outline: remote ref
 
 Scenario Outline: fragment within remote ref
 /* Schema: 
-{"$ref": "http://localhost:1234/subSchemas.json#/definitions/integer"}
+{"$ref": "http://localhost:1234/draft7/subSchemas.json#/definitions/integer"}
 */
     Given the input JSON file "refRemote.json"
     And the schema at "#/1/schema"
@@ -48,7 +48,7 @@ Scenario Outline: fragment within remote ref
 Scenario Outline: ref within remote ref
 /* Schema: 
 {
-            "$ref": "http://localhost:1234/subSchemas.json#/definitions/refToInteger"
+            "$ref": "http://localhost:1234/draft7/subSchemas.json#/definitions/refToInteger"
         }
 */
     Given the input JSON file "refRemote.json"
@@ -169,7 +169,7 @@ Scenario Outline: root ref in remote ref
             "$id": "http://localhost:1234/object",
             "type": "object",
             "properties": {
-                "name": {"$ref": "name.json#/definitions/orNull"}
+                "name": {"$ref": "draft7/name.json#/definitions/orNull"}
             }
         }
 */
@@ -196,7 +196,7 @@ Scenario Outline: remote ref with ref to definitions
 {
             "$id": "http://localhost:1234/schema-remote-ref-ref-defs1.json",
             "allOf": [
-                { "$ref": "ref-and-definitions.json" }
+                { "$ref": "draft7/ref-and-definitions.json" }
             ]
         }
 */
@@ -219,7 +219,7 @@ Scenario Outline: remote ref with ref to definitions
 Scenario Outline: Location-independent identifier in remote ref
 /* Schema: 
 {
-            "$ref": "http://localhost:1234/locationIndependentIdentifierPre2019.json#/definitions/refToInteger"
+            "$ref": "http://localhost:1234/draft7/locationIndependentIdentifier.json#/definitions/refToInteger"
         }
 */
     Given the input JSON file "refRemote.json"

--- a/Solutions/Corvus.Json.Specs/Hooks/ContainerConfiguration.cs
+++ b/Solutions/Corvus.Json.Specs/Hooks/ContainerConfiguration.cs
@@ -33,7 +33,23 @@ public static class ContainerConfiguration
 
         var services = new ServiceCollection();
 
-        services.AddTransient(serviceProvider => new CompoundDocumentResolver(new FakeWebDocumentResolver(serviceProvider.GetRequiredService<IConfiguration>()["jsonSchemaBuilderDriverSettings:remotesBaseDirectory"]!), new FileSystemDocumentResolver()).AddMetaschema());
+        services.AddTransient(serviceProvider =>
+        {
+            ScenarioContext scenarioContext = serviceProvider.GetRequiredService<ScenarioContext>();
+            string path;
+            if (scenarioContext.ScenarioInfo.ScenarioAndFeatureTags.Any(t => t == "openApi30"))
+            {
+                path = serviceProvider.GetRequiredService<IConfiguration>()["jsonSchemaBuilderOpenApi30DriverSettings:remotesBaseDirectory"]!;
+            }
+            else
+            {
+                path = serviceProvider.GetRequiredService<IConfiguration>()["jsonSchemaBuilderDriverSettings:remotesBaseDirectory"]!;
+            }
+
+            return new CompoundDocumentResolver(
+                new FakeWebDocumentResolver(path),
+                new FileSystemDocumentResolver()).AddMetaschema();
+        });
         services.AddTransient<JsonSchemaTypeBuilder>();
         services.AddTransient(sp =>
         {

--- a/Solutions/Corvus.Json.Specs/appsettings.json
+++ b/Solutions/Corvus.Json.Specs/appsettings.json
@@ -9,7 +9,8 @@
         "testBaseDirectory": "../../../../../JSON-Schema-Test-Suite/tests/draft4"
     },
     "jsonSchemaBuilderOpenApi30DriverSettings": {
-        "testBaseDirectory": "../../../../../OpenApi-Test-Suite/tests/openApi30"
+        "testBaseDirectory": "../../../../../OpenApi-Test-Suite/tests/openApi30",
+        "remotesBaseDirectory": "../../../../../OpenApi-Test-Suite/remotes"
     },
     "jsonSchemaBuilder7DriverSettings": {
         "testBaseDirectory": "../../../../../JSON-Schema-Test-Suite/tests/draft7"

--- a/Solutions/Corvus.JsonSchema.SpecGenerator/JsonSchemaOrgTestSuiteSelector.jsonc
+++ b/Solutions/Corvus.JsonSchema.SpecGenerator/JsonSchemaOrgTestSuiteSelector.jsonc
@@ -22,6 +22,7 @@
                     "subdirectories": {
                         "format": {
                             "excludeFromThisDirectory": [
+                                "ecmascript-regex\\.json"
                             ],
                             "testExclusions": {
                                 "optional/format/date-time.json": {
@@ -57,6 +58,7 @@
                     "subdirectories": {
                         "format": {
                             "excludeFromThisDirectory": [
+                                "ecmascript-regex\\.json"
                             ],
                             "testExclusions": {
                                 "optional/format/date-time.json": {
@@ -93,6 +95,7 @@
                     "subdirectories": {
                         "format": {
                             "excludeFromThisDirectory": [
+                                "ecmascript-regex\\.json"
                             ],
                             "testExclusions": {
                                 "optional/format/date-time.json": {
@@ -125,7 +128,7 @@
         },
 
         "draft2019-09": {
-            "assertFormat": true,
+            "assertFormat": false,
             "testSet": "draft2019-09",
             "outputFolder": "Draft201909",
             "excludeFromThisDirectory": [
@@ -143,7 +146,8 @@
                     "subdirectories": {
                         "format": {
                             "excludeFromThisDirectory": [
-                                "unknown\\.json"
+                                "unknown\\.json",
+                                "ecmascript-regex\\.json"
                             ],
                             "testExclusions": {
                                 "optional/format/date-time.json": {
@@ -194,8 +198,9 @@
                     ],
                     "subdirectories": {
                         "format": {
-                            "assertFormat":  true,
+                            "assertFormat": true,
                             "excludeFromThisDirectory": [
+                                "ecmascript-regex\\.json"
                             ],
                             "testExclusions": {
                                 "optional/format/date-time.json": {

--- a/Solutions/Sandbox.SourceGenerator/Model/FlimFlam.cs
+++ b/Solutions/Sandbox.SourceGenerator/Model/FlimFlam.cs
@@ -2,7 +2,7 @@
 using Corvus.Json;
 
 namespace SourceGenTest2.Model;
-[JsonSchemaTypeGenerator("../test.json")]
+[JsonSchemaTypeGenerator("../test.json#/$defs/FlimFlam")]
 public readonly partial struct FlimFlam
 {
 }

--- a/Solutions/Sandbox.SourceGenerator/test.json
+++ b/Solutions/Sandbox.SourceGenerator/test.json
@@ -1,8 +1,13 @@
 {
     "$schema": "https://corvus-oss.org/json-schema/2020-12/schema",
-    "type": "object",
-    "properties": {
-        "theArray": {
+    "$defs": {
+        "FlimFlam": {
+            "type": "object",
+            "properties": {
+                "theArray": { "$ref": "#/%24defs/someArray" }
+            }
+        },
+        "someArray": {
             "type": "array",
             "prefixItems": [
                 {


### PR DESCRIPTION
Source generator fallback namespace should be derived from the first type we see.
The test suite needs to be updated to the latest commit.