### PR TITLE
Fix bug - `System` is missing from reserved words.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/Formatting.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/Formatting.cs
@@ -106,6 +106,7 @@ public static class Formatting
         "SchemaLocation",
         "SetProperty",
         "Stream",
+        "System",
         "ToString",
         "TryCreateUriTemplateParser",
         "TryGetBoolean",

--- a/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft202012/collisionWithBuiltInName.feature
+++ b/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft202012/collisionWithBuiltInName.feature
@@ -2,7 +2,7 @@
 
 Feature: Collision with a built-in name draft2020-12
 
-Scenario Outline: An property that matches a built-in name
+Scenario Outline: A property that matches a built-in name
 	Given a schema file
 		"""
 		{
@@ -25,3 +25,33 @@ Examples:
 	| inputData         | valid |
 	| {"match": "foo" } | true  |
 	| {"match": "f" }   | false |
+
+
+Scenario Outline: Repro 625 - collides with System
+	Given a schema file
+		"""
+		{
+		  "type": "object",
+		  "properties": {
+			"system": {
+			  "type": "string",
+			  "minLength": 0
+			},
+			"someOtherProp": {
+			  "type": "string",
+			  "minLength": 0
+			}
+		  },
+		  "required": ["system", "someOtherProp"]
+		}
+		"""
+	And the input data value <inputData>
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance
+	Then the result will be <valid>
+
+Examples:
+	| inputData                                  | valid |
+	| {"system": "foo", "someOtherProp": "bar" } | true  |
+	| {"someOtherProp": "bar"  }                 | false |


### PR DESCRIPTION
- Added "Repro 625 - collides with System" scenario for testing collisions with the "System" namespace and a "system" property.

Closes #625.