### PR TITLE
Add implicit operator string support and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,12 @@ Benchmark suites for various components.
 
 The Source Generator which generates types from Json Schema.
 
+## V4.3.10 Updates
+
+Added `<CorvusJsonSchemaUseImplicitOperatorString>true</CorvusJsonSchemaUseImplicitOperatorString>` to enable implicit conversion to `string`.
+
+WARNING: Although this is very convenient for string-heavy code, it may cause unintended allocations if used without care.
+
 ## V4.3.0 Updates
 
 ### Type Accessibility using the Source Generator

--- a/Solutions/Corvus.Json.SourceGenerator/Corvus.Json.SourceGenerator.props
+++ b/Solutions/Corvus.Json.SourceGenerator/Corvus.Json.SourceGenerator.props
@@ -7,6 +7,7 @@
         <CompilerVisibleProperty Include="CorvusJsonSchemaDisabledNamingHeuristics" />
       <CompilerVisibleProperty Include="CorvusJsonSchemaDefaultAccessibility" />
       <CompilerVisibleProperty Include="CorvusJsonSchemaAddExplicitUsings" />
+      <CompilerVisibleProperty Include="CorvusJsonSchemaUseImplicitOperatorString" />
     </ItemGroup>
 
     <PropertyGroup>

--- a/Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
+++ b/Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
@@ -127,7 +127,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
             alwaysAssertFormat: generationSource.AlwaysAssertFormat,
             fileExtension: "_g.cs",
             defaultAccessibility: generationSource.DefaultAccessibility,
-            addExplicitUsings: generationSource.AddExplicitUsings);
+            addExplicitUsings: generationSource.AddExplicitUsings,
+            useImplicitOperatorString: generationSource.UseImplicitOperatorString);
 
         var languageProvider = CSharpLanguageProvider.DefaultWithOptions(options);
 
@@ -217,6 +218,13 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
             addExplicitUsings = addExplicitUsingsName == "true" || addExplicitUsingsName == "True";
         }
 
+        bool useImplicitOperatorString = true;
+
+        if (source.GlobalOptions.TryGetValue("build_property.CorvusJsonSchemaUseImplicitOperatorString", out string? useImplicitOperatorStringName))
+        {
+            useImplicitOperatorString = useImplicitOperatorStringName == "true" || useImplicitOperatorStringName == "True";
+        }
+
         bool useOptionalNameHeuristics = true;
 
         if (source.GlobalOptions.TryGetValue("build_property.CorvusJsonSchemaUseOptionalNameHeuristics", out string? useOptionalNameHeuristicsName))
@@ -255,7 +263,7 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
             disabledNamingHeuristics = disabledNames.Select(d => d.Trim()).ToImmutableArray();
         }
 
-        return new(fallbackVocabulary, optionalAsNullable, useOptionalNameHeuristics, alwaysAssertFormat, disabledNamingHeuristics ?? DefaultDisabledNamingHeuristics, defaultAccessibility, addExplicitUsings);
+        return new(fallbackVocabulary, optionalAsNullable, useOptionalNameHeuristics, alwaysAssertFormat, disabledNamingHeuristics ?? DefaultDisabledNamingHeuristics, defaultAccessibility, addExplicitUsings, useImplicitOperatorString);
     }
 
     private static CompoundDocumentResolver BuildDocumentResolver(ImmutableArray<AdditionalText> source, CancellationToken token)
@@ -392,6 +400,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         public GeneratedTypeAccessibility DefaultAccessibility { get; } = right.DefaultAccessibility;
 
         public bool AddExplicitUsings { get; } = right.AddExplicitUsings;
+
+        public bool UseImplicitOperatorString { get; } = right.UseImplicitOperatorString;
     }
 
     private readonly struct TypesToGenerate(ImmutableArray<GenerationSpecification> left, GenerationContext right)
@@ -413,9 +423,11 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         public GeneratedTypeAccessibility DefaultAccessibility { get; } = right.DefaultAccessibility;
 
         public bool AddExplicitUsings { get; } = right.AddExplicitUsings;
+
+        public bool UseImplicitOperatorString { get; } = right.UseImplicitOperatorString;
     }
 
-    private readonly struct GlobalOptions(IVocabulary fallbackVocabulary, bool optionalAsNullable, bool useOptionalNameHeuristics, bool alwaysAssertFormat, ImmutableArray<string> disabledNamingHeuristics, GeneratedTypeAccessibility defaultAccessibility, bool addExplicitUsings)
+    private readonly struct GlobalOptions(IVocabulary fallbackVocabulary, bool optionalAsNullable, bool useOptionalNameHeuristics, bool alwaysAssertFormat, ImmutableArray<string> disabledNamingHeuristics, GeneratedTypeAccessibility defaultAccessibility, bool addExplicitUsings, bool useImplicitOperatorString)
     {
         public IVocabulary FallbackVocabulary { get; } = fallbackVocabulary;
 
@@ -430,5 +442,7 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         public GeneratedTypeAccessibility DefaultAccessibility { get; } = defaultAccessibility;
 
         public bool AddExplicitUsings { get; } = addExplicitUsings;
+
+        public bool UseImplicitOperatorString { get; } = useImplicitOperatorString;
     }
 }

--- a/Solutions/Sandbox.SourceGenerator/Sandbox.SourceGenerator.csproj
+++ b/Solutions/Sandbox.SourceGenerator/Sandbox.SourceGenerator.csproj
@@ -12,6 +12,7 @@
     <CorvusJsonSchemaOptionalAsNullable>None</CorvusJsonSchemaOptionalAsNullable>
     <CorvusJsonSchemaDefaultAccessibility>Internal</CorvusJsonSchemaDefaultAccessibility>
     <CorvusJsonSchemaAddExplicitUsings>True</CorvusJsonSchemaAddExplicitUsings>
+    <CorvusJsonSchemaUseImplicitOperatorString>True</CorvusJsonSchemaUseImplicitOperatorString>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Solutions/Sandbox.SourceGenerator/test.json
+++ b/Solutions/Sandbox.SourceGenerator/test.json
@@ -16,7 +16,7 @@
                     "format": "int32",
                     "minimum": 0
                 },
-                { "type": "string" },
+                { "type": "string", "minLength": 0 },
                 {
                     "type": "number",
                     "minimum": 3.5


### PR DESCRIPTION
- Added `CorvusJsonSchemaUseImplicitOperatorString` property in Corvus.Json.SourceGenerator.props.
- Implemented logic to read the `CorvusJsonSchemaUseImplicitOperatorString` from global options for build-time configuration.
- Enhanced `IncrementalSourceGenerator` to support the new `useImplicitOperatorString` parameter in method calls and constructors.

Closes #627 