### PR TITLE
Update IncrementalSourceGenerator.cs

### DIFF
--- a/Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
+++ b/Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
@@ -200,6 +200,7 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
                 "Draft6" => CodeGeneration.Draft6.VocabularyAnalyser.DefaultVocabulary,
                 "Draft4" => CodeGeneration.Draft4.VocabularyAnalyser.DefaultVocabulary,
                 "OpenApi30" => CodeGeneration.OpenApi30.VocabularyAnalyser.DefaultVocabulary,
+                "OpenApi31" -> CodeGeneration.OpenApi31.VocabularyAnalyser.DefaultVocabulary,
                 _ => CodeGeneration.Draft202012.VocabularyAnalyser.DefaultVocabulary,
             };
         }
@@ -316,6 +317,7 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         CodeGeneration.Draft6.VocabularyAnalyser.RegisterAnalyser(vocabularyRegistry);
         CodeGeneration.Draft4.VocabularyAnalyser.RegisterAnalyser(vocabularyRegistry);
         CodeGeneration.OpenApi30.VocabularyAnalyser.RegisterAnalyser(vocabularyRegistry);
+        CodeGeneration.OpenApi31.VocabularyAnalyser.RegisterAnalyser(vocabularyRegistry);
 
         // And register the custom vocabulary for Corvus extensions.
         vocabularyRegistry.RegisterVocabularies(


### PR DESCRIPTION
This pull request updates the `IncrementalSourceGenerator` in the `Corvus.Json.SourceGenerator` project to add support for OpenAPI 3.1. The changes involve integrating the OpenAPI 3.1 vocabulary into the vocabulary selection and registration processes.

### OpenAPI 3.1 Support:

* Added OpenAPI 3.1 vocabulary to the global options for vocabulary selection in the `GetGlobalOptions` method. (`Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs`, [Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.csR203](diffhunk://#diff-7eba3fb0b329e86b8242a0efa59443bd45ba13df775ab43da099c634ccad4b7cR203))
* Registered the OpenAPI 3.1 vocabulary analyser in the `RegisterVocabularies` method. (`Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs`, [Solutions/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.csR320](diffhunk://#diff-7eba3fb0b329e86b8242a0efa59443bd45ba13df775ab43da099c634ccad4b7cR320))