### PR TITLE
Added netstandard2.1 packages to support Unity builds.

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,10 @@ Benchmark suites for various components.
 
 The Source Generator which generates types from Json Schema.
 
+## V4.3.17 Updates
+
+Added netstandard2.1 packages for `Corvus.Json.ExtendedTypes` and `Corvus.Json.JsonReference` in order to support Unity builds.
+
 ## V4.3.16 Updates
 
 ### Use of IndexRange package is deprecated.

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json.ExtendedTypes.csproj
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json.ExtendedTypes.csproj
@@ -2,7 +2,7 @@
 	<Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
 	<PropertyGroup>
-		<TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+		<TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
 		<ImplicitUsings>enable</ImplicitUsings>
 		<Nullable>enable</Nullable>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedCoreTypes/JsonIpV4.String.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedCoreTypes/JsonIpV4.String.cs
@@ -509,7 +509,7 @@ public readonly partial struct JsonIpV4
 #else
         if (this.jsonElementBacking.ValueKind == JsonValueKind.String)
         {
-            return StandardIPAddress.IPAddressParser(this.jsonElementBacking.GetString(), null, out result);
+            return StandardIPAddress.IPAddressParser(this.jsonElementBacking.GetString()!, null, out result);
         }
 #endif
 

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedCoreTypes/JsonIpV6.String.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedCoreTypes/JsonIpV6.String.cs
@@ -509,7 +509,7 @@ public readonly partial struct JsonIpV6
 #else
         if (this.jsonElementBacking.ValueKind == JsonValueKind.String)
         {
-            return StandardIPAddress.IPAddressParser(this.jsonElementBacking.GetString(), null, out result);
+            return StandardIPAddress.IPAddressParser(this.jsonElementBacking.GetString()!, null, out result);
         }
 #endif
 

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedCoreTypes/JsonUuid.String.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/GeneratedCoreTypes/JsonUuid.String.cs
@@ -509,7 +509,7 @@ public readonly partial struct JsonUuid
 #else
         if (this.jsonElementBacking.ValueKind == JsonValueKind.String)
         {
-            return StandardUuid.GuidParser(this.jsonElementBacking.GetString(), null, out result);
+            return StandardUuid.GuidParser(this.jsonElementBacking.GetString()!, null, out result);
         }
 #endif
 

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/JsonValueHelpers.Hashcode.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Internal/JsonValueHelpers.Hashcode.cs
@@ -139,7 +139,7 @@ public static partial class JsonValueHelpers
             return true;
         }
 #else
-        return value.GetString().GetHashCode();
+        return value.GetString()?.GetHashCode() ?? 0;
 #endif
     }
 

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonPropertyName.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/JsonPropertyName.cs
@@ -561,7 +561,7 @@ public readonly struct JsonPropertyName
 
             throw new InvalidOperationException();
 #else
-            return this.jsonElementBacking.GetString().GetHashCode();
+            return this.jsonElementBacking.GetString()?.GetHashCode() ?? 0;
 #endif
         }
 

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Validate.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/Validate.cs
@@ -3925,7 +3925,7 @@ public static partial class Validate
 #if NET8_0_OR_GREATER
         instance.AsString.TryGetValue(IpV6Validator, new ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
 #else
-        IpV6Validator(instance.AsString.GetString(), new ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
+        IpV6Validator(instance.AsString.GetString()!, new ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
 #endif
 
         if (level == ValidationLevel.Flag && !result.IsValid)
@@ -4018,7 +4018,7 @@ public static partial class Validate
 #if NET8_0_OR_GREATER
         instance.AsString.TryGetValue(IpV4Validator, new ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
 #else
-        IpV4Validator(instance.AsString.GetString(), new ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
+        IpV4Validator(instance.AsString.GetString()!, new ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
 #endif
         if (level == ValidationLevel.Flag && !result.IsValid)
         {

--- a/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/ValidateWithoutCoreType.cs
+++ b/Solutions/Corvus.Json.ExtendedTypes/Corvus.Json/ValidateWithoutCoreType.cs
@@ -1933,7 +1933,7 @@ public static partial class ValidateWithoutCoreType
 #if NET8_0_OR_GREATER
         instance.AsString.TryGetValue(IpV6Validator, new Validate.ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
 #else
-        IpV6Validator(instance.AsString.GetString(), new Validate.ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
+        IpV6Validator(instance.AsString.GetString()!, new Validate.ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
 #endif
 
         if (level == ValidationLevel.Flag && !result.IsValid)
@@ -2002,7 +2002,7 @@ public static partial class ValidateWithoutCoreType
 #if NET8_0_OR_GREATER
         instance.AsString.TryGetValue(IpV4Validator, new Validate.ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
 #else
-        IpV4Validator(instance.AsString.GetString(), new Validate.ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
+        IpV4Validator(instance.AsString.GetString()!, new Validate.ValidationContextWrapperWithFormatKeyword(result, level, formatKeyword), out result);
 #endif
         if (level == ValidationLevel.Flag && !result.IsValid)
         {

--- a/Solutions/Corvus.Json.JsonReference/Corvus.Json.JsonReference.csproj
+++ b/Solutions/Corvus.Json.JsonReference/Corvus.Json.JsonReference.csproj
@@ -2,7 +2,7 @@
   <Import Project="$(EndjinProjectPropsPath)" Condition="$(EndjinProjectPropsPath) != ''" />
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net8.0</TargetFrameworks>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>

--- a/Solutions/Corvus.JsonSchema.sln
+++ b/Solutions/Corvus.JsonSchema.sln
@@ -95,6 +95,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".Sandboxes", ".Sandboxes", 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Corvus.Json.CodeGeneration.OpenApi31", "Corvus.Json.CodeGeneration.OpenApi31\Corvus.Json.CodeGeneration.OpenApi31.csproj", "{589ED819-DE6C-ABF5-07DC-FCF11D666FCF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Sandbox.NetStandard21", "Sandbox.NetStandard21\Sandbox.NetStandard21.csproj", "{E7D530C9-462A-46DA-BCEB-54A249C975B8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -241,6 +243,10 @@ Global
 		{589ED819-DE6C-ABF5-07DC-FCF11D666FCF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{589ED819-DE6C-ABF5-07DC-FCF11D666FCF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{589ED819-DE6C-ABF5-07DC-FCF11D666FCF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{E7D530C9-462A-46DA-BCEB-54A249C975B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E7D530C9-462A-46DA-BCEB-54A249C975B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E7D530C9-462A-46DA-BCEB-54A249C975B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E7D530C9-462A-46DA-BCEB-54A249C975B8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -282,6 +288,7 @@ Global
 		{F6E781FA-DAEF-4E55-B7AA-C6B650B61680} = {02EA681E-C7D8-13C7-8484-4AC65E1B71E8}
 		{907DC949-3413-4A70-AC7F-D7307DF1440A} = {D2E9E1BB-9ADE-4A9F-945E-5DCAEA860E80}
 		{589ED819-DE6C-ABF5-07DC-FCF11D666FCF} = {30D98060-7807-46E1-BC51-A0712820DF66}
+		{E7D530C9-462A-46DA-BCEB-54A249C975B8} = {4AEFC523-70EA-4ACC-A424-F8FF8D4F285A}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {A9FB3137-5BE5-44D0-86AC-4BC1DA4BA066}

--- a/Solutions/Sandbox.NetStandard21/Class1.cs
+++ b/Solutions/Sandbox.NetStandard21/Class1.cs
@@ -1,0 +1,13 @@
+﻿using System.Diagnostics.CodeAnalysis;
+
+namespace CorvusLibrary
+{
+    // This project exists to validate that a pure netstandard2.1 library can be built.
+    public class Class1
+    {
+        public static bool IsValidInput([NotNullWhen(true)] string? input)
+        {
+            return !string.IsNullOrWhiteSpace(input);
+        }
+    }
+}

--- a/Solutions/Sandbox.NetStandard21/Sandbox.NetStandard21.csproj
+++ b/Solutions/Sandbox.NetStandard21/Sandbox.NetStandard21.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>netstandard2.1</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Corvus.Json.ExtendedTypes\Corvus.Json.ExtendedTypes.csproj" />
+  </ItemGroup>
+
+</Project>


### PR DESCRIPTION
Added netstandard2.1 build of Corvus.Json.ExtendedTypes and Corvus.Json.JsonReference to support Unity.
Included an example Sandbox project to illustrate that it can build in a netstandard2.1 project.
Closes #648.