### PR TITLE
Fix generated SchemaLocation constants on Linux/macOS

### DIFF
--- a/Solutions/Corvus.Json.Specs/Features/JsonReferenceMakeRelative.feature
+++ b/Solutions/Corvus.Json.Specs/Features/JsonReferenceMakeRelative.feature
@@ -1,0 +1,54 @@
+Feature: JsonReference MakeRelative
+	In order to generate correct relative schema locations on all platforms
+	As a developer
+	I want to support making relative references from absolute references
+
+Scenario Outline: Make relative references from absolute URIs
+	When I make "<target>" relative to the base reference "<base>"
+	Then the relative reference will be "<relative>"
+
+	Examples:
+		| base                                         | target                                                   | relative                   |
+		| https://endjin.com/home/user/test.json       | https://endjin.com/home/user/test.json                   |                            |
+		| https://endjin.com/home/user/test.json       | https://endjin.com/home/user/test.json#/$defs/TestType   | #/$defs/TestType           |
+		| https://endjin.com/home/user/test.json       | https://endjin.com/home/user/other.json                  | other.json                 |
+		| https://endjin.com/home/user/test.json       | https://endjin.com/home/user/other.json#/$defs/TestType  | other.json#/$defs/TestType |
+		| https://endjin.com/home/user/test.json       | https://endjin.com/home/other/file.json                  | ../other/file.json         |
+		| https://endjin.com/schema.json               | https://endjin.com/schema.json#/$defs/Type               | #/$defs/Type               |
+		| https://endjin.com/path/to/schema.json       | https://endjin.com/path/to/schema.json#/properties/name  | #/properties/name          |
+
+Scenario Outline: Make relative references from implicit file paths (Windows-style)
+	When I make "<target>" relative to the base reference "<base>"
+	Then the relative reference will be "<relative>"
+
+	Examples:
+		| base                           | target                                       | relative                   |
+		| C:/Users/test/schema.json      | C:/Users/test/schema.json                    |                            |
+		| C:/Users/test/schema.json      | C:/Users/test/schema.json#/$defs/TestType    | #/$defs/TestType           |
+		| C:/Users/test/schema.json      | C:/Users/test/other.json                     | other.json                 |
+		| C:/Users/test/schema.json      | C:/Users/test/other.json#/$defs/TestType     | other.json#/$defs/TestType |
+
+Scenario Outline: GetRelativeLocationFor returns filename for base location (implicit file paths)
+	When I get relative location for "<target>" with base "<base>"
+	Then the relative reference will be "<relative>"
+
+	Examples:
+		| base                           | target                                       | relative                       |
+		| C:/Users/test/schema.json      | C:/Users/test/schema.json                    | schema.json                    |
+		| C:/Users/test/schema.json      | C:/Users/test/schema.json#/$defs/TestType    | schema.json#/$defs/TestType    |
+		| C:/Users/test/schema.json      | C:/Users/test/other.json                     | other.json                     |
+		| C:/Users/test/schema.json      | C:/Users/test/other.json#/$defs/TestType     | other.json#/$defs/TestType     |
+
+Scenario Outline: GetRelativeLocationFor returns filename for base location (absolute URIs)
+	When I get relative location for "<target>" with base "<base>"
+	Then the relative reference will be "<relative>"
+
+	Examples:
+		| base                                         | target                                                   | relative                       |
+		| https://endjin.com/home/user/test.json       | https://endjin.com/home/user/test.json                   | test.json                      |
+		| https://endjin.com/home/user/test.json       | https://endjin.com/home/user/test.json#/$defs/TestType   | test.json#/$defs/TestType      |
+		| https://endjin.com/home/user/test.json       | https://endjin.com/home/user/other.json                  | other.json                     |
+		| https://endjin.com/home/user/test.json       | https://endjin.com/home/user/other.json#/$defs/TestType  | other.json#/$defs/TestType     |
+		| https://endjin.com/home/user/test.json       | https://endjin.com/home/other/file.json                  | ../other/file.json             |
+		| https://endjin.com/schema.json               | https://endjin.com/schema.json#/$defs/Type               | schema.json#/$defs/Type        |
+		| https://endjin.com/path/to/schema.json       | https://endjin.com/path/to/schema.json#/properties/name  | schema.json#/properties/name   |

