### PR TITLE
Ensure the full `patternProperties` schema path is appended to the schema location.

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/IObjectPatternPropertyValidationKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/IObjectPatternPropertyValidationKeyword.cs
@@ -13,7 +13,8 @@ public interface IObjectPatternPropertyValidationKeyword : IObjectValidationKeyw
     /// <summary>
     /// Gets the reduced path modifier for the pattern property declaration.
     /// </summary>
+    /// <param name="pattern">The pattern that produced the type declaration.</param>
     /// <param name="propertyTypeDeclaration">The pattern property type declaration.</param>
     /// <returns>The path modifier for this item from this keyword.</returns>
-    string GetPathModifier(ReducedTypeDeclaration propertyTypeDeclaration);
+    string GetPathModifier(string pattern, ReducedTypeDeclaration propertyTypeDeclaration);
 }

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/PatternPropertiesKeyword.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Keywords/Standard/PatternPropertiesKeyword.cs
@@ -107,8 +107,8 @@ public sealed class PatternPropertiesKeyword
     public bool RequiresObjectEnumeration(TypeDeclaration typeDeclaration) => typeDeclaration.HasKeyword(this);
 
     /// <inheritdoc/>
-    public string GetPathModifier(ReducedTypeDeclaration propertyTypeDeclaration)
+    public string GetPathModifier(string pattern, ReducedTypeDeclaration propertyTypeDeclaration)
     {
-        return KeywordPathReference.AppendFragment(propertyTypeDeclaration.ReducedPathModifier);
+        return KeywordPathReference.AppendUnencodedPropertyNameToFragment(pattern).AppendFragment(propertyTypeDeclaration.ReducedPathModifier);
     }
 }

--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/PropertyProvider/PatternPropertyDeclaration.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/PropertyProvider/PatternPropertyDeclaration.cs
@@ -32,5 +32,5 @@ public sealed class PatternPropertyDeclaration(IObjectPatternPropertyValidationK
     /// <summary>
     /// Gets the reduced path modifier for the pattern property.
     /// </summary>
-    public string KeywordPathModifier { get; } = keyword.GetPathModifier(patternPropertyType.ReducedTypeDeclaration());
+    public string KeywordPathModifier { get; } = keyword.GetPathModifier(pattern, patternPropertyType.ReducedTypeDeclaration());
 }


### PR DESCRIPTION
`PatternPropertyDeclaration` now passes the pattern to the keyword in addition to the reduced type declaration, so that keyword can  look  up the correct path to the pattern schema in its `GetPathModifier()` method.

For the standard `patternProperties` keyword this trivially appends the property name fragment to the modifier prior to that for the pattern property's reduced type declaration.