### PR TITLE
Feature/563 source generator should respect the accessibility of the partial struct that it is assigned to

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -20,5 +20,5 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "4.2"
+next-version: "4.3"
 

--- a/README.md
+++ b/README.md
@@ -404,6 +404,31 @@ Benchmark suites for various components.
 
 The Source Generator which generates types from Json Schema.
 
+## V4.3.0 Updates
+
+### Type Accessibility using the Source Generator
+
+The source generator now respects the accessibility of the model type.
+
+For example
+
+```csharp
+[JsonSchemaTypeGenerator("../test.json#/$defs/FlimFlam")]
+internal readonly partial struct FlimFlam
+{
+}
+```
+
+Any nested types will be generated with `public` accessibility.
+
+Only `internal` and `public` are supported. The source generator will fail for an unsupported accessiblity declaration.
+
+You can override the default accessibility for all generated types with a build property:
+
+`<CorvusJsonSchemaDefaultAccessibility>Internal</CorvusJsonSchemaDefaultAccessibility>`
+
+Note that you can still generate code that will not compile if you incorrectly mix-and-match `public` and `internal`. It is your responsibility to ensure that your types have compatible accessibility.
+
 ## V4.2.0 Updates
 
 ### Breaking change

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/ArrayPartial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/ArrayPartial.cs
@@ -52,7 +52,8 @@ public sealed class ArrayPartial : ICodeFileBuilder
                     .BeginTypeDeclarationNesting(typeDeclaration)
                         .AppendDocumentation(typeDeclaration)
                         .AppendDotnet80OrGreaterCollectionBuilderAttribute(typeDeclaration)
-                        .BeginPublicReadonlyPartialStructDeclaration(
+                        .BeginReadonlyPartialStructDeclaration(
+                            typeDeclaration.DotnetAccessibility(),
                             typeDeclaration.DotnetTypeName(),
                             interfaces:
                             [

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/BooleanPartial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/BooleanPartial.cs
@@ -49,7 +49,8 @@ public sealed class BooleanPartial : ICodeFileBuilder
                     .AppendLine()
                     .BeginTypeDeclarationNesting(typeDeclaration)
                         .AppendDocumentation(typeDeclaration)
-                        .BeginPublicReadonlyPartialStructDeclaration(
+                        .BeginReadonlyPartialStructDeclaration(
+                            typeDeclaration.DotnetAccessibility(),
                             typeDeclaration.DotnetTypeName(),
                             interfaces:
                                 [

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/CorePartial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/CorePartial.cs
@@ -47,7 +47,8 @@ public sealed class CorePartial : ICodeFileBuilder
                 .BeginTypeDeclarationNesting(typeDeclaration)
                     .AppendDocumentation(typeDeclaration)
                     .AppendJsonConverterAttribute(typeDeclaration)
-                    .BeginPublicReadonlyPartialStructDeclaration(
+                    .BeginReadonlyPartialStructDeclaration(
+                        typeDeclaration.DotnetAccessibility(),
                         typeDeclaration.DotnetTypeName(),
                         interfaces: [
                             JsonAnyType(typeDeclaration)

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/NumberPartial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/NumberPartial.cs
@@ -50,7 +50,8 @@ public sealed class NumberPartial : ICodeFileBuilder
                     .AppendLine()
                     .BeginTypeDeclarationNesting(typeDeclaration)
                         .AppendDocumentation(typeDeclaration)
-                        .BeginPublicReadonlyPartialStructDeclaration(
+                        .BeginReadonlyPartialStructDeclaration(
+                            typeDeclaration.DotnetAccessibility(),
                             typeDeclaration.DotnetTypeName(),
                             interfaces:
                                 [

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/ObjectPartial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/ObjectPartial.cs
@@ -51,7 +51,8 @@ public sealed class ObjectPartial : ICodeFileBuilder
                     .AppendLine()
                     .BeginTypeDeclarationNesting(typeDeclaration)
                         .AppendDocumentation(typeDeclaration)
-                        .BeginPublicReadonlyPartialStructDeclaration(
+                        .BeginReadonlyPartialStructDeclaration(
+                            typeDeclaration.DotnetAccessibility(),
                             typeDeclaration.DotnetTypeName(),
                             interfaces:
                             [

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/StringPartial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/StringPartial.cs
@@ -50,7 +50,8 @@ public sealed class StringPartial : ICodeFileBuilder
                     .AppendLine()
                     .BeginTypeDeclarationNesting(typeDeclaration)
                         .AppendDocumentation(typeDeclaration)
-                        .BeginPublicReadonlyPartialStructDeclaration(
+                        .BeginReadonlyPartialStructDeclaration(
+                            typeDeclaration.DotnetAccessibility(),
                             typeDeclaration.DotnetTypeName(),
                             interfaces:
                                 [

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/ValidatePartial.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/ValidatePartial.cs
@@ -42,12 +42,14 @@ public sealed class ValidatePartial : ICodeFileBuilder
                         new("global::System.Threading.Tasks", addExplicitUsings),
                         "System.Runtime.CompilerServices",
                         "System.Text.Json",
-                        RequiresRegularExressions(typeDeclaration) ? "System.Text.RegularExpressions" : ConditionalCodeSpecification.DoNotEmit,
+                        RequiresRegularExpressions(typeDeclaration) ? "System.Text.RegularExpressions" : ConditionalCodeSpecification.DoNotEmit,
                         new("Corvus.Json", EmitIfNotCorvusJsonExtendedType(typeDeclaration)))
                     .AppendLine()
                     .BeginTypeDeclarationNesting(typeDeclaration)
                         .AppendDocumentation(typeDeclaration)
-                        .BeginPublicReadonlyPartialStructDeclaration(typeDeclaration.DotnetTypeName());
+                        .BeginReadonlyPartialStructDeclaration(
+                            typeDeclaration.DotnetAccessibility(),
+                            typeDeclaration.DotnetTypeName());
 
             // This is a core type
             if (typeDeclaration.IsCorvusJsonExtendedType())
@@ -85,7 +87,7 @@ public sealed class ValidatePartial : ICodeFileBuilder
         }
     }
 
-    private static bool RequiresRegularExressions(TypeDeclaration typeDeclaration)
+    private static bool RequiresRegularExpressions(TypeDeclaration typeDeclaration)
     {
         return typeDeclaration.ValidationRegularExpressions() is IReadOnlyDictionary<IValidationRegexProviderKeyword, IReadOnlyList<string>> regexes && regexes.Count != 0;
     }

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.cs
@@ -3695,7 +3695,8 @@ internal static partial class CodeGeneratorExtensions
             generator
                 .AppendSeparatorLine()
                 .AppendDocumentation(parent)
-                .BeginPublicReadonlyPartialStructDeclaration(
+                .BeginReadonlyPartialStructDeclaration(
+                    parent.DotnetAccessibility(),
                     parent.DotnetTypeName());
         }
 
@@ -3990,11 +3991,13 @@ internal static partial class CodeGeneratorExtensions
     /// Emits the start of a partial struct declaration.
     /// </summary>
     /// <param name="generator">The generator to which to append the beginning of the struct declaration.</param>
+    /// <param name="accessibility">The accessibility for the generated type.</param>
     /// <param name="dotnetTypeName">The .NET type name for the partial struct.</param>
     /// <param name="interfaces">Interfaces to implement.</param>
     /// <returns>A reference to the generator having completed the operation.</returns>
-    public static CodeGenerator BeginPublicReadonlyPartialStructDeclaration(
+    public static CodeGenerator BeginReadonlyPartialStructDeclaration(
         this CodeGenerator generator,
+        GeneratedTypeAccessibility accessibility,
         string dotnetTypeName,
         ConditionalCodeSpecification[]? interfaces = null)
     {
@@ -4003,9 +4006,16 @@ internal static partial class CodeGeneratorExtensions
             return generator;
         }
 
+        string accessibilityString = accessibility switch
+        {
+            GeneratedTypeAccessibility.Public => "public",
+            GeneratedTypeAccessibility.Internal => "internal",
+            _ => throw new ArgumentOutOfRangeException(nameof(accessibility)),
+        };
+
         generator.ReserveNameIfNotReserved(dotnetTypeName);
         generator
-            .AppendIndent("public readonly partial struct ")
+            .AppendIndent(accessibilityString, " readonly partial struct ")
             .AppendLine(dotnetTypeName);
 
         if (interfaces is ConditionalCodeSpecification[] conditionalSpecifications)

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/GeneratedTypeAccessibility.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/GeneratedTypeAccessibility.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="GeneratedTypeAccessibility.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Json.CodeGeneration.CSharp;
+
+/// <summary>
+/// Defines the accessibility of the generated types.
+/// </summary>
+public enum GeneratedTypeAccessibility
+{
+    /// <summary>
+    /// The generated types should be <see langword="public"/>.
+    /// </summary>
+    Public,
+
+    /// <summary>
+    /// The generated types should be <see langword="internal"/>.
+    /// </summary>
+    Internal,
+}

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/TypeDeclarationExtensions.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/TypeDeclarationExtensions.cs
@@ -24,6 +24,8 @@ public static class TypeDeclarationExtensions
     private const string PreferredBinaryJsonNumberKindKey = "CSharp_LanguageProvider_PreferredBinaryJsonNumberKind";
     private const string UseImplicitOperatorStringKey = "CSharp_LanguageProvider_UseImplicitOperatorString";
     private const string AddExplicitUsingsKey = "CSharp_LanguageProvider_AddExplicitUsings";
+    private const string DefaultAccessibilityKey = "CSharp_LanguageProvider_DefaultAccessibilityKey";
+    private const string AccessibilityKey = "CSharp_LanguageProvider_DefaultAccessibilityKey";
 
     /// <summary>
     /// Sets the relevant metadata from the <see cref="CSharpLanguageProvider.Options"/>.
@@ -36,6 +38,7 @@ public static class TypeDeclarationExtensions
         typeDeclaration.SetMetadata(OptionalAsNullableKey, options.OptionalAsNullable);
         typeDeclaration.SetMetadata(UseImplicitOperatorStringKey, options.UseImplicitOperatorString);
         typeDeclaration.SetMetadata(AddExplicitUsingsKey, options.AddExplicitUsings);
+        typeDeclaration.SetMetadata(DefaultAccessibilityKey, options.DefaultAccessibility);
     }
 
     /// <summary>
@@ -600,6 +603,49 @@ public static class TypeDeclarationExtensions
     {
         typeDeclaration.SetMetadata(DotnetNamespaceKey, ns);
         return typeDeclaration;
+    }
+
+    /// <summary>
+    /// Sets the .NET accessibility.
+    /// </summary>
+    /// <param name="typeDeclaration">The type declaration.</param>
+    /// <param name="accessibility">The <see cref="GeneratedTypeAccessibility"/>.</param>
+    /// <returns>A reference to the type declaration after the operation has completed.</returns>
+    public static TypeDeclaration SetDotnetAccessibility(this TypeDeclaration typeDeclaration, GeneratedTypeAccessibility accessibility)
+    {
+        typeDeclaration.SetMetadata(AccessibilityKey, accessibility);
+        return typeDeclaration;
+    }
+
+    /// <summary>
+    /// Gets the .NET accessibility.
+    /// </summary>
+    /// <param name="typeDeclaration">The type declaration.</param>
+    /// <returns>
+    /// The <see cref="GeneratedTypeAccessibility"/> for the type. If this has been set explicitly, it will return the accessibility for this type.
+    /// If it has a <c>Parent</c>, it will be <see cref="GeneratedTypeAccessibility.Public"/>. Otherwise, it will fall back to the default accessibility
+    /// for the code generation context (which defaults to <see cref="GeneratedTypeAccessibility.Public"/>).
+    /// </returns>
+    public static GeneratedTypeAccessibility DotnetAccessibility(this TypeDeclaration typeDeclaration)
+    {
+        if (typeDeclaration.TryGetMetadata(AccessibilityKey, out GeneratedTypeAccessibility? typeAccessibility) &&
+            typeAccessibility is GeneratedTypeAccessibility value)
+        {
+            return value;
+        }
+
+        if (typeDeclaration.Parent() is not null)
+        {
+            return GeneratedTypeAccessibility.Public;
+        }
+
+        if (typeDeclaration.TryGetMetadata(DefaultAccessibilityKey, out GeneratedTypeAccessibility? defaultTypeAccessibility) &&
+            defaultTypeAccessibility is GeneratedTypeAccessibility defaultValue)
+        {
+            return defaultValue;
+        }
+
+        return GeneratedTypeAccessibility.Public;
     }
 
     /// <summary>

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/TypeDeclarationExtensions.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/TypeDeclarationExtensions.cs
@@ -25,7 +25,7 @@ public static class TypeDeclarationExtensions
     private const string UseImplicitOperatorStringKey = "CSharp_LanguageProvider_UseImplicitOperatorString";
     private const string AddExplicitUsingsKey = "CSharp_LanguageProvider_AddExplicitUsings";
     private const string DefaultAccessibilityKey = "CSharp_LanguageProvider_DefaultAccessibilityKey";
-    private const string AccessibilityKey = "CSharp_LanguageProvider_DefaultAccessibilityKey";
+    private const string AccessibilityKey = "CSharp_LanguageProvider_AccessibilityKey";
 
     /// <summary>
     /// Sets the relevant metadata from the <see cref="CSharpLanguageProvider.Options"/>.

--- a/Solutions/Corvus.Json.SourceGenerator/Corvus.Json.SourceGenerator.props
+++ b/Solutions/Corvus.Json.SourceGenerator/Corvus.Json.SourceGenerator.props
@@ -5,6 +5,7 @@
         <CompilerVisibleProperty Include="CorvusJsonSchemaUseOptionalNameHeuristics" />
         <CompilerVisibleProperty Include="CorvusJsonSchemaAlwaysAssertFormat" />
         <CompilerVisibleProperty Include="CorvusJsonSchemaDisabledNamingHeuristics" />
+        <CompilerVisibleProperty Include="CorvusJsonSchemaDefaultAccessibility" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/Solutions/Corvus.Json.SourceGeneratorTools/SourceGeneratorHelpers.cs
+++ b/Solutions/Corvus.Json.SourceGeneratorTools/SourceGeneratorHelpers.cs
@@ -93,7 +93,8 @@ public static class SourceGeneratorHelpers
                     new CSharpLanguageProvider.NamedType(
                         rootType.ReducedTypeDeclaration().ReducedType.LocatedSchema.Location,
                         spec.TypeName,
-                        spec.Namespace));
+                        spec.Namespace,
+                        spec.Accessibility));
             }
         }
 
@@ -104,7 +105,8 @@ public static class SourceGeneratorHelpers
             alwaysAssertFormat: typesToGenerate.AlwaysAssertFormat,
             optionalAsNullable: typesToGenerate.OptionalAsNullable,
             disabledNamingHeuristics: [.. typesToGenerate.DisabledNamingHeuristics],
-            fileExtension: ".g.cs");
+            fileExtension: ".g.cs",
+            defaultAccessibility: typesToGenerate.DefaultAccessibility);
 
         var languageProvider = CSharpLanguageProvider.DefaultWithOptions(options);
 
@@ -254,6 +256,11 @@ public static class SourceGeneratorHelpers
         /// Gets a value indicating whether to assert format regardless of the vocabulary.
         /// </summary>
         public bool AlwaysAssertFormat => generationContext.AlwaysAssertFormat;
+
+        /// <summary>
+        /// Gets the default accessibility.
+        /// </summary>
+        public GeneratedTypeAccessibility DefaultAccessibility => generationContext.DefaultAccessibility;
     }
 
     /// <summary>
@@ -263,7 +270,8 @@ public static class SourceGeneratorHelpers
     /// <param name="location">The schema location of the type.</param>
     /// <param name="rebaseToRootPath">Indicates whether to rebase the schema as a document root.</param>
     /// <param name="typeName">The .NET name of the type. If null, the type name will be inferred.</param>
-    public readonly struct GenerationSpecification(string ns, string location, bool rebaseToRootPath, string? typeName = null)
+    /// <param name="accessibility">The accessibility of the type. The default is <see cref="GeneratedTypeAccessibility.Public"/>.</param>
+    public readonly struct GenerationSpecification(string ns, string location, bool rebaseToRootPath, string? typeName = null, GeneratedTypeAccessibility accessibility = GeneratedTypeAccessibility.Public)
     {
         /// <summary>
         /// Gets the .NET name of the type.
@@ -284,6 +292,11 @@ public static class SourceGeneratorHelpers
         /// Gets a value indicating whether to rebase the schema as document root.
         /// </summary>
         public bool RebaseToRootPath { get; } = rebaseToRootPath;
+
+        /// <summary>
+        /// Gets the accessibility for the generated type.
+        /// </summary>
+        public GeneratedTypeAccessibility Accessibility { get; } = accessibility;
     }
 
     /// <summary>
@@ -322,6 +335,11 @@ public static class SourceGeneratorHelpers
         /// Gets a value indicating whether to assert format regardless of the vocabulary.
         /// </summary>
         public bool AlwaysAssertFormat { get; } = globalOptions.AlwaysAssertFormat;
+
+        /// <summary>
+        /// Gets the default accessibility for the generated types.
+        /// </summary>
+        public GeneratedTypeAccessibility DefaultAccessibility { get; } = globalOptions.DefaultAccessibility;
     }
 
     /// <summary>
@@ -332,7 +350,8 @@ public static class SourceGeneratorHelpers
     /// <param name="useOptionalNameHeuristics">Indicates whether optional name heuristics should be used.</param>
     /// <param name="alwaysAssertFormat">Indicates whether to assert format regardless of the vocabulary.</param>
     /// <param name="disabledNamingHeuristics">The names of the disabled naming heuristics.</param>
-    public readonly struct GlobalOptions(IVocabulary fallbackVocabulary, bool optionalAsNullable, bool useOptionalNameHeuristics, bool alwaysAssertFormat, ImmutableArray<string> disabledNamingHeuristics)
+    /// <param name="defaultAccessibility">The default accessibility for generated types. Defaults to <see cref="GeneratedTypeAccessibility.Public"/>.</param>
+    public readonly struct GlobalOptions(IVocabulary fallbackVocabulary, bool optionalAsNullable, bool useOptionalNameHeuristics, bool alwaysAssertFormat, ImmutableArray<string> disabledNamingHeuristics, GeneratedTypeAccessibility defaultAccessibility = GeneratedTypeAccessibility.Public)
     {
         /// <summary>
         /// Gets the global fallback vocabulary. This can be overridden for particular types to generate.
@@ -358,5 +377,10 @@ public static class SourceGeneratorHelpers
         /// Gets a value indicating whether to assert format regardless of the vocabulary.
         /// </summary>
         public bool AlwaysAssertFormat { get; } = alwaysAssertFormat;
+
+        /// <summary>
+        /// Gets the default accessibility for generated types.
+        /// </summary>
+        public GeneratedTypeAccessibility DefaultAccessibility { get; } = defaultAccessibility;
     }
 }

--- a/Solutions/Sandbox.SourceGenerator/Model/FlimFlam.cs
+++ b/Solutions/Sandbox.SourceGenerator/Model/FlimFlam.cs
@@ -2,7 +2,8 @@
 using Corvus.Json;
 
 namespace SourceGenTest2.Model;
+
 [JsonSchemaTypeGenerator("../test.json#/$defs/FlimFlam")]
-public readonly partial struct FlimFlam
+internal readonly partial struct FlimFlam
 {
 }

--- a/Solutions/Sandbox.SourceGenerator/Model/KeyCloak.cs
+++ b/Solutions/Sandbox.SourceGenerator/Model/KeyCloak.cs
@@ -1,8 +1,9 @@
-﻿namespace Repro547;
-
+﻿
 using Corvus.Json;
 
+namespace Repro547;
+
 [JsonSchemaTypeGenerator("./keycloak-realm-26.0.2.json")]
-public readonly partial struct KeyCloak
+internal readonly partial struct KeyCloak
 {
 }

--- a/Solutions/Sandbox.SourceGenerator/Sandbox.SourceGenerator.csproj
+++ b/Solutions/Sandbox.SourceGenerator/Sandbox.SourceGenerator.csproj
@@ -10,6 +10,7 @@
 
   <PropertyGroup>
     <CorvusJsonSchemaOptionalAsNullable>None</CorvusJsonSchemaOptionalAsNullable>
+    <CorvusJsonSchemaDefaultAccessibility>Internal</CorvusJsonSchemaDefaultAccessibility>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Allow the Source Generator to respect the accessibility of the declaring partials.

Supports `public` and `internal`.

Closes #563.