--- a/Solutions/Corvus.Json.Specs/Steps/JsonReferenceDefinitions.cs
+++ b/Solutions/Corvus.Json.Specs/Steps/JsonReferenceDefinitions.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using Corvus.Json;
+using Corvus.Json.CodeGeneration;
 using NUnit.Framework;
 using TechTalk.SpecFlow;
 
@@ -55,11 +56,50 @@ public sealed class JsonReferenceDefinitions
     }
 
     /// <summary>
+    /// Makes a target reference relative to the base reference and puts the result cast to a string in "Result".
+    /// </summary>
+    /// <param name="targetReference">The target reference to make relative.</param>
+    /// <param name="baseReference">The base reference.</param>
+    [When(@"I make ""(.*)"" relative to the base reference ""(.*)""")]
+    public void WhenIMakeTheReferenceRelativeToTheBase(string targetReference, string baseReference)
+    {
+        var baseRef = new JsonReference(baseReference);
+        var targetRef = new JsonReference(targetReference);
+
+        this.scenarioContext.Add("Result", (string)baseRef.MakeRelative(targetRef));
+    }
+
+    /// <summary>
+    /// Gets the relative location for a target reference using TypeBuilderContext.GetRelativeLocationFor.
+    /// </summary>
+    /// <param name="targetReference">The target reference.</param>
+    /// <param name="baseReference">The base reference.</param>
+    [When(@"I get relative location for ""(.*)"" with base ""(.*)""")]
+    public void WhenIGetRelativeLocationForWithBase(string targetReference, string baseReference)
+    {
+        var baseRef = new JsonReference(baseReference);
+        var targetRef = new JsonReference(targetReference);
+
+        string result = TypeBuilderContext.GetRelativeLocationFor(targetRef, baseRef);
+        this.scenarioContext.Add("Result", result);
+    }
+
+    /// <summary>
     /// Verifies that the string value in "Result" equals the expected value.
     /// </summary>
     /// <param name="expectedResult">The expected result of merging the reference.</param>
     [Then(@"the applied reference will be ""(.*)""")]
     public void ThenTheAppliedReferenceWillBe(string expectedResult)
+    {
+        Assert.AreEqual(expectedResult, this.scenarioContext.Get<string>("Result"));
+    }
+
+    /// <summary>
+    /// Verifies that the string value in "Result" equals the expected relative reference.
+    /// </summary>
+    /// <param name="expectedResult">The expected relative reference.</param>
+    [Then(@"the relative reference will be ""(.*)""")]
+    public void ThenTheRelativeReferenceWillBe(string expectedResult)
     {
         Assert.AreEqual(expectedResult, this.scenarioContext.Get<string>("Result"));
     }

--- a/Solutions/Corvus.Json.Specs/packages.lock.json
+++ b/Solutions/Corvus.Json.Specs/packages.lock.json
@@ -91,12 +91,6 @@
         "resolved": "4.6.0",
         "contentHash": "R7e1+a4vuV/YS+ItfL7f//rG+JBvVeVLX4mHzFEZo4W1qEKl8Zz27AqvQSAqo+BtIzUCo4aAJMYa56VXS4hudw=="
       },
-      "Roslynator.Analyzers": {
-        "type": "Direct",
-        "requested": "[4.13.1, )",
-        "resolved": "4.13.1",
-        "contentHash": "KZpLy6ZlCebMk+d/3I5KU2R7AOb4LNJ6tPJqPtvFXmO8bEBHQvCIAvJOnY2tu4C9/aVOROTDYUFADxFqw1gh/g=="
-      },
       "SolidToken.SpecFlow.DependencyInjection": {
         "type": "Direct",
         "requested": "[3.9.3, )",
@@ -116,15 +110,6 @@
           "NUnit": "3.13.1",
           "SpecFlow": "[3.9.74]",
           "SpecFlow.Tools.MsBuild.Generation": "[3.9.74]"
-        }
-      },
-      "StyleCop.Analyzers": {
-        "type": "Direct",
-        "requested": "[1.2.0-beta.556, )",
-        "resolved": "1.2.0-beta.556",
-        "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
-        "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.556"
         }
       },
       "System.Collections.Immutable": {
@@ -481,11 +466,6 @@
           "SpecFlow": "[3.9.74]"
         }
       },
