### PR TITLE
Fix TryResolvePointer when traversing object properties against Utf8Bytes

### DIFF
--- a/Solutions/Corvus.Json.JsonReference/Corvus.Json/JsonPointerUtilities.cs
+++ b/Solutions/Corvus.Json.JsonReference/Corvus.Json/JsonPointerUtilities.cs
@@ -418,7 +418,11 @@ public static class JsonPointerUtilities
                         break;
                     }
 
+                    // Read to the property value.
                     reader.Read();
+
+                    // Skip to the next property or EndObject token.
+                    reader.Skip();
                 }
 
                 if (!found)


### PR DESCRIPTION
Added a Skip() to move to the next property.