### PR TITLE
Handle file references ($ref) starting with "file:///"

### DIFF
--- a/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/DocumentResolvers/SchemaReferenceNormalization.cs
+++ b/Solutions/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/DocumentResolvers/SchemaReferenceNormalization.cs
@@ -40,7 +40,14 @@ public static class SchemaReferenceNormalization
                     schemaFile = Path.Combine(basePath, schemaFile);
                 }
 
-                schemaFile = Path.GetFullPath(schemaFile);
+                if (schemaFile.StartsWith("file:///"))
+                {
+                    schemaFile = Path.GetFullPath(schemaFile.Substring("file:///".Length));
+                }
+                else
+                {
+                    schemaFile = Path.GetFullPath(schemaFile);
+                }
             }
 
             result = schemaFile.Replace('\\', '/');


### PR DESCRIPTION
While trying to generate C# code from a folder with hundreds of .json schema files, I tracked down this bug (is it a bug?) where TryNormalizeSchemaReference was unable to handle the $ref fields in the particular json schemas I received (they all start with "file:///")

Adding this small if/else resolved my problem and allowed me to generate the C# files.

As I'm not super familiar with json schemas, I'm unsure if this is a bug in the code or if the schemas I received are not following standard practice.

Decided to make a pull request in any case. Feel free to reject if not valid.