### PR TITLE
Fix code gen when requiring a property declared in a composed schema.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Object.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.Object.cs
@@ -785,7 +785,7 @@ internal static partial class CodeGeneratorExtensions
             return
             [
                 .. typeDeclaration.PropertyDeclarations
-                            .Where(p => p.RequiredOrOptional == RequiredOrOptional.Required &&
+                            .Where(p => p.RequiredOrOptional != RequiredOrOptional.Optional &&
                                    p.ReducedPropertyType.SingleConstantValue().ValueKind == JsonValueKind.Undefined)
                             .OrderBy(p => p.JsonPropertyName)
                             .Select(p => new MethodParameter("in", p.ReducedPropertyType.FullyQualifiedDotnetTypeName(), generator.GetUniqueParameterNameInScope(p.JsonPropertyName, childScope: "Create"))),
@@ -809,7 +809,7 @@ internal static partial class CodeGeneratorExtensions
             return
             [
                 .. typeDeclaration.PropertyDeclarations
-                                            .Where(p => p.RequiredOrOptional == RequiredOrOptional.Required)
+                                            .Where(p => p.RequiredOrOptional != RequiredOrOptional.Optional)
                                             .OrderBy(p => p.JsonPropertyName),
                 .. typeDeclaration.PropertyDeclarations
                                             .Where(p => p.RequiredOrOptional == RequiredOrOptional.Optional)
@@ -838,7 +838,7 @@ internal static partial class CodeGeneratorExtensions
                     return generator;
                 }
 
-                if (property.RequiredOrOptional == RequiredOrOptional.Required)
+                if (property.RequiredOrOptional != RequiredOrOptional.Optional)
                 {
                     parameterIndex = AddRequiredProperty(generator, parameters, parameterIndex, property, builderName);
                 }

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/NameHeuristics/RequiredPropertyNameHeuristic.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/NameHeuristics/RequiredPropertyNameHeuristic.cs
@@ -42,7 +42,7 @@ public sealed class RequiredPropertyNameHeuristic : INameHeuristicBeforeSubschem
         foreach (PropertyDeclaration property in
                     typeDeclaration.PropertyDeclarations
                         .Where(p =>
-                            p.RequiredOrOptional == RequiredOrOptional.Required))
+                            p.RequiredOrOptional != RequiredOrOptional.Optional))
         {
             if (count > 3)
             {

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PropertyCountValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PropertyCountValidationHandler.cs
@@ -116,7 +116,7 @@ public class PropertyCountValidationHandler : IChildArrayItemValidationHandler
             }
 
             generator
-                .Append("array of length {propertyCount} ")
+                .Append("property count {propertyCount} ")
                 .AppendTextForInverseOperator(op)
                 .Append(" {")
                 .Append(memberName)

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/RequiredKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/RequiredKeyword.cs
@@ -58,7 +58,7 @@ public sealed class RequiredKeyword : IPropertyProviderKeyword, IObjectRequiredP
                         target,
                         Uri.UnescapeDataString(propertyName),
                         WellKnownTypeDeclarations.JsonAny,
-                        treatRequiredAsOptional ? RequiredOrOptional.Optional : RequiredOrOptional.Required,
+                        treatRequiredAsOptional ? RequiredOrOptional.Optional : source == target ? RequiredOrOptional.Required : RequiredOrOptional.ComposedRequired,
                         source == target ? LocalOrComposed.Local : LocalOrComposed.Composed,
                         this,
                         this));

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/PropertyProvider/RequiredOrOptional.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/PropertyProvider/RequiredOrOptional.cs
@@ -15,6 +15,11 @@ public enum RequiredOrOptional
     Required,
 
     /// <summary>
+    /// The property is required by composition.
+    /// </summary>
+    ComposedRequired,
+
+    /// <summary>
     /// The property is optional.
     /// </summary>
     Optional,

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/TypeDeclarations/TypeDeclaration.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/TypeDeclarations/TypeDeclaration.cs
@@ -138,7 +138,7 @@ public sealed class TypeDeclaration(LocatedSchema locatedSchema)
                     MergeRequiredOrOptional(propertyDeclaration, existingProperty),
                     propertyDeclaration.LocalOrComposed,
                     propertyDeclaration.Keyword ?? existingProperty.Keyword,
-                    propertyDeclaration.RequiredKeyword ?? existingProperty.RequiredKeyword);
+                    existingProperty.RequiredKeyword ?? propertyDeclaration.RequiredKeyword);
         }
         else if (propertyDeclaration.Owner != this)
         {
@@ -147,7 +147,7 @@ public sealed class TypeDeclaration(LocatedSchema locatedSchema)
                     this,
                     propertyDeclaration.JsonPropertyName,
                     propertyDeclaration.UnreducedPropertyType,
-                    propertyDeclaration.RequiredOrOptional,
+                    propertyDeclaration.RequiredOrOptional == RequiredOrOptional.Required ? RequiredOrOptional.ComposedRequired : propertyDeclaration.RequiredOrOptional,
                     LocalOrComposed.Composed,
                     propertyDeclaration.Keyword,
                     propertyDeclaration.RequiredKeyword);
@@ -159,13 +159,17 @@ public sealed class TypeDeclaration(LocatedSchema locatedSchema)
 
         static RequiredOrOptional MergeRequiredOrOptional(PropertyDeclaration propertyDeclaration, PropertyDeclaration existingProperty)
         {
-            if (propertyDeclaration.RequiredOrOptional == RequiredOrOptional.Required ||
-                existingProperty.RequiredOrOptional == RequiredOrOptional.Required)
+            if (existingProperty.RequiredOrOptional == RequiredOrOptional.Required)
             {
                 return RequiredOrOptional.Required;
             }
 
-            return RequiredOrOptional.Optional;
+            if (propertyDeclaration.RequiredOrOptional is RequiredOrOptional.Required or RequiredOrOptional.ComposedRequired)
+            {
+                return RequiredOrOptional.ComposedRequired;
+            }
+
+            return existingProperty.RequiredOrOptional;
         }
     }
 

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/TypeDeclarations/TypeDeclarationExtensions.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/TypeDeclarations/TypeDeclarationExtensions.cs
@@ -1007,8 +1007,8 @@ public static class TypeDeclarationExtensions
         {
             propertyTypes =
                 that.PropertyDeclarations.Where(
-                    p => p.LocalOrComposed == LocalOrComposed.Local &&
-                    p.RequiredOrOptional == RequiredOrOptional.Required).ToList();
+                    p =>
+                        p.RequiredOrOptional == RequiredOrOptional.Required).ToList();
 
             that.SetMetadata(nameof(ExplicitRequiredProperties), propertyTypes);
         }
@@ -1028,7 +1028,7 @@ public static class TypeDeclarationExtensions
         {
             propertyTypes =
                 that.PropertyDeclarations.Where(
-                    p => p.LocalOrComposed == LocalOrComposed.Local).ToList();
+                    p => p.LocalOrComposed == LocalOrComposed.Local || p.RequiredOrOptional == RequiredOrOptional.Required).ToList();
 
             that.SetMetadata(nameof(ExplicitProperties), propertyTypes);
         }

--- a/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft202012/Repro633.feature
+++ b/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft202012/Repro633.feature
@@ -1,0 +1,155 @@
+@draft202012
+@
+
+Feature: Repro 633 draft202012
+
+Scenario Outline: Validate required property defined in reference
+	Given a schema file
+		"""
+		{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"$ref": "#/$defs/ifThisThenThat",
+			"required": [
+				"match"
+			],
+			"maxProperties": 1,
+			"$defs": {
+				"ifThisThenThat": {
+					"type": "object",
+					"properties": {
+						"match": {
+							"type": "string"
+						}
+					},
+					"unevaluatedProperties": {
+						"type": "number"
+					}
+				}
+			}
+		}
+		"""
+	And the input data value <inputData>
+	And I assert format
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance with level Detailed
+	Then the result will be <valid>
+
+Examples:
+	| inputData        | valid |
+	| {"match": "foo"} | true  |
+	| {}               | false |
+
+
+Scenario Outline: Validate required property required in reference
+	Given a schema file
+		"""
+		{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"$ref": "#/$defs/ifThisThenThat",
+			"maxProperties": 1,
+			"$defs": {
+				"ifThisThenThat": {
+					"type": "object",
+					"required": [
+						"match"
+					],
+					"properties": {
+						"match": {
+							"type": "string"
+						}
+					},
+					"unevaluatedProperties": {
+						"type": "number"
+					}
+				}
+			}
+		}
+		"""
+	And the input data value <inputData>
+	And I assert format
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance with level Detailed
+	Then the result will be <valid>
+
+Examples:
+	| inputData        | valid |
+	| {"match": "foo"} | true  |
+	| {}               | false |
+
+
+Scenario Outline: Validate overrides
+	Given a schema file
+		"""
+		{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"$ref": "#/$defs/ifThisThenThat",
+			"properties": {
+				"match": {
+					"minimum": 3
+				}
+			},
+			"$defs": {
+				"ifThisThenThat": {
+					"type": "object",
+					"properties": {
+						"match": {
+							"minimum": 2
+						}
+					}
+				}
+			}
+		}
+		"""
+	And the input data value <inputData>
+	And I assert format
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance with level Detailed
+	Then the result will be <valid>
+
+Examples:
+	| inputData     | valid |
+	| {"match": 3 } | true  |
+	| {"match": 2 } | false |
+
+
+Scenario Outline: Validate reverse overrides
+	Given a schema file
+		"""
+		{
+			"$schema": "https://json-schema.org/draft/2020-12/schema",
+			"type": "object",
+			"$ref": "#/$defs/ifThisThenThat",
+			"properties": {
+				"match": {
+					"minimum": 2
+				}
+			},
+			"$defs": {
+				"ifThisThenThat": {
+					"type": "object",
+					"properties": {
+						"match": {
+							"minimum": 3
+						}
+					}
+				}
+			}
+		}
+		"""
+	And the input data value <inputData>
+	And I assert format
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance with level Detailed
+	Then the result will be <valid>
+
+Examples:
+	| inputData     | valid |
+	| {"match": 3 } | true  |
+	| {"match": 2 } | false |


### PR DESCRIPTION
Added specs to reproduce the problem.

Added discrimination between Composed 'type' information and Composed 'required' information for a property.

Fixed typo in error message for max properties validation.

Fixes #633.