### PR TITLE
Disambiguate `IsXXX` and `AsXXX` where naming collisions occur.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Text.Json;
 using System.Web;
@@ -1876,8 +1877,13 @@ internal static partial class CodeGeneratorExtensions
 
         HashSet<string> visitedTypes = [];
 
+        int index = 0;
+
+        HashSet<string> usedPropertyNames = new();
+
         foreach (TypeDeclaration t in rootDeclaration.CompositionTypeDeclarations())
         {
+            ++index;
             if (generator.IsCancellationRequested)
             {
                 return generator;
@@ -1889,7 +1895,52 @@ internal static partial class CodeGeneratorExtensions
             }
 
             string propertyNameAs = generator.GetPropertyNameInScope("As", suffix: t.DotnetTypeName());
+            string currentPropertyName = propertyNameAs;
+
+            int pnIndex = 0;
+            while (usedPropertyNames.Contains(currentPropertyName))
+            {
+                if (pnIndex == 0)
+                {
+                    currentPropertyName = generator.GetPropertyNameInScope("As", suffix: t.DotnetTypeNameWithoutNamespace());
+
+                    // Create the new base name
+                    propertyNameAs = currentPropertyName;
+                }
+                else
+                {
+                    currentPropertyName = generator.GetPropertyNameInScope(propertyNameAs, suffix: pnIndex.ToString());
+                }
+
+                pnIndex++;
+            }
+
+            propertyNameAs = currentPropertyName;
+            usedPropertyNames.Add(propertyNameAs);
+
             string propertyNameIs = generator.GetPropertyNameInScope("Is", suffix: t.DotnetTypeName());
+            currentPropertyName = propertyNameIs;
+
+            pnIndex = 0;
+            while (usedPropertyNames.Contains(currentPropertyName))
+            {
+                if (pnIndex == 0)
+                {
+                    currentPropertyName = generator.GetPropertyNameInScope("Is", suffix: t.DotnetTypeNameWithoutNamespace());
+
+                    // Create the new base name
+                    propertyNameIs = currentPropertyName;
+                }
+                else
+                {
+                    currentPropertyName = generator.GetPropertyNameInScope(propertyNameIs, suffix: pnIndex.ToString());
+                }
+
+                pnIndex++;
+            }
+
+            propertyNameIs = currentPropertyName;
+            usedPropertyNames.Add(propertyNameIs);
 
             generator
                 .AppendSeparatorLine()

--- a/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft7/Repro620NestedAnyOf.feature
+++ b/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft7/Repro620NestedAnyOf.feature
@@ -1,0 +1,68 @@
+@draft7
+
+Feature: Repro620 Nested anyOf draft7
+
+Scenario Outline: Repro 620 - names collide in Is and As Matchers
+	Given a schema file
+		"""
+		{
+			"$schema": "http://json-schema.org/draft-07/schema",
+			"type": "object",
+			"anyOf": [
+				{
+					"type": "object",
+					"required": [
+						"kind",
+						"data"
+					],
+					"additionalProperties": false,
+					"properties": {
+						"kind": {
+							"const": "foo"
+						},
+						"data": {
+							"anyOf": [
+								{
+									"type": "object",
+									"required": [
+										"kind"
+									],
+									"additionalProperties": false,
+									"properties": {
+										"kind": {
+											"const": "bar"
+										}
+									}
+								},
+								{
+									"type": "object",
+									"required": [
+										"kind"
+									],
+									"additionalProperties": false,
+									"properties": {
+										"kind": {
+											"const": "baz"
+										}
+									}
+								}
+							]
+						}
+					}
+				},
+				{
+					"$ref": "#/anyOf/0/properties/data/anyOf/0"
+				}
+			]
+		}
+		"""
+	And the input data value <inputData>
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance
+	Then the result will be <valid>
+
+Examples:
+	| inputData                                | valid |
+	| {"kind": "foo", "data": {"kind": "bar"} } | true  |
+	| {"kind": "foo", "data": {"kind": "bat"} } | false |

--- a/Solutions/Sandbox.SourceGenerator/Model/Test2.cs
+++ b/Solutions/Sandbox.SourceGenerator/Model/Test2.cs
@@ -1,0 +1,9 @@
+﻿
+using Corvus.Json;
+
+namespace SourceGenTest2.Model;
+
+[JsonSchemaTypeGenerator("../test2.json")]
+internal readonly partial struct Test2
+{
+}

--- a/Solutions/Sandbox.SourceGenerator/Sandbox.SourceGenerator.csproj
+++ b/Solutions/Sandbox.SourceGenerator/Sandbox.SourceGenerator.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <None Remove="Model\keycloak-realm-26.0.2.json" />
+    <None Remove="test2.json" />
   </ItemGroup>
 
   <ItemGroup>
@@ -27,6 +28,7 @@
   <ItemGroup>
     <AdditionalFiles Include="Model\keycloak-realm-26.0.2.json" />
     <AdditionalFiles Include="test.json" />
+    <AdditionalFiles Include="test2.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Solutions/Sandbox.SourceGenerator/test2.json
+++ b/Solutions/Sandbox.SourceGenerator/test2.json
@@ -1,0 +1,50 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema",
+    "type": "object",
+    "anyOf": [
+        {
+            "type": "object",
+            "required": [
+                "kind",
+                "data"
+            ],
+            "additionalProperties": false,
+            "properties": {
+                "kind": {
+                    "const": "foo"
+                },
+                "data": {
+                    "anyOf": [
+                        {
+                            "type": "object",
+                            "required": [
+                                "kind"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "kind": {
+                                    "const": "bar"
+                                }
+                            }
+                        },
+                        {
+                            "type": "object",
+                            "required": [
+                                "kind"
+                            ],
+                            "additionalProperties": false,
+                            "properties": {
+                                "kind": {
+                                    "const": "baz"
+                                }
+                            }
+                        }
+                    ]
+                }
+            }
+        },
+        {
+            "$ref": "#/anyOf/0/properties/data/anyOf/0"
+        }
+    ]
+}


### PR DESCRIPTION
Fixes #620