### PR TITLE
Set TypeKeyword validation priority to CoreType

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/TypeKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/TypeKeyword.cs
@@ -27,7 +27,7 @@ public sealed class TypeKeyword : ICoreTypeValidationKeyword
     public ReadOnlySpan<byte> KeywordUtf8 => "type"u8;
 
     /// <inheritdoc />
-    public uint ValidationPriority => ValidationPriorities.Default;
+    public uint ValidationPriority => ValidationPriorities.CoreType;
 
     /// <inheritdoc />
     public CoreTypes ImpliesCoreTypes(TypeDeclaration typeDeclaration)

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Validation/ValidationPriorities.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Validation/ValidationPriorities.cs
@@ -15,6 +15,11 @@ public static class ValidationPriorities
     public const uint First = 0;
 
     /// <summary>
+    /// The priority of core-type contributing keywords.
+    /// </summary>
+    public const uint CoreType = First + 1000;
+
+    /// <summary>
     /// The default priority.
     /// </summary>
     public const uint Default = uint.MaxValue / 2;


### PR DESCRIPTION
Introduce CoreType validation priority for core-type keywords, setting it to First + 1000. Update TypeKeyword to use this new priority, ensuring core-type validation occurs before default priority keywords.