### PR TITLE
Removed the exclusions for defaulted values from required checking.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PropertiesValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/PropertiesValidationHandler.cs
@@ -96,8 +96,7 @@ public class PropertiesValidationHandler : IChildObjectPropertyValidationHandler
                 .AppendLineIndent("{")
                 .PushIndent();
 
-            if (property.RequiredOrOptional == RequiredOrOptional.Required &&
-                !property.ReducedPropertyType.HasDefaultValue())
+            if (property.RequiredOrOptional == RequiredOrOptional.Required)
             {
                 string hasSeenField = RequiredValidationHandler.GetHasSeenVariableName(generator, property);
                 generator

--- a/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/RequiredValidationHandler.cs
+++ b/Solutions/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationHandlers/ObjectChildHandlers/RequiredValidationHandler.cs
@@ -37,8 +37,7 @@ public class RequiredValidationHandler : IChildObjectPropertyValidationHandler
                     return generator;
                 }
 
-                // Don't bother with properties that have default values.
-                if (property.ReducedPropertyType.HasDefaultValue() || property.RequiredKeyword is not IObjectRequiredPropertyValidationKeyword keyword)
+                if (property.RequiredKeyword is not IObjectRequiredPropertyValidationKeyword keyword)
                 {
                     continue;
                 }
@@ -138,12 +137,6 @@ public class RequiredValidationHandler : IChildObjectPropertyValidationHandler
                 if (generator.IsCancellationRequested)
                 {
                     return generator;
-                }
-
-                // Don't bother with properties that have default values.
-                if (property.ReducedPropertyType.HasDefaultValue())
-                {
-                    continue;
                 }
 
                 string requiredName = GetHasSeenVariableName(generator, property);

--- a/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft202012/Repro705.feature
+++ b/Solutions/Corvus.Json.Specs/Features/AdditionalSchema/Draft202012/Repro705.feature
@@ -1,0 +1,33 @@
+@draft202012
+
+Feature: Repro 705 draft202012
+
+Scenario Outline: Defaulted required property 
+	Given a schema file
+		"""
+		{
+			"type": "object",
+			"properties": {
+				"regularProperty": { "type": "string" },
+				"propertyWithDefault": { "$ref": "#/$defs/defaultedValue" },
+				"unsetProperty": { "type": "string" }
+			},
+			"required": ["regularProperty", "propertyWithDefault"],
+			"$defs": {
+				"defaultedValue": {
+					"type": "string",
+					"default": "Hello"
+				}
+			}
+		}
+		"""
+	And the input data value <inputData>
+	And I generate a type for the schema
+	And I construct an instance of the schema type from the data
+	When I validate the instance with level Detailed
+	Then the result will be <valid>
+
+Examples:
+	| inputData                                                | valid |
+	| {"regularProperty": "foo"}                               | false |
+	| {"regularProperty": "foo", "propertyWithDefault": "bar"} | true  |


### PR DESCRIPTION
Fixes #705 

Removed default value exclusions from explicit property checking.
Added tests for the interaction between required and default value.

Also opened 

https://github.com/json-schema-org/JSON-Schema-Test-Suite/pull/835

to add this interaction test to the test suite.