-      "StyleCop.Analyzers.Unstable": {
-        "type": "Transitive",
-        "resolved": "1.2.0.556",
-        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
-      },
       "System.Buffers": {
         "type": "Transitive",
         "resolved": "4.5.1",
@@ -786,12 +766,6 @@
         "resolved": "4.6.0",
         "contentHash": "R7e1+a4vuV/YS+ItfL7f//rG+JBvVeVLX4mHzFEZo4W1qEKl8Zz27AqvQSAqo+BtIzUCo4aAJMYa56VXS4hudw=="
       },
-      "Roslynator.Analyzers": {
-        "type": "Direct",
-        "requested": "[4.13.1, )",
-        "resolved": "4.13.1",
-        "contentHash": "KZpLy6ZlCebMk+d/3I5KU2R7AOb4LNJ6tPJqPtvFXmO8bEBHQvCIAvJOnY2tu4C9/aVOROTDYUFADxFqw1gh/g=="
-      },
       "SolidToken.SpecFlow.DependencyInjection": {
         "type": "Direct",
         "requested": "[3.9.3, )",
@@ -811,15 +785,6 @@
           "NUnit": "3.13.1",
           "SpecFlow": "[3.9.74]",
           "SpecFlow.Tools.MsBuild.Generation": "[3.9.74]"
-        }
-      },
-      "StyleCop.Analyzers": {
-        "type": "Direct",
-        "requested": "[1.2.0-beta.556, )",
-        "resolved": "1.2.0-beta.556",
-        "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
-        "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.556"
         }
       },
       "System.Collections.Immutable": {
@@ -1379,11 +1344,6 @@
         "dependencies": {
           "SpecFlow": "[3.9.74]"
         }
-      },
-      "StyleCop.Analyzers.Unstable": {
-        "type": "Transitive",
-        "resolved": "1.2.0.556",
-        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
       },
       "System.AppContext": {
         "type": "Transitive",
@@ -2201,12 +2161,6 @@
         "resolved": "4.6.0",
         "contentHash": "R7e1+a4vuV/YS+ItfL7f//rG+JBvVeVLX4mHzFEZo4W1qEKl8Zz27AqvQSAqo+BtIzUCo4aAJMYa56VXS4hudw=="
       },
-      "Roslynator.Analyzers": {
-        "type": "Direct",
-        "requested": "[4.13.1, )",
-        "resolved": "4.13.1",
-        "contentHash": "KZpLy6ZlCebMk+d/3I5KU2R7AOb4LNJ6tPJqPtvFXmO8bEBHQvCIAvJOnY2tu4C9/aVOROTDYUFADxFqw1gh/g=="
-      },
       "SolidToken.SpecFlow.DependencyInjection": {
         "type": "Direct",
         "requested": "[3.9.3, )",
@@ -2226,15 +2180,6 @@
           "NUnit": "3.13.1",
           "SpecFlow": "[3.9.74]",
           "SpecFlow.Tools.MsBuild.Generation": "[3.9.74]"
-        }
-      },
-      "StyleCop.Analyzers": {
-        "type": "Direct",
-        "requested": "[1.2.0-beta.556, )",
-        "resolved": "1.2.0-beta.556",
-        "contentHash": "llRPgmA1fhC0I0QyFLEcjvtM2239QzKr/tcnbsjArLMJxJlu0AA5G7Fft0OI30pHF3MW63Gf4aSSsjc5m82J1Q==",
-        "dependencies": {
-          "StyleCop.Analyzers.Unstable": "1.2.0.556"
         }
       },
       "System.Collections.Immutable": {
@@ -2785,11 +2730,6 @@
         "dependencies": {
           "SpecFlow": "[3.9.74]"
         }
-      },
-      "StyleCop.Analyzers.Unstable": {
-        "type": "Transitive",
-        "resolved": "1.2.0.556",
-        "contentHash": "zvn9Mqs/ox/83cpYPignI8hJEM2A93s2HkHs8HYMOAQW0PkampyoErAiIyKxgTLqbbad29HX/shv/6LGSjPJNQ=="
       },
       "System.AppContext": {
         "type": "Transitive",


### PR DESCRIPTION
- Updated GetRelativeLocationFor to handle absolute URIs created by prepending DefaultAbsoluteLocation on non-Windows platforms

- When target path matches base path, the method now correctly returns filename#fragment instead of just #fragment

- Extracted PrependFilenameIfNeeded helper method to reduce code duplication

- Made GetRelativeLocationFor public static for testability

- Added comprehensive tests for both MakeRelative and GetRelativeLocationFor

Fixes #669