### PR TITLE
Avoid extra dependencies that might conflict with MS.CA

### DIFF
--- a/Solutions/Corvus.Json.SourceGenerator/Corvus.Json.SourceGenerator.csproj
+++ b/Solutions/Corvus.Json.SourceGenerator/Corvus.Json.SourceGenerator.csproj
@@ -76,7 +76,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Text.Json" Version="9.0.0" PrivateAssets="all" GeneratePathProperty="true" />
+		<!-- System.Text.Json 8.x has a dependency on Microsoft.Bcl.AsyncInterfaces 8.0.0 -->
+		<!-- System.Text.Json 9.x has a dependency on Microsoft.Bcl.AsyncInterfaces 9.0.0 -->
+		<!-- Roslyn 4.10 has a dependency on AsyncInterfaces 8.0.0: https://github.com/dotnet/roslyn/blob/3bdcd8b471bef9a522c16a0ada911eb9890b1a6c/eng/Versions.props#L39 -->
+		<!-- So, stick with 8.x of STJ. -->
+		<PackageReference Include="System.Text.Json" Version="8.0.6" PrivateAssets="all" GeneratePathProperty="true" />
+
     <PackageReference Include="Microsoft.Bcl.HashCode" Version="1.1.1" PrivateAssets="all" GeneratePathProperty="true" />
   </ItemGroup>
 
@@ -87,7 +92,6 @@
   <Target Name="GetDependencyTargetPaths">
     <ItemGroup>
       <TargetPathWithTargetPlatformMoniker Include="$(PKGSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" IncludeRuntimeDependency="false" />
-			<TargetPathWithTargetPlatformMoniker Include="$(PKGSystem_IO_Pipelines)\lib\netstandard2.0\System.IO.Pipelines.dll" IncludeRuntimeDependency="false" />
       <TargetPathWithTargetPlatformMoniker Include="$(PKGMicrosoft_Bcl_HashCode)\lib\netstandard2.0\Microsoft.Bcl.HashCode.dll" IncludeRuntimeDependency="false" />
     </ItemGroup>
   </Target>
@@ -127,7 +131,6 @@
     <!-- Package the generator in the analyzer directory of the nuget package -->
     <None Include="$(OutputPath)\$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 		<None Include="$(PKGSystem_Text_Json)\lib\netstandard2.0\System.Text.Json.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
-		<None Include="$(PKGSystem_IO_Pipelines)\lib\netstandard2.0\System.IO.Pipelines.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
 		<None Include="$(PKGMicrosoft_Bcl_HashCode)\lib\netstandard2.0\Microsoft.Bcl.HashCode.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <!-- Package the props file -->
     <None Include="Corvus.Json.SourceGenerator.props" Pack="true" PackagePath="build" Visible="false" />


### PR DESCRIPTION
It's not a good idea to ship that many dlls in the NuGet package when they are mostly unnecessary, as that could conflict with dependencies that Microsoft.CodeAnalysis has and cause failures in the consuming projects.

Also, I downgraded MS.CA to 3.10 which is shipped in .NET 8 (which is still in support).