### PR TITLE
Fix index handling

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/NameHeuristics/SingleTypeArrayNameHeuristic.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/NameHeuristics/SingleTypeArrayNameHeuristic.cs
@@ -65,7 +65,7 @@ public sealed class SingleTypeArrayNameHeuristic : INameHeuristicAfterSubschema
             nameWithoutArraySuffix.CopyTo(typeNameBuffer);
             int written = nameWithoutArraySuffix.Length;
             itemsNameSpan.CopyTo(typeNameBuffer[written..]);
-            written = itemsNameSpan.Length;
+            written += itemsNameSpan.Length;
             written += Formatting.ApplyArraySuffix(typeNameBuffer[written..]);
             return written;
         }


### PR DESCRIPTION
Fix https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/663

New output:
```
Completed in: 0.2507679s

Generating JSON types
Building type declarations for
C:\z\Response.schema.json
Generating code for schema.
Writing files
Response.cs (#/definitions/Response)
Response.Object.cs (#/definitions/Response)
Response.Validate.cs (#/definitions/Response)
Response.JsonNumberArray.cs (#/definitions/Response/properties/final_aaaa_d)
Response.JsonNumberArray.Array.cs (#/definitions/Response/properties/final_aaaa_d)
Response.JsonNumberArray.Validate.cs (#/definitions/Response/properties/final_aaaa_d)
Response.InitialAaaaAJsonNumberArray.cs (#/definitions/Response/properties/initial_aaaa_a)
Response.InitialAaaaAJsonNumberArray.Array.cs (#/definitions/Response/properties/initial_aaaa_a)
Response.InitialAaaaAJsonNumberArray.Validate.cs (#/definitions/Response/properties/initial_aaaa_a)
Response.InitialAaaaBJsonNumberArray.cs (#/definitions/Response/properties/initial_aaaa_b)
Response.InitialAaaaBJsonNumberArray.Array.cs (#/definitions/Response/properties/initial_aaaa_b)
Response.InitialAaaaBJsonNumberArray.Validate.cs (#/definitions/Response/properties/initial_aaaa_b)
Response.InitialAaaaCJsonNumberArray.cs (#/definitions/Response/properties/initial_aaaa_c)
Response.InitialAaaaCJsonNumberArray.Array.cs (#/definitions/Response/properties/initial_aaaa_c)
Response.InitialAaaaCJsonNumberArray.Validate.cs (#/definitions/Response/properties/initial_aaaa_c)
````