### PR TITLE
Fix OpenAPI server streaming responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ High-performance, source-generated, strongly-typed C# models from JSON Schema �
 - **JSON Patch, Merge Patch & Diff** — RFC 6902 JSON Patch, RFC 7396 Merge Patch, and diff with zero-allocation operations on `JsonElement`.
 - **JSON Canonicalization** — RFC 8785 JSON Canonicalization Scheme (JCS) for deterministic serialization. Zero heap allocation.
 - **[YAML](#yaml)** — High-performance YAML 1.2 to JSON converter with 100% yaml-test-suite conformance. Zero-allocation `ref struct` tokenizer.
+- **[TOON](#toon)** — Bidirectional TOON (Token-Oriented Object Notation) conversion for compact JSON-shaped LLM prompts, with Corvus and System.Text.Json packages.
 
 ## Quick Start
 
@@ -110,6 +111,8 @@ Most applications need `Corvus.Text.Json` plus either the source generator or th
 | JSON Patch | **Corvus.Text.Json.Patch** | RFC 6902 JSON Patch, RFC 7396 Merge Patch, and diff. |
 | YAML | **Corvus.Text.Json.Yaml** | YAML 1.2 to JSON converter with Corvus document model integration. |
 | YAML | **Corvus.Yaml.SystemTextJson** | YAML 1.2 to JSON converter using only System.Text.Json. |
+| TOON | **Corvus.Text.Json.Toon** | TOON to JSON and JSON to TOON converter with Corvus document model integration. |
+| TOON | **Corvus.Toon.SystemTextJson** | TOON to JSON and JSON to TOON converter using only System.Text.Json. |
 
 ### Install
 
@@ -171,6 +174,7 @@ Then open http://localhost:5000.
 - [JSON Patch, Merge Patch & Diff](docs/JsonPatch.md)
 - [JSON Canonicalization (RFC 8785)](docs/JsonCanonicalization.md)
 - [YAML to JSON Converter](docs/Yaml.md)
+- [TOON Converter](docs/Toon.md)
 - [Migrating from V4](docs/MigratingFromV4ToV5.md)
 
 ## Building
@@ -336,6 +340,16 @@ Console.WriteLine(doc.RootElement.GetProperty("name").GetString()); // "Alice"
 ```
 
 See [YAML documentation](docs/Yaml.md) for the full API, configuration options, and supported YAML features. **[Try the YAML Playground](docs/playground-yaml/)** to convert between YAML and JSON in your browser.
+
+## TOON
+
+TOON (Token-Oriented Object Notation) is a compact text representation for JSON-shaped data, especially useful at LLM prompt boundaries. It keeps the JSON data model while reducing repeated punctuation and object member names; uniform arrays of objects can be represented as table-style rows.
+
+- **Bidirectional conversion** — convert TOON to JSON, JSON to TOON, TOON to parsed documents, and JSON elements to TOON.
+- **Two packages**: `Corvus.Text.Json.Toon` (full Corvus integration) and `Corvus.Toon.SystemTextJson` (System.Text.Json only).
+- **UTF-8-first APIs** — write JSON or TOON directly to caller-provided UTF-8 buffers for hot paths and streaming boundaries.
+
+See [TOON documentation](docs/Toon.md) for the full API, configuration options, examples, and benchmarks. **[Try the TOON Playground](docs/playground-toon/)** to convert between TOON and JSON in your browser.
 
 ## Supported platforms
 

--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,17 @@
 # Version History
 
+## V5.1.1
+
+V5.1.1 adds TOON conversion support and fixes OpenAPI 3.2 server streaming responses generated from `itemSchema` response content.
+
+### New features
+
+- **TOON conversion** — Added bidirectional TOON (Token-Oriented Object Notation) conversion for JSON-shaped data, with `Corvus.Text.Json.Toon` for the Corvus pooled document model and `Corvus.Toon.SystemTextJson` for `System.Text.Json`-only applications. The converters support TOON to JSON, JSON to TOON, parsed documents, UTF-8 buffer APIs, tabular object arrays, dotted-path expansion, key folding, documentation, examples, benchmarks, and a browser playground.
+
+### Bug fixes
+
+- **OpenAPI 3.2 server streaming responses** — Generated ASP.NET Core server stubs now emit response bodies for `itemSchema` streaming responses. Streaming result factories use generated push-writer callbacks, frame `text/event-stream` responses as SSE (`data: ...\n\n`), frame `application/x-ndjson` and other streaming media as newline-delimited JSON, and complete the HTTP stream when the callback returns.
+
 ## V5.1
 
 V5.1 expands Corvus.Text.Json beyond JSON Schema model generation into strongly-typed API generation, and closes a set of V4/V5 parity gaps that were identified during the 5.1 release wrap-up.

--- a/docs/AsyncApi.md
+++ b/docs/AsyncApi.md
@@ -1048,11 +1048,14 @@ Different transports handle header serialization differently:
 |-----------|-----------------|-------|
 | Kafka | Native message headers (`Message.Headers`) | Key-value byte pairs |
 | AMQP | Application properties | Native key-value map |
+| Azure Service Bus | Application properties (`ServiceBusMessage.ApplicationProperties`) | User metadata map; values are encoded as strings and reconstructed as typed JSON headers for generated handlers |
 | NATS | Base64-encoded JSON in message headers | Protocol has limited header support |
 | MQTT | User properties (MQTT 5) or base64 in topic | MQTT 3.1 has no header concept |
 | WebSocket | JSON envelope field | Framed alongside payload |
 
 The transport layer handles encoding/decoding transparently — your handler always receives the typed struct regardless of the wire format.
+
+Azure Service Bus deserves one extra note because it has both broker system properties and user application properties. Corvus writes AsyncAPI message headers to `ApplicationProperties`; it does not use them for broker control fields such as `CorrelationId`, `ReplyTo`, or `SessionId`. Request/reply support uses those native Service Bus fields separately, while your AsyncAPI header schema remains in the application-property map and is passed to generated handlers as the same typed header struct used by other transports.
 
 ## Request/Reply
 

--- a/docs/ExampleRecipes/029-OpenApiClient/Generated/ApiPetsClient.cs
+++ b/docs/ExampleRecipes/029-OpenApiClient/Generated/ApiPetsClient.cs
@@ -57,7 +57,7 @@ public sealed class ApiPetsClient : IApiPetsClient
     public ValueTask<CreatePetResponse> CreatePetAsync(Petstore.Client.NewPet.Source body, CancellationToken cancellationToken = default, ValidationMode validationMode = ValidationMode.Basic, ValidationMode responseValidationMode = ValidationMode.None)
     {
         JsonWorkspace workspace = JsonWorkspace.CreateUnrented();
-        Petstore.Client.NewPet bodyValue = Petstore.Client.NewPet.CreateBuilder(workspace, body, 0).RootElement;
+        Petstore.Client.NewPet bodyValue = Petstore.Client.NewPet.CreateBuilder(workspace, body, 30).RootElement;
         CreatePetRequest request = new();
 
         request.Validate(validationMode);

--- a/docs/ExampleRecipes/029-OpenApiClient/Program.cs
+++ b/docs/ExampleRecipes/029-OpenApiClient/Program.cs
@@ -3,18 +3,22 @@
 // </copyright>
 
 using Corvus.Text.Json;
+using Corvus.Text.Json.Internal;
 using Corvus.Text.Json.OpenApi;
-using Corvus.Text.Json.OpenApi.HttpTransport;
 using Petstore.Client;
 
 // ── Setting up the client ────────────────────────────────────────────────────
 // The generated ApiPetsClient wraps the IApiTransport, which handles the actual
-// HTTP communication. You provide an HttpClient configured with the server's
-// base address. The generated code handles everything else: path template
+// HTTP communication. The generated code handles everything else: path template
 // resolution, query string encoding, header serialization, and response parsing.
-HttpClient httpClient = new() { BaseAddress = new Uri("https://petstore.example.com/v1") };
-await using HttpClientTransport transport = new(httpClient, disposeClient: true);
+//
+// Production code normally uses HttpClientTransport. This recipe uses an in-memory
+// transport so `dotnet run` is self-contained and does not depend on a fictional
+// petstore.example.com server.
+await using DemoTransport transport = new();
 ApiPetsClient client = new(transport);
+Console.WriteLine("Using in-memory demo transport. In production, replace it with HttpClientTransport.");
+Console.WriteLine();
 
 // ── 1. List pets (GET /pets) ─────────────────────────────────────────────────
 // The optional `limit` parameter accepts a plain C# int via implicit conversion.
@@ -60,7 +64,7 @@ Console.WriteLine();
 //   • Validates the body against the NewPet JSON Schema (name is required)
 //   • Serializes it as application/json in the request body
 //   • Parses the 201 response into a typed Pet
-Console.WriteLine("2. Creating a pet...");
+Console.WriteLine("\n2. Creating a pet...");
 await using CreatePetResponse createResponse = await client.CreatePetAsync(
     body: new NewPet.Source(static (ref NewPet.Builder b) =>
     {
@@ -88,7 +92,7 @@ Console.WriteLine();
 //   • URI-encodes the value (percent-encoding special characters)
 //   • Substitutes it into the path template: /pets/{petId} → /pets/pet-123
 //   • Deserializes the 200 body into a typed Pet
-Console.WriteLine("3. Showing pet by ID...");
+Console.WriteLine("\n3. Showing pet by ID...");
 await using ShowPetByIdResponse showResponse = await client.ShowPetByIdAsync(petId: "pet-123"u8);
 
 showResponse.MatchResult(
@@ -109,7 +113,7 @@ Console.WriteLine();
 // By default (ValidationMode.Basic), all request parameters and bodies are
 // validated against their JSON Schema before sending. You can opt into detailed
 // validation for richer error messages, or disable it for performance.
-Console.WriteLine("4. Demonstrating request validation...");
+Console.WriteLine("\n4. Demonstrating request validation...");
 try
 {
     // This will throw because limit > 100 violates the schema's "maximum: 100"
@@ -117,10 +121,99 @@ try
         limit: 200,
         validationMode: ValidationMode.Detailed);
 }
-catch (InvalidOperationException ex)
+catch (ArgumentException ex)
 {
     Console.WriteLine($"   Validation caught: {ex.Message}");
 }
 
 Console.WriteLine();
 Console.WriteLine("Done!");
+
+internal sealed class DemoTransport : IApiTransport
+{
+    private static readonly DemoHeaders ListPetsHeaders = new(("x-next", "/pets?limit=10&cursor=next"));
+
+    public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+        in TRequest request,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IApiRequest<TRequest>
+        where TResponse : struct, IApiResponse<TResponse> =>
+        CreateResponseAsync<TResponse>(cancellationToken);
+
+    public ValueTask<TResponse> SendAsync<TRequest, TBody, TResponse>(
+        in TRequest request,
+        in TBody body,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IApiRequest<TRequest>
+        where TBody : struct, IJsonElement<TBody>
+        where TResponse : struct, IApiResponse<TResponse> =>
+        CreateResponseAsync<TResponse>(cancellationToken);
+
+    public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+        in TRequest request,
+        Stream body,
+        string contentType,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IApiRequest<TRequest>
+        where TResponse : struct, IApiResponse<TResponse> =>
+        CreateResponseAsync<TResponse>(cancellationToken);
+
+    public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+        in TRequest request,
+        Func<Stream, CancellationToken, ValueTask> bodyWriter,
+        string contentType,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IApiRequest<TRequest>
+        where TResponse : struct, IApiResponse<TResponse> =>
+        CreateResponseAsync<TResponse>(cancellationToken);
+
+    public ValueTask DisposeAsync() => default;
+
+    private static ValueTask<TResponse> CreateResponseAsync<TResponse>(CancellationToken cancellationToken)
+        where TResponse : struct, IApiResponse<TResponse>
+    {
+        if (typeof(TResponse) == typeof(ListPetsResponse))
+        {
+            return TResponse.CreateAsync(
+                200,
+                CreateStream("""[{"id":1,"name":"Fido","tag":"dog"},{"id":2,"name":"Misty","tag":"cat"}]"""),
+                "application/json",
+                ListPetsHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        if (typeof(TResponse) == typeof(CreatePetResponse))
+        {
+            return TResponse.CreateAsync(
+                201,
+                CreateStream("""{"id":42,"name":"Fido","tag":"dog"}"""),
+                "application/json",
+                cancellationToken: cancellationToken);
+        }
+
+        if (typeof(TResponse) == typeof(ShowPetByIdResponse))
+        {
+            return TResponse.CreateAsync(
+                200,
+                CreateStream("""{"id":123,"name":"Rex","tag":"dog"}"""),
+                "application/json",
+                cancellationToken: cancellationToken);
+        }
+
+        throw new NotSupportedException($"The demo transport has no canned response for {typeof(TResponse).Name}.");
+    }
+
+    private static MemoryStream CreateStream(string content) =>
+        new(System.Text.Encoding.UTF8.GetBytes(content), writable: false);
+}
+
+internal sealed class DemoHeaders(params (string Name, string Value)[] values) : IResponseHeaders
+{
+    private readonly Dictionary<string, string> values = values.ToDictionary(
+        static item => item.Name,
+        static item => item.Value,
+        StringComparer.OrdinalIgnoreCase);
+
+    public bool TryGetValue(string headerName, out string? value) =>
+        this.values.TryGetValue(headerName, out value);
+}

--- a/docs/ExampleRecipes/029-OpenApiClient/README.md
+++ b/docs/ExampleRecipes/029-OpenApiClient/README.md
@@ -212,7 +212,7 @@ try
         limit: 200,
         validationMode: ValidationMode.Detailed);
 }
-catch (InvalidOperationException ex)
+catch (ArgumentException ex)
 {
     // Detailed mode includes JSON Schema validation output showing exactly
     // which constraint was violated
@@ -226,6 +226,15 @@ Validation modes:
 | `ValidationMode.Basic` | Validates parameters and bodies; throws on failure with a brief message |
 | `ValidationMode.Detailed` | Same validation but includes full JSON Schema evaluation output in the exception |
 | `ValidationMode.None` | Skips all validation — use for trusted inputs in performance-critical paths |
+
+## Running
+
+```bash
+dotnet build
+dotnet run
+```
+
+The runnable recipe uses an in-memory `IApiTransport` so it produces deterministic console output without needing the fictional `petstore.example.com` host to exist. In production code, replace the demo transport with `HttpClientTransport` configured with your API server's base address, as shown in the transport setup section above.
 
 ## Best Practices
 

--- a/docs/ExampleRecipes/030-OpenApiServer/Generated/CreatePetResult.cs
+++ b/docs/ExampleRecipes/030-OpenApiServer/Generated/CreatePetResult.cs
@@ -41,7 +41,7 @@ public readonly struct CreatePetResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="CreatePetResult"/> with status 201.</returns>
-    public static CreatePetResult Created(Petstore.Server.Pet.Source body, JsonWorkspace workspace) => new(201, Petstore.Server.Pet.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static CreatePetResult Created(Petstore.Server.Pet.Source body, JsonWorkspace workspace) => new(201, Petstore.Server.Pet.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a default error result.
@@ -50,7 +50,7 @@ public readonly struct CreatePetResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="CreatePetResult"/> with status default.</returns>
-    public static CreatePetResult Default(int statusCode, Petstore.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Server.Error.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static CreatePetResult Default(int statusCode, Petstore.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/030-OpenApiServer/Generated/ListPetsResult.cs
+++ b/docs/ExampleRecipes/030-OpenApiServer/Generated/ListPetsResult.cs
@@ -48,7 +48,7 @@ public readonly struct ListPetsResult
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <param name="xNext">The value for the <c>x-next</c> response header.</param>
     /// <returns>A <see cref="ListPetsResult"/> with status 200.</returns>
-    public static ListPetsResult Ok(Petstore.Server.Pets.Source body, JsonWorkspace workspace, Petstore.Server.JsonString xNext = default) => new(200, Petstore.Server.Pets.CreateBuilder(workspace, body, 0).RootElement, "application/json", xNext: xNext);
+    public static ListPetsResult Ok(Petstore.Server.Pets.Source body, JsonWorkspace workspace, Petstore.Server.JsonString xNext = default) => new(200, Petstore.Server.Pets.CreateBuilder(workspace, body, 30).RootElement, "application/json", xNext: xNext);
 
     /// <summary>
     /// Creates a default error result.
@@ -57,7 +57,7 @@ public readonly struct ListPetsResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="ListPetsResult"/> with status default.</returns>
-    public static ListPetsResult Default(int statusCode, Petstore.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Server.Error.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static ListPetsResult Default(int statusCode, Petstore.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/030-OpenApiServer/Generated/ShowPetByIdResult.cs
+++ b/docs/ExampleRecipes/030-OpenApiServer/Generated/ShowPetByIdResult.cs
@@ -41,7 +41,7 @@ public readonly struct ShowPetByIdResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="ShowPetByIdResult"/> with status 200.</returns>
-    public static ShowPetByIdResult Ok(Petstore.Server.Pet.Source body, JsonWorkspace workspace) => new(200, Petstore.Server.Pet.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static ShowPetByIdResult Ok(Petstore.Server.Pet.Source body, JsonWorkspace workspace) => new(200, Petstore.Server.Pet.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a default error result.
@@ -50,7 +50,7 @@ public readonly struct ShowPetByIdResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="ShowPetByIdResult"/> with status default.</returns>
-    public static ShowPetByIdResult Default(int statusCode, Petstore.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Server.Error.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static ShowPetByIdResult Default(int statusCode, Petstore.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/030-OpenApiServer/Program.cs
+++ b/docs/ExampleRecipes/030-OpenApiServer/Program.cs
@@ -23,6 +23,30 @@ using Petstore.Server;
 WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 WebApplication app = builder.Build();
 
+app.Lifetime.ApplicationStarted.Register(() =>
+{
+    string baseUrl = app.Urls.FirstOrDefault(static url => url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+        ?? app.Urls.FirstOrDefault()
+        ?? "http://localhost:50515";
+
+    Console.WriteLine();
+    Console.WriteLine("OpenAPI Server example is running.");
+    Console.WriteLine($"Base URL: {baseUrl}");
+    Console.WriteLine();
+    Console.WriteLine("Try these requests from another terminal:");
+    Console.WriteLine($"  curl \"{baseUrl}/pets?limit=2\"");
+    Console.WriteLine($"  curl -X POST \"{baseUrl}/pets\" -H \"Content-Type: application/json\" -d \"{{\\\"name\\\":\\\"Fido\\\",\\\"tag\\\":\\\"dog\\\"}}\"");
+    Console.WriteLine($"  curl \"{baseUrl}/pets/1\"");
+    Console.WriteLine();
+});
+
+app.Use(async (context, next) =>
+{
+    Console.WriteLine($"--> {context.Request.Method} {context.Request.Path}{context.Request.QueryString}");
+    await next(context);
+    Console.WriteLine($"<-- {context.Response.StatusCode} {context.Response.ContentType ?? "(no content type)"}");
+});
+
 // Register a single handler instance — in production, use DI registration
 PetsHandler handler = new();
 app.MapApiEndpoints(handler);
@@ -72,6 +96,7 @@ internal sealed class PetsHandler : IApiPetsHandler
             : 20;
 
         var petsToReturn = this.pets.Take(limit).ToList();
+        Console.WriteLine($"    [Pets] Returning {petsToReturn.Count} pet(s), limit={limit}");
 
         // Build the response using the typed Result factory.
         // Ok() accepts a Pets.Source (array builder) and the workspace.
@@ -122,6 +147,7 @@ internal sealed class PetsHandler : IApiPetsHandler
         string? tag = body.Tag.IsNotUndefined() ? (string)body.Tag : null;
 
         this.pets.Add((id, name, tag));
+        Console.WriteLine($"    [Pets] Created pet {id}: {name} ({tag ?? "no tag"})");
 
         // Return 201 Created with the full Pet (including the generated ID)
         CreatePetResult result = CreatePetResult.Created(
@@ -161,6 +187,8 @@ internal sealed class PetsHandler : IApiPetsHandler
             (long Id, string Name, string? Tag) found = this.pets.FirstOrDefault(p => p.Id == id);
             if (found != default)
             {
+                Console.WriteLine($"    [Pets] Found pet {found.Id}: {found.Name}");
+
                 return ValueTask.FromResult(ShowPetByIdResult.Ok(
                     body: new Pet.Source((ref Pet.Builder b) =>
                     {
@@ -178,6 +206,7 @@ internal sealed class PetsHandler : IApiPetsHandler
         }
 
         // Return a default error response for "not found"
+        Console.WriteLine($"    [Pets] Pet '{petId}' was not found");
         return ValueTask.FromResult(ShowPetByIdResult.Default(
             statusCode: 404,
             body: new Error.Source((ref Error.Builder b) =>

--- a/docs/ExampleRecipes/030-OpenApiServer/Properties/launchSettings.json
+++ b/docs/ExampleRecipes/030-OpenApiServer/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "OpenApiServer": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/docs/ExampleRecipes/030-OpenApiServer/README.md
+++ b/docs/ExampleRecipes/030-OpenApiServer/README.md
@@ -502,7 +502,7 @@ cd docs/ExampleRecipes/030-OpenApiServer
 dotnet run
 ```
 
-The server starts on `http://localhost:5000` (or a random port if 5000 is in use).
+The launch profile does not open a browser. The server writes its actual base URL, sample `curl` commands, request summaries, and handler activity to the console.
 
 ### Testing with curl:
 

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/Program.cs
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/Program.cs
@@ -3,8 +3,8 @@
 // </copyright>
 
 using Corvus.Text.Json;
+using Corvus.Text.Json.Internal;
 using Corvus.Text.Json.OpenApi;
-using Corvus.Text.Json.OpenApi.HttpTransport;
 using Petstore.Extended;
 
 // ══════════════════════════════════════════════════════════════════════════════
@@ -22,8 +22,12 @@ using Petstore.Extended;
 //   8. Multipart form-data with file attachments
 //   9. URL-encoded form submissions
 
-HttpClient httpClient = new() { BaseAddress = new Uri("https://petstore.example.com/v2") };
-await using HttpClientTransport transport = new(httpClient, disposeClient: true);
+// Production code normally uses HttpClientTransport with a real base address.
+// This recipe uses an in-memory transport so `dotnet run` is self-contained and
+// does not depend on a fictional petstore.example.com server.
+await using DemoTransport transport = new();
+Console.WriteLine("Using in-memory demo transport. In production, replace it with HttpClientTransport.");
+Console.WriteLine();
 
 // The generator creates separate client classes per tag group.
 // Each client shares the same transport.
@@ -90,7 +94,7 @@ Console.WriteLine();
 // The path parameter is declared as style=simple, schema=array[int64].
 // The generated code serializes the array into the path: /pets/batch/1,2,3
 // using comma-separated (simple style) encoding.
-Console.WriteLine("2. Batch fetching pets by IDs...");
+Console.WriteLine("\n2. Batch fetching pets by IDs...");
 await using GetPetsBatchResponse batchResponse = await petsClient.GetPetsBatchAsync(
     ids: new GetPetsBatchByIdsIds.Source((ref GetPetsBatchByIdsIds.Builder b) =>
     {
@@ -119,7 +123,7 @@ Console.WriteLine();
 // The session_token cookie is declared as a required cookie parameter.
 // The generated code writes it into the Cookie header automatically.
 // The consumer just passes the token as a typed value.
-Console.WriteLine("3. Creating a pet (with session cookie)...");
+Console.WriteLine("\n3. Creating a pet (with session cookie)...");
 await using CreatePetResponse createResponse = await petsClient.CreatePetAsync(
     session_token: "sess_k7j2m9x4"u8,
     body: new NewPet.Source((ref NewPet.Builder b) =>
@@ -167,7 +171,7 @@ Console.WriteLine();
 //
 // Behind the scenes, the generated code builds the multipart boundary, writes
 // each field as a form part, and streams the binary content without buffering.
-Console.WriteLine("4. Uploading a pet photo...");
+Console.WriteLine("\n4. Uploading a pet photo...");
 byte[] photoBytes = [0x89, 0x50, 0x4E, 0x47]; // PNG header stub
 
 await using UploadPetPhotoResponse uploadResponse = await photosClient.UploadPetPhotoAsync(
@@ -176,7 +180,7 @@ await using UploadPetPhotoResponse uploadResponse = await photosClient.UploadPet
     body: new PostPetsByPetIdPhotosBody.Source((ref PostPetsByPetIdPhotosBody.Builder b) =>
     {
         b.Create(
-            file: default, // binary part handled separately
+            file: "bella-park.png"u8, // binary bytes are supplied by BinaryPartData below
             caption: "Bella at the park"u8,
             isPrimary: true);
     }),
@@ -223,7 +227,7 @@ Console.WriteLine();
 // response exposes the raw Stream directly — no JSON parsing overhead.
 // MatchResult<ValueTask> distinguishes between a successful stream and error
 // responses while allowing async I/O on the stream.
-Console.WriteLine("5. Downloading a pet photo...");
+Console.WriteLine("\n5. Downloading a pet photo...");
 await using DownloadPhotoResponse downloadResponse = await photosClient.DownloadPhotoAsync(
     photoId: "photo-001"u8);
 
@@ -256,7 +260,7 @@ Console.WriteLine();
 // exposes IAsyncEnumerable<ParsedJsonDocument<ChatChunk>> for streaming
 // consumption. Each chunk arrives as a strongly-typed, pooled document — you
 // process it and dispose automatically via await foreach.
-Console.WriteLine("6. Starting vet chat (SSE streaming)...");
+Console.WriteLine("\n6. Starting vet chat (SSE streaming)...");
 await using StartVetChatResponse chatResponse = await chatClient.StartVetChatAsync(
     petId: "pet-42"u8,
     session_token: "sess_k7j2m9x4"u8,
@@ -296,7 +300,7 @@ Console.WriteLine();
 // application/x-ndjson streams newline-delimited JSON objects. The generated
 // code provides the same IAsyncEnumerable interface as SSE, but each item is
 // parsed from a single line. No SSE envelope — just raw typed objects.
-Console.WriteLine("7. Streaming pet activity (NDJSON)...");
+Console.WriteLine("\n7. Streaming pet activity (NDJSON)...");
 await using StreamPetActivityResponse activityResponse = await chatClient.StreamPetActivityAsync(
     petId: "pet-42"u8);
 
@@ -321,7 +325,7 @@ Console.WriteLine();
 // The spec declares application/x-www-form-urlencoded. The generated code
 // serializes the typed body as key=value&key=value with proper URL-encoding.
 // No manual string concatenation — the builder mirrors the schema properties.
-Console.WriteLine("8. Submitting adoption application (form-encoded)...");
+Console.WriteLine("\n8. Submitting adoption application (form-encoded)...");
 await using SubmitAdoptionApplicationResponse adoptionResponse =
     await adoptionClient.SubmitAdoptionApplicationAsync(
         body: new PostAdoptionApplyBody.Source((ref PostAdoptionApplyBody.Builder b) =>
@@ -359,3 +363,153 @@ adoptionResponse.MatchResult(
 
 Console.WriteLine();
 Console.WriteLine("Done!");
+
+internal sealed class DemoTransport : IApiTransport
+{
+    private static readonly DemoHeaders ListPetsHeaders = new(
+        ("x-total-count", "42"),
+        ("x-next", "/pets?cursor=next"));
+
+    public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+        in TRequest request,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IApiRequest<TRequest>
+        where TResponse : struct, IApiResponse<TResponse> =>
+        CreateResponseAsync<TResponse>(cancellationToken);
+
+    public ValueTask<TResponse> SendAsync<TRequest, TBody, TResponse>(
+        in TRequest request,
+        in TBody body,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IApiRequest<TRequest>
+        where TBody : struct, IJsonElement<TBody>
+        where TResponse : struct, IApiResponse<TResponse> =>
+        CreateResponseAsync<TResponse>(cancellationToken);
+
+    public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+        in TRequest request,
+        Stream body,
+        string contentType,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IApiRequest<TRequest>
+        where TResponse : struct, IApiResponse<TResponse> =>
+        CreateResponseAsync<TResponse>(cancellationToken);
+
+    public ValueTask<TResponse> SendAsync<TRequest, TResponse>(
+        in TRequest request,
+        Func<Stream, CancellationToken, ValueTask> bodyWriter,
+        string contentType,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IApiRequest<TRequest>
+        where TResponse : struct, IApiResponse<TResponse> =>
+        CreateResponseAsync<TResponse>(cancellationToken);
+
+    public ValueTask DisposeAsync() => default;
+
+    private static ValueTask<TResponse> CreateResponseAsync<TResponse>(CancellationToken cancellationToken)
+        where TResponse : struct, IApiResponse<TResponse>
+    {
+        if (typeof(TResponse) == typeof(ListPetsResponse))
+        {
+            return TResponse.CreateAsync(
+                200,
+                CreateStream("""[{"id":1,"name":"Bella","breed":"labrador","age":2,"status":"available","tags":["dog","friendly"]},{"id":2,"name":"Misty","breed":"domestic short hair","age":4,"status":"available","tags":["cat"]}]"""),
+                "application/json",
+                ListPetsHeaders,
+                cancellationToken: cancellationToken);
+        }
+
+        if (typeof(TResponse) == typeof(GetPetsBatchResponse))
+        {
+            return TResponse.CreateAsync(
+                200,
+                CreateStream("""[{"id":1,"name":"Bella","status":"available"},{"id":2,"name":"Misty","status":"available"},{"id":3,"name":"Rex","status":"pending"}]"""),
+                "application/json",
+                cancellationToken: cancellationToken);
+        }
+
+        if (typeof(TResponse) == typeof(CreatePetResponse))
+        {
+            return TResponse.CreateAsync(
+                201,
+                CreateStream("""{"id":42,"name":"Bella","breed":"golden retriever","age":2,"status":"available","tags":["dog","friendly","trained"]}"""),
+                "application/json",
+                cancellationToken: cancellationToken);
+        }
+
+        if (typeof(TResponse) == typeof(UploadPetPhotoResponse))
+        {
+            return TResponse.CreateAsync(
+                201,
+                CreateStream("""{"photoId":"photo-001","petId":"pet-42","caption":"Bella at the park","isPrimary":true,"uploadedAt":"2026-01-02T12:34:56Z"}"""),
+                "application/json",
+                cancellationToken: cancellationToken);
+        }
+
+        if (typeof(TResponse) == typeof(DownloadPhotoResponse))
+        {
+            return TResponse.CreateAsync(
+                200,
+                new MemoryStream([0x89, 0x50, 0x4E, 0x47], writable: false),
+                "application/octet-stream",
+                cancellationToken: cancellationToken);
+        }
+
+        if (typeof(TResponse) == typeof(StartVetChatResponse))
+        {
+            return TResponse.CreateAsync(
+                200,
+                CreateStream(
+                    """
+                    data: {"id":"chunk-1","delta":"Keep Bella hydrated. ","done":false}
+
+                    data: {"id":"chunk-2","delta":"Call us if symptoms worsen.","done":false}
+
+                    data: {"id":"chunk-3","done":true}
+
+                    """),
+                "text/event-stream",
+                cancellationToken: cancellationToken);
+        }
+
+        if (typeof(TResponse) == typeof(StreamPetActivityResponse))
+        {
+            return TResponse.CreateAsync(
+                200,
+                CreateStream(
+                    """
+                    {"eventId":"evt-1","type":"feeding","timestamp":"2026-01-02T08:00:00Z","description":"Bella ate breakfast"}
+                    {"eventId":"evt-2","type":"walk","timestamp":"2026-01-02T09:30:00Z","description":"Morning walk completed"}
+                    {"eventId":"evt-3","type":"photo_added","timestamp":"2026-01-02T12:34:56Z","description":"New park photo uploaded"}
+
+                    """),
+                "application/x-ndjson",
+                cancellationToken: cancellationToken);
+        }
+
+        if (typeof(TResponse) == typeof(SubmitAdoptionApplicationResponse))
+        {
+            return TResponse.CreateAsync(
+                202,
+                CreateStream("""{"applicationId":"app-2026-001","status":"received","estimatedReviewDays":5}"""),
+                "application/json",
+                cancellationToken: cancellationToken);
+        }
+
+        throw new NotSupportedException($"The demo transport has no canned response for {typeof(TResponse).Name}.");
+    }
+
+    private static MemoryStream CreateStream(string content) =>
+        new(System.Text.Encoding.UTF8.GetBytes(content), writable: false);
+}
+
+internal sealed class DemoHeaders(params (string Name, string Value)[] values) : IResponseHeaders
+{
+    private readonly Dictionary<string, string> values = values.ToDictionary(
+        static item => item.Name,
+        static item => item.Value,
+        StringComparer.OrdinalIgnoreCase);
+
+    public bool TryGetValue(string headerName, out string? value) =>
+        this.values.TryGetValue(headerName, out value);
+}

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/README.md
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/README.md
@@ -64,7 +64,7 @@ await petsClient.ListPetsAsync(
 
 ### Streaming Responses
 
-For SSE and NDJSON streams, the generated response exposes `IAsyncEnumerable<ParsedJsonDocument<T>>`. Each item arrives as a strongly-typed, pooled document:
+For SSE and NDJSON streams, the generated response exposes `IAsyncEnumerable<ParsedJsonDocument<T>>`. Each item arrives as a strongly-typed, pooled document. SSE responses also expose `EnumerateOkSseItems()` when you need event metadata:
 
 ```csharp
 await foreach (ParsedJsonDocument<ChatChunk> chunk in chatResponse.EnumerateOkItems())

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/README.md
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/README.md
@@ -128,7 +128,7 @@ dotnet build
 dotnet run
 ```
 
-> **Note:** This example calls a fictional API. You'll need a running Petstore-compatible server (see [030-OpenApiServer](../030-OpenApiServer/) for how to build one).
+The runnable recipe uses an in-memory `IApiTransport` so it produces deterministic console output for filtering, uploads, downloads, SSE, NDJSON, and form submission without needing the fictional `petstore.example.com` host to exist. In production code, replace the demo transport with `HttpClientTransport` configured with your API server's base address.
 
 ## Project Structure
 

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/ApiEndpointRegistration.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/ApiEndpointRegistration.cs
@@ -678,7 +678,23 @@ public static class ApiEndpointRegistration
                 }
 
                 context.Response.StatusCode = result.StatusCode;
-                if (!result.Body.IsUndefined())
+                if (result.HasStreamingBody)
+                {
+                    context.Response.ContentType = result.ContentType!;
+                    Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);
+                    try
+                    {
+                        JsonStreamWriter streamWriter = new(context.Response.BodyWriter, writer, result.ContentType!);
+                        await result.WriteStreamAsync(streamWriter, context.RequestAborted).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        workspace.ReturnWriter(writer);
+                    }
+
+                    await context.Response.BodyWriter.FlushAsync(context.RequestAborted).ConfigureAwait(false);
+                }
+                else if (!result.Body.IsUndefined())
                 {
                     context.Response.ContentType = result.ContentType ?? "application/json";
                     Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);
@@ -763,7 +779,23 @@ public static class ApiEndpointRegistration
                 }
 
                 context.Response.StatusCode = result.StatusCode;
-                if (!result.Body.IsUndefined())
+                if (result.HasStreamingBody)
+                {
+                    context.Response.ContentType = result.ContentType!;
+                    Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);
+                    try
+                    {
+                        JsonStreamWriter streamWriter = new(context.Response.BodyWriter, writer, result.ContentType!);
+                        await result.WriteStreamAsync(streamWriter, context.RequestAborted).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        workspace.ReturnWriter(writer);
+                    }
+
+                    await context.Response.BodyWriter.FlushAsync(context.RequestAborted).ConfigureAwait(false);
+                }
+                else if (!result.Body.IsUndefined())
                 {
                     context.Response.ContentType = result.ContentType ?? "application/json";
                     Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/CreatePetResult.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/CreatePetResult.cs
@@ -41,7 +41,7 @@ public readonly struct CreatePetResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="CreatePetResult"/> with status 201.</returns>
-    public static CreatePetResult Created(Petstore.Extended.Server.Pet.Source body, JsonWorkspace workspace) => new(201, Petstore.Extended.Server.Pet.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static CreatePetResult Created(Petstore.Extended.Server.Pet.Source body, JsonWorkspace workspace) => new(201, Petstore.Extended.Server.Pet.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a 401 Unauthorized result.
@@ -49,7 +49,7 @@ public readonly struct CreatePetResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="CreatePetResult"/> with status 401.</returns>
-    public static CreatePetResult Unauthorized(Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static CreatePetResult Unauthorized(Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a default error result.
@@ -58,7 +58,7 @@ public readonly struct CreatePetResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="CreatePetResult"/> with status default.</returns>
-    public static CreatePetResult Default(int statusCode, Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static CreatePetResult Default(int statusCode, Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/DownloadPhotoResult.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/DownloadPhotoResult.cs
@@ -47,7 +47,7 @@ public readonly struct DownloadPhotoResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="DownloadPhotoResult"/> with status 404.</returns>
-    public static DownloadPhotoResult NotFound(Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(404, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static DownloadPhotoResult NotFound(Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(404, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/GetPetsBatchResult.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/GetPetsBatchResult.cs
@@ -41,7 +41,7 @@ public readonly struct GetPetsBatchResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="GetPetsBatchResult"/> with status 200.</returns>
-    public static GetPetsBatchResult Ok(Petstore.Extended.Server.PetList.Source body, JsonWorkspace workspace) => new(200, Petstore.Extended.Server.PetList.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static GetPetsBatchResult Ok(Petstore.Extended.Server.PetList.Source body, JsonWorkspace workspace) => new(200, Petstore.Extended.Server.PetList.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/ListPetsResult.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/ListPetsResult.cs
@@ -55,7 +55,7 @@ public readonly struct ListPetsResult
     /// <param name="xTotalCount">The value for the <c>x-total-count</c> response header.</param>
     /// <param name="xNext">The value for the <c>x-next</c> response header.</param>
     /// <returns>A <see cref="ListPetsResult"/> with status 200.</returns>
-    public static ListPetsResult Ok(Petstore.Extended.Server.PetList.Source body, JsonWorkspace workspace, Petstore.Extended.Server.JsonInteger xTotalCount = default, Petstore.Extended.Server.JsonString xNext = default) => new(200, Petstore.Extended.Server.PetList.CreateBuilder(workspace, body, 0).RootElement, "application/json", xTotalCount: xTotalCount, xNext: xNext);
+    public static ListPetsResult Ok(Petstore.Extended.Server.PetList.Source body, JsonWorkspace workspace, Petstore.Extended.Server.JsonInteger xTotalCount = default, Petstore.Extended.Server.JsonString xNext = default) => new(200, Petstore.Extended.Server.PetList.CreateBuilder(workspace, body, 30).RootElement, "application/json", xTotalCount: xTotalCount, xNext: xNext);
 
     /// <summary>
     /// Creates a default error result.
@@ -64,7 +64,7 @@ public readonly struct ListPetsResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="ListPetsResult"/> with status default.</returns>
-    public static ListPetsResult Default(int statusCode, Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static ListPetsResult Default(int statusCode, Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonDateTime.Mutable.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonDateTime.Mutable.cs
@@ -499,7 +499,7 @@ public readonly partial struct JsonDateTime
 
         private Source(NodaTime.OffsetDateTime value) { SimpleTypesBacking.Initialize(ref _simpleTypeBacking, value, static (v, buffer, out written) => JsonElementHelpers.TryFormatOffsetDateTime(v, buffer, out written)); _kind = Kind.StringSimpleType; }
 
-        private Source(DateTimeOffset value) { SimpleTypesBacking.Initialize(ref _simpleTypeBacking, value, static (v, buffer, out written) => Utf8Formatter.TryFormat(v, buffer, out written)); _kind = Kind.StringSimpleType; }
+        private Source(DateTimeOffset value) { SimpleTypesBacking.Initialize(ref _simpleTypeBacking, value, static (v, buffer, out written) => Utf8Formatter.TryFormat(v, buffer, out written, 'O')); _kind = Kind.StringSimpleType; }
 
         public static implicit operator Source(JsonDateTime instance) => new(JsonElement.From(instance));
 
@@ -514,6 +514,9 @@ public readonly partial struct JsonDateTime
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator Source(NodaTime.OffsetDateTime value) => new (value);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator Source(DateTimeOffset value) => new (value);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Source RawString(ReadOnlySpan<byte> value, bool requiresUnescaping) => new(value, requiresUnescaping);

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/ShowPetByIdResult.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/ShowPetByIdResult.cs
@@ -41,7 +41,7 @@ public readonly struct ShowPetByIdResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="ShowPetByIdResult"/> with status 200.</returns>
-    public static ShowPetByIdResult Ok(Petstore.Extended.Server.Pet.Source body, JsonWorkspace workspace) => new(200, Petstore.Extended.Server.Pet.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static ShowPetByIdResult Ok(Petstore.Extended.Server.Pet.Source body, JsonWorkspace workspace) => new(200, Petstore.Extended.Server.Pet.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a 404 NotFound result.
@@ -49,7 +49,7 @@ public readonly struct ShowPetByIdResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="ShowPetByIdResult"/> with status 404.</returns>
-    public static ShowPetByIdResult NotFound(Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(404, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static ShowPetByIdResult NotFound(Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(404, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/StartVetChatResult.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/StartVetChatResult.cs
@@ -19,12 +19,17 @@ namespace Petstore.Extended.Server;
 /// </summary>
 public readonly struct StartVetChatResult
 {
-    private StartVetChatResult(int statusCode, JsonElement body = default, string? contentType = null)
+    private StartVetChatResult(int statusCode, JsonElement body = default, string? contentType = null, StartVetChatStreamWriterInvoker? streamWriter = null, object? streamWriterContext = null)
     {
         this.StatusCode = statusCode;
         this.Body = body;
         this.ContentType = contentType;
+        this.streamWriter = streamWriter;
+        this.streamWriterContext = streamWriterContext;
     }
+
+    private readonly StartVetChatStreamWriterInvoker? streamWriter;
+    private readonly object? streamWriterContext;
 
     /// <summary>Gets the HTTP status code.</summary>
     public int StatusCode { get; }
@@ -35,11 +40,26 @@ public readonly struct StartVetChatResult
     /// <summary>Gets the content type for the response body.</summary>
     public string? ContentType { get; }
 
+    /// <summary>Gets a value indicating whether this result has a streaming response body.</summary>
+    public bool HasStreamingBody => this.streamWriter is not null;
+
     /// <summary>
     /// Creates a 200 Ok result.
     /// </summary>
+    /// <param name="writer">The callback that appends items to the <see cref="StartVetChatStream"/>.</param>
     /// <returns>A <see cref="StartVetChatResult"/> with status 200.</returns>
-    public static StartVetChatResult Ok() => new(200, default, null);
+    public static StartVetChatResult Ok(StartVetChatStreamWriter writer) => new(200, default, "text/event-stream", streamWriter: static (jsonStreamWriter, context, cancellationToken) => ((StartVetChatStreamWriter)context!)(new StartVetChatStream(jsonStreamWriter), cancellationToken), streamWriterContext: writer);
+
+    /// <typeparam name="TContext">The callback context type.</typeparam>
+    /// <param name="context">The callback context.</param>
+    /// <param name="writer">The callback that appends items to the <see cref="StartVetChatStream"/>.</param>
+    /// <returns>A <see cref="StartVetChatResult"/> with status 200.</returns>
+    public static StartVetChatResult Ok<TContext>(TContext context, StartVetChatStreamWriter<TContext> writer) => new(200, default, "text/event-stream", streamWriter: static (jsonStreamWriter, context, cancellationToken) =>
+        {
+            var wrapper = (StartVetChatStreamWriterContext<TContext>)context!;
+            return wrapper.Writer(new StartVetChatStream(jsonStreamWriter), wrapper.Context, cancellationToken);
+        },
+        streamWriterContext: new StartVetChatStreamWriterContext<TContext>(context, writer));
 
     /// <summary>
     /// Creates a 401 Unauthorized result.
@@ -47,7 +67,7 @@ public readonly struct StartVetChatResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="StartVetChatResult"/> with status 401.</returns>
-    public static StartVetChatResult Unauthorized(Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static StartVetChatResult Unauthorized(Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.
@@ -74,4 +94,87 @@ public readonly struct StartVetChatResult
             this.Body.WriteTo(writer);
         }
     }
+
+    /// <summary>
+    /// Writes the streaming response body.
+    /// </summary>
+    /// <param name="writer">The stream writer.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the stream has been written.</returns>
+    public ValueTask WriteStreamAsync(JsonStreamWriter writer, CancellationToken cancellationToken = default)
+    {
+        return this.streamWriter is null
+            ? ValueTask.CompletedTask
+            : this.streamWriter(writer, this.streamWriterContext, cancellationToken);
+    }
+
+    private delegate ValueTask StartVetChatStreamWriterInvoker(JsonStreamWriter writer, object? context, CancellationToken cancellationToken);
+
+    private sealed class StartVetChatStreamWriterContext<TContext>
+    {
+        public StartVetChatStreamWriterContext(TContext context, StartVetChatStreamWriter<TContext> writer)
+        {
+            this.Context = context;
+            this.Writer = writer;
+        }
+
+        public TContext Context { get; }
+
+        public StartVetChatStreamWriter<TContext> Writer { get; }
+    }
 }
+
+/// <summary>
+/// Writes items for the StartVetChat streaming response.
+/// </summary>
+public readonly struct StartVetChatStream
+{
+    private readonly JsonStreamWriter writer;
+
+    internal StartVetChatStream(JsonStreamWriter writer)
+    {
+        this.writer = writer;
+    }
+
+    /// <summary>
+    /// Appends a <see cref="Petstore.Extended.Server.ChatChunk"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendChatChunk(in Petstore.Extended.Server.ChatChunk.Source item, CancellationToken cancellationToken = default)
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+        using JsonDocumentBuilder<Petstore.Extended.Server.ChatChunk.Mutable> builder = Petstore.Extended.Server.ChatChunk.CreateBuilder(workspace, item);
+        return this.writer.WriteItemAsync(builder.RootElement, cancellationToken);
+    }
+
+    /// <summary>
+    /// Appends a <see cref="Petstore.Extended.Server.ChatChunk"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendChatChunk(Petstore.Extended.Server.ChatChunk item, CancellationToken cancellationToken = default)
+    {
+        return this.writer.WriteItemAsync(item, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Callback used to write a StartVetChatStream response.
+/// </summary>
+/// <param name="stream">The StartVetChatStream writer.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask StartVetChatStreamWriter(StartVetChatStream stream, CancellationToken cancellationToken);
+
+/// <summary>
+/// Callback used to write a StartVetChatStream response with a context value.
+/// </summary>
+/// <typeparam name="TContext">The callback context type.</typeparam>
+/// <param name="stream">The StartVetChatStream writer.</param>
+/// <param name="context">The callback context.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask StartVetChatStreamWriter<TContext>(StartVetChatStream stream, TContext context, CancellationToken cancellationToken);

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/StreamPetActivityResult.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/StreamPetActivityResult.cs
@@ -19,12 +19,17 @@ namespace Petstore.Extended.Server;
 /// </summary>
 public readonly struct StreamPetActivityResult
 {
-    private StreamPetActivityResult(int statusCode, JsonElement body = default, string? contentType = null)
+    private StreamPetActivityResult(int statusCode, JsonElement body = default, string? contentType = null, StreamPetActivityStreamWriterInvoker? streamWriter = null, object? streamWriterContext = null)
     {
         this.StatusCode = statusCode;
         this.Body = body;
         this.ContentType = contentType;
+        this.streamWriter = streamWriter;
+        this.streamWriterContext = streamWriterContext;
     }
+
+    private readonly StreamPetActivityStreamWriterInvoker? streamWriter;
+    private readonly object? streamWriterContext;
 
     /// <summary>Gets the HTTP status code.</summary>
     public int StatusCode { get; }
@@ -35,11 +40,26 @@ public readonly struct StreamPetActivityResult
     /// <summary>Gets the content type for the response body.</summary>
     public string? ContentType { get; }
 
+    /// <summary>Gets a value indicating whether this result has a streaming response body.</summary>
+    public bool HasStreamingBody => this.streamWriter is not null;
+
     /// <summary>
     /// Creates a 200 Ok result.
     /// </summary>
+    /// <param name="writer">The callback that appends items to the <see cref="StreamPetActivityStream"/>.</param>
     /// <returns>A <see cref="StreamPetActivityResult"/> with status 200.</returns>
-    public static StreamPetActivityResult Ok() => new(200, default, null);
+    public static StreamPetActivityResult Ok(StreamPetActivityStreamWriter writer) => new(200, default, "application/x-ndjson", streamWriter: static (jsonStreamWriter, context, cancellationToken) => ((StreamPetActivityStreamWriter)context!)(new StreamPetActivityStream(jsonStreamWriter), cancellationToken), streamWriterContext: writer);
+
+    /// <typeparam name="TContext">The callback context type.</typeparam>
+    /// <param name="context">The callback context.</param>
+    /// <param name="writer">The callback that appends items to the <see cref="StreamPetActivityStream"/>.</param>
+    /// <returns>A <see cref="StreamPetActivityResult"/> with status 200.</returns>
+    public static StreamPetActivityResult Ok<TContext>(TContext context, StreamPetActivityStreamWriter<TContext> writer) => new(200, default, "application/x-ndjson", streamWriter: static (jsonStreamWriter, context, cancellationToken) =>
+        {
+            var wrapper = (StreamPetActivityStreamWriterContext<TContext>)context!;
+            return wrapper.Writer(new StreamPetActivityStream(jsonStreamWriter), wrapper.Context, cancellationToken);
+        },
+        streamWriterContext: new StreamPetActivityStreamWriterContext<TContext>(context, writer));
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.
@@ -62,4 +82,87 @@ public readonly struct StreamPetActivityResult
             this.Body.WriteTo(writer);
         }
     }
+
+    /// <summary>
+    /// Writes the streaming response body.
+    /// </summary>
+    /// <param name="writer">The stream writer.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the stream has been written.</returns>
+    public ValueTask WriteStreamAsync(JsonStreamWriter writer, CancellationToken cancellationToken = default)
+    {
+        return this.streamWriter is null
+            ? ValueTask.CompletedTask
+            : this.streamWriter(writer, this.streamWriterContext, cancellationToken);
+    }
+
+    private delegate ValueTask StreamPetActivityStreamWriterInvoker(JsonStreamWriter writer, object? context, CancellationToken cancellationToken);
+
+    private sealed class StreamPetActivityStreamWriterContext<TContext>
+    {
+        public StreamPetActivityStreamWriterContext(TContext context, StreamPetActivityStreamWriter<TContext> writer)
+        {
+            this.Context = context;
+            this.Writer = writer;
+        }
+
+        public TContext Context { get; }
+
+        public StreamPetActivityStreamWriter<TContext> Writer { get; }
+    }
 }
+
+/// <summary>
+/// Writes items for the StreamPetActivity streaming response.
+/// </summary>
+public readonly struct StreamPetActivityStream
+{
+    private readonly JsonStreamWriter writer;
+
+    internal StreamPetActivityStream(JsonStreamWriter writer)
+    {
+        this.writer = writer;
+    }
+
+    /// <summary>
+    /// Appends a <see cref="Petstore.Extended.Server.ActivityEvent"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendActivityEvent(in Petstore.Extended.Server.ActivityEvent.Source item, CancellationToken cancellationToken = default)
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+        using JsonDocumentBuilder<Petstore.Extended.Server.ActivityEvent.Mutable> builder = Petstore.Extended.Server.ActivityEvent.CreateBuilder(workspace, item);
+        return this.writer.WriteItemAsync(builder.RootElement, cancellationToken);
+    }
+
+    /// <summary>
+    /// Appends a <see cref="Petstore.Extended.Server.ActivityEvent"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendActivityEvent(Petstore.Extended.Server.ActivityEvent item, CancellationToken cancellationToken = default)
+    {
+        return this.writer.WriteItemAsync(item, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Callback used to write a StreamPetActivityStream response.
+/// </summary>
+/// <param name="stream">The StreamPetActivityStream writer.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask StreamPetActivityStreamWriter(StreamPetActivityStream stream, CancellationToken cancellationToken);
+
+/// <summary>
+/// Callback used to write a StreamPetActivityStream response with a context value.
+/// </summary>
+/// <typeparam name="TContext">The callback context type.</typeparam>
+/// <param name="stream">The StreamPetActivityStream writer.</param>
+/// <param name="context">The callback context.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask StreamPetActivityStreamWriter<TContext>(StreamPetActivityStream stream, TContext context, CancellationToken cancellationToken);

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/SubmitAdoptionApplicationResult.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/SubmitAdoptionApplicationResult.cs
@@ -41,7 +41,7 @@ public readonly struct SubmitAdoptionApplicationResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="SubmitAdoptionApplicationResult"/> with status 202.</returns>
-    public static SubmitAdoptionApplicationResult Accepted(Petstore.Extended.Server.PostAdoptionApplyAccepted.Source body, JsonWorkspace workspace) => new(202, Petstore.Extended.Server.PostAdoptionApplyAccepted.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static SubmitAdoptionApplicationResult Accepted(Petstore.Extended.Server.PostAdoptionApplyAccepted.Source body, JsonWorkspace workspace) => new(202, Petstore.Extended.Server.PostAdoptionApplyAccepted.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a default error result.
@@ -50,7 +50,7 @@ public readonly struct SubmitAdoptionApplicationResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="SubmitAdoptionApplicationResult"/> with status default.</returns>
-    public static SubmitAdoptionApplicationResult Default(int statusCode, Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static SubmitAdoptionApplicationResult Default(int statusCode, Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/UploadPetPhotoResult.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/UploadPetPhotoResult.cs
@@ -41,7 +41,7 @@ public readonly struct UploadPetPhotoResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="UploadPetPhotoResult"/> with status 201.</returns>
-    public static UploadPetPhotoResult Created(Petstore.Extended.Server.PhotoMetadata.Source body, JsonWorkspace workspace) => new(201, Petstore.Extended.Server.PhotoMetadata.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static UploadPetPhotoResult Created(Petstore.Extended.Server.PhotoMetadata.Source body, JsonWorkspace workspace) => new(201, Petstore.Extended.Server.PhotoMetadata.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a 401 Unauthorized result.
@@ -49,7 +49,7 @@ public readonly struct UploadPetPhotoResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="UploadPetPhotoResult"/> with status 401.</returns>
-    public static UploadPetPhotoResult Unauthorized(Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 0).RootElement, "application/json");
+    public static UploadPetPhotoResult Unauthorized(Petstore.Extended.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.Extended.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Program.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Program.cs
@@ -2,7 +2,6 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
-using System.Runtime.CompilerServices;
 using Corvus.Text.Json;
 using Corvus.Text.Json.OpenApi;
 using Petstore.Extended.Server;
@@ -15,7 +14,7 @@ using Petstore.Extended.Server;
 // how to handle:
 //   - Deep-object/array query parameters (already deserialized into typed params)
 //   - Cookie-based authentication (session token validation)
-//   - Streaming responses (SSE and NDJSON via IAsyncEnumerable)
+//   - Streaming responses (SSE and NDJSON via generated push writers)
 //   - File upload/download (multipart form body, binary streams)
 //   - Form-encoded request bodies (typed property access)
 //   - Response header emission (pagination headers)
@@ -333,9 +332,8 @@ internal sealed class PhotosHandler : IApiPhotosHandler
 
 /// <summary>
 /// Implements SSE streaming (vet chat) and NDJSON streaming (activity feed).
-/// For streaming operations, the handler returns Ok() to signal success, and
-/// the endpoint registration streams typed items to the client using
-/// IAsyncEnumerable.
+/// Streaming operations return a result with a writer callback. The generated
+/// endpoint registration invokes the callback while the response body is open.
 /// </summary>
 internal sealed class ChatHandler : IApiChatHandler
 {
@@ -359,10 +357,14 @@ internal sealed class ChatHandler : IApiChatHandler
         string message = (string)parameters.Body.Message;
         Console.WriteLine($"[Chat] Pet {parameters.PetId}: {message}");
 
-        // For SSE streaming, return Ok() to signal the response should stream.
-        // The generated endpoint registration handles writing the SSE envelope
-        // and serializing each ChatChunk item.
-        return ValueTask.FromResult(StartVetChatResult.Ok());
+        return new(StartVetChatResult.Ok(static async (stream, cancellationToken) =>
+        {
+            ChatChunk greeting = ChatChunk.ParseValue("""{"id":"chunk-1","delta":"Hello! ","done":false}"""u8);
+            await stream.AppendChatChunk(greeting, cancellationToken).ConfigureAwait(false);
+
+            ChatChunk advice = ChatChunk.ParseValue("""{"id":"chunk-2","delta":"A vet will review Bella's symptoms and respond shortly.","done":true}"""u8);
+            await stream.AppendChatChunk(advice, cancellationToken).ConfigureAwait(false);
+        }));
     }
 
     public ValueTask<StreamPetActivityResult> HandleStreamPetActivityAsync(
@@ -372,10 +374,17 @@ internal sealed class ChatHandler : IApiChatHandler
     {
         Console.WriteLine($"[Activity] Starting stream for pet {parameters.PetId}");
 
-        // For NDJSON streaming, return Ok() to signal success.
-        // The generated endpoint registration writes each ActivityEvent as a
-        // newline-delimited JSON line.
-        return ValueTask.FromResult(StreamPetActivityResult.Ok());
+        return new(StreamPetActivityResult.Ok(static async (stream, cancellationToken) =>
+        {
+            ActivityEvent checkIn = ActivityEvent.ParseValue("""{"eventId":"evt-1","timestamp":"2026-05-30T18:00:00Z","type":"check-in","description":"Bella checked in at reception"}"""u8);
+            await stream.AppendActivityEvent(checkIn, cancellationToken).ConfigureAwait(false);
+
+            ActivityEvent exam = ActivityEvent.ParseValue("""{"eventId":"evt-2","timestamp":"2026-05-30T18:05:00Z","type":"exam","description":"Initial examination started"}"""u8);
+            await stream.AppendActivityEvent(exam, cancellationToken).ConfigureAwait(false);
+
+            ActivityEvent complete = ActivityEvent.ParseValue("""{"eventId":"evt-3","timestamp":"2026-05-30T18:20:00Z","type":"complete","description":"Examination completed"}"""u8);
+            await stream.AppendActivityEvent(complete, cancellationToken).ConfigureAwait(false);
+        }));
     }
 }
 

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Program.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Program.cs
@@ -23,6 +23,30 @@ WebApplicationBuilder builder = WebApplication.CreateBuilder(args);
 
 WebApplication app = builder.Build();
 
+app.Lifetime.ApplicationStarted.Register(() =>
+{
+    string baseUrl = app.Urls.FirstOrDefault(static url => url.StartsWith("http://", StringComparison.OrdinalIgnoreCase))
+        ?? app.Urls.FirstOrDefault()
+        ?? "http://localhost:50516";
+
+    Console.WriteLine();
+    Console.WriteLine("OpenAPI Advanced Server example is running.");
+    Console.WriteLine($"Base URL: {baseUrl}");
+    Console.WriteLine();
+    Console.WriteLine("Try these requests from another terminal:");
+    Console.WriteLine($"  curl \"{baseUrl}/pets?limit=2&filter[status]=available&tags=dog\" -H \"x-request-id: demo-request-1\"");
+    Console.WriteLine($"  curl -N \"{baseUrl}/pets/1/activity\" -H \"Accept: application/x-ndjson\"");
+    Console.WriteLine($"  curl -N -X POST \"{baseUrl}/pets/1/chat\" -H \"Accept: text/event-stream\" -H \"Content-Type: application/json\" -H \"Cookie: session_token=admin-token-123\" -d \"{{\\\"message\\\":\\\"Bella is coughing. What should I do?\\\"}}\"");
+    Console.WriteLine();
+});
+
+app.Use(async (context, next) =>
+{
+    Console.WriteLine($"--> {context.Request.Method} {context.Request.Path}{context.Request.QueryString}");
+    await next(context);
+    Console.WriteLine($"<-- {context.Response.StatusCode} {context.Response.ContentType ?? "(no content type)"}");
+});
+
 // The generated ApiEndpointRegistration wires all routes to your handler implementations.
 // Each handler interface covers one tag group from the spec.
 PetsHandler petsHandler = new();

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Program.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Program.cs
@@ -34,7 +34,8 @@ app.Lifetime.ApplicationStarted.Register(() =>
     Console.WriteLine($"Base URL: {baseUrl}");
     Console.WriteLine();
     Console.WriteLine("Try these requests from another terminal:");
-    Console.WriteLine($"  curl \"{baseUrl}/pets?limit=2&filter[status]=available&tags=dog\" -H \"x-request-id: demo-request-1\"");
+    Console.WriteLine("  # --globoff stops curl from treating filter[status] as URL range/glob syntax.");
+    Console.WriteLine($"  curl --globoff \"{baseUrl}/pets?limit=2&filter[status]=available&tags=dog\" -H \"x-request-id: demo-request-1\"");
     Console.WriteLine($"  curl -N \"{baseUrl}/pets/1/activity\" -H \"Accept: application/x-ndjson\"");
     Console.WriteLine($"  curl -N -X POST \"{baseUrl}/pets/1/chat\" -H \"Accept: text/event-stream\" -H \"Content-Type: application/json\" -H \"Cookie: session_token=admin-token-123\" -d \"{{\\\"message\\\":\\\"Bella is coughing. What should I do?\\\"}}\"");
     Console.WriteLine();

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Properties/launchSettings.json
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "OpenApiAdvancedServer": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/README.md
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/README.md
@@ -158,6 +158,14 @@ dotnet run
 
 The launch profile does not open a browser. The server writes its actual base URL, sample `curl` commands, request summaries, and handler activity to the console. Pair with [031-OpenApiAdvancedClient](../031-OpenApiAdvancedClient/) to exercise the full flow.
 
+For deep-object query examples such as `filter[status]=available`, pass `--globoff` to curl:
+
+```bash
+curl --globoff "http://localhost:50516/pets?limit=2&filter[status]=available&tags=dog" -H "x-request-id: demo-request-1"
+```
+
+curl treats square brackets in URLs as range/glob syntax unless globbing is disabled. Encoding the brackets as `filter%5Bstatus%5D=available` is also valid, but `--globoff` keeps the OpenAPI deep-object parameter shape visible in the sample.
+
 ## Project Structure
 
 ```

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/README.md
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/README.md
@@ -156,7 +156,7 @@ dotnet build
 dotnet run
 ```
 
-The server starts on the default Kestrel port. Pair with [031-OpenApiAdvancedClient](../031-OpenApiAdvancedClient/) to exercise the full flow.
+The launch profile does not open a browser. The server writes its actual base URL, sample `curl` commands, request summaries, and handler activity to the console. Pair with [031-OpenApiAdvancedClient](../031-OpenApiAdvancedClient/) to exercise the full flow.
 
 ## Project Structure
 

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/README.md
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/README.md
@@ -119,15 +119,25 @@ return ListPetsResult.Ok(
 
 ### Streaming Responses (SSE/NDJSON)
 
-For streaming operations, return `Ok()` to signal success. The endpoint registration handles the streaming envelope:
+For streaming operations, return `Ok(...)` with a generated writer callback. The endpoint registration keeps the HTTP response body open while the callback runs and applies the media framing for each item:
 
 ```csharp
-// SSE: generated code writes "data: {...}\n\n" for each item
-return ValueTask.FromResult(StartVetChatResult.Ok());
+// SSE: generated code writes "data: {...}\n\n" for each appended item
+return new(StartVetChatResult.Ok(static async (stream, cancellationToken) =>
+{
+    ChatChunk chunk = ChatChunk.ParseValue("""{"delta":"Hello!","done":true}"""u8);
+    await stream.AppendChatChunk(chunk, cancellationToken);
+}));
 
-// NDJSON: generated code writes "{...}\n" for each item
-return ValueTask.FromResult(StreamPetActivityResult.Ok());
+// NDJSON: generated code writes "{...}\n" for each appended item
+return new(StreamPetActivityResult.Ok(static async (stream, cancellationToken) =>
+{
+    ActivityEvent activity = ActivityEvent.ParseValue("""{"eventId":"evt-1","timestamp":"2026-05-30T18:00:00Z","type":"check-in","description":"Bella checked in"}"""u8);
+    await stream.AppendActivityEvent(activity, cancellationToken);
+}));
 ```
+
+SSE completion is implicit. When the callback returns, the generated endpoint flushes and completes the HTTP response; no `End*` call is generated or needed.
 
 ### Form Body Access
 
@@ -175,5 +185,5 @@ The server starts on the default Kestrel port. Pair with [031-OpenApiAdvancedCli
 | You write | Call methods, handle responses | Implement interfaces, return results |
 | Parameters | You build Sources with typed builders | You read typed properties from Params |
 | Responses | Use `MatchResult()` exhaustively | Return factory methods (Ok, Created, etc.) |
-| Streaming | `await foreach` over `EnumerateOkItems()` | Return `Ok()`, infrastructure streams |
+| Streaming | `await foreach` over `EnumerateOkItems()` | Return `Ok(...)` with a writer callback |
 | Auth | Pass cookie as a parameter | Read cookie from Params, validate |

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/ApiEndpointRegistration.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/ApiEndpointRegistration.cs
@@ -678,7 +678,23 @@ public static class ApiEndpointRegistration
                 }
 
                 context.Response.StatusCode = result.StatusCode;
-                if (!result.Body.IsUndefined())
+                if (result.HasStreamingBody)
+                {
+                    context.Response.ContentType = result.ContentType!;
+                    Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);
+                    try
+                    {
+                        JsonStreamWriter streamWriter = new(context.Response.BodyWriter, writer, result.ContentType!);
+                        await result.WriteStreamAsync(streamWriter, context.RequestAborted).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        workspace.ReturnWriter(writer);
+                    }
+
+                    await context.Response.BodyWriter.FlushAsync(context.RequestAborted).ConfigureAwait(false);
+                }
+                else if (!result.Body.IsUndefined())
                 {
                     context.Response.ContentType = result.ContentType ?? "application/json";
                     Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);
@@ -763,7 +779,23 @@ public static class ApiEndpointRegistration
                 }
 
                 context.Response.StatusCode = result.StatusCode;
-                if (!result.Body.IsUndefined())
+                if (result.HasStreamingBody)
+                {
+                    context.Response.ContentType = result.ContentType!;
+                    Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);
+                    try
+                    {
+                        JsonStreamWriter streamWriter = new(context.Response.BodyWriter, writer, result.ContentType!);
+                        await result.WriteStreamAsync(streamWriter, context.RequestAborted).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        workspace.ReturnWriter(writer);
+                    }
+
+                    await context.Response.BodyWriter.FlushAsync(context.RequestAborted).ConfigureAwait(false);
+                }
+                else if (!result.Body.IsUndefined())
                 {
                     context.Response.ContentType = result.ContentType ?? "application/json";
                     Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/CreatePetResult.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/CreatePetResult.cs
@@ -41,7 +41,7 @@ public readonly struct CreatePetResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="CreatePetResult"/> with status 201.</returns>
-    public static CreatePetResult Created(Petstore.EndToEnd.Server.Pet.Source body, JsonWorkspace workspace) => new(201, Petstore.EndToEnd.Server.Pet.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static CreatePetResult Created(Petstore.EndToEnd.Server.Pet.Source body, JsonWorkspace workspace) => new(201, Petstore.EndToEnd.Server.Pet.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a 401 Unauthorized result.
@@ -49,7 +49,7 @@ public readonly struct CreatePetResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="CreatePetResult"/> with status 401.</returns>
-    public static CreatePetResult Unauthorized(Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static CreatePetResult Unauthorized(Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a default error result.
@@ -58,7 +58,7 @@ public readonly struct CreatePetResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="CreatePetResult"/> with status default.</returns>
-    public static CreatePetResult Default(int statusCode, Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static CreatePetResult Default(int statusCode, Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/DownloadPhotoResult.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/DownloadPhotoResult.cs
@@ -47,7 +47,7 @@ public readonly struct DownloadPhotoResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="DownloadPhotoResult"/> with status 404.</returns>
-    public static DownloadPhotoResult NotFound(Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(404, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static DownloadPhotoResult NotFound(Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(404, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/GetPetsBatchResult.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/GetPetsBatchResult.cs
@@ -41,7 +41,7 @@ public readonly struct GetPetsBatchResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="GetPetsBatchResult"/> with status 200.</returns>
-    public static GetPetsBatchResult Ok(Petstore.EndToEnd.Server.PetList.Source body, JsonWorkspace workspace) => new(200, Petstore.EndToEnd.Server.PetList.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static GetPetsBatchResult Ok(Petstore.EndToEnd.Server.PetList.Source body, JsonWorkspace workspace) => new(200, Petstore.EndToEnd.Server.PetList.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/ListPetsResult.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/ListPetsResult.cs
@@ -55,7 +55,7 @@ public readonly struct ListPetsResult
     /// <param name="xTotalCount">The value for the <c>x-total-count</c> response header.</param>
     /// <param name="xNext">The value for the <c>x-next</c> response header.</param>
     /// <returns>A <see cref="ListPetsResult"/> with status 200.</returns>
-    public static ListPetsResult Ok(Petstore.EndToEnd.Server.PetList.Source body, JsonWorkspace workspace, Petstore.EndToEnd.Server.JsonInteger xTotalCount = default, Petstore.EndToEnd.Server.JsonString xNext = default) => new(200, Petstore.EndToEnd.Server.PetList.CreateBuilder(workspace, body).RootElement, "application/json", xTotalCount: xTotalCount, xNext: xNext);
+    public static ListPetsResult Ok(Petstore.EndToEnd.Server.PetList.Source body, JsonWorkspace workspace, Petstore.EndToEnd.Server.JsonInteger xTotalCount = default, Petstore.EndToEnd.Server.JsonString xNext = default) => new(200, Petstore.EndToEnd.Server.PetList.CreateBuilder(workspace, body, 30).RootElement, "application/json", xTotalCount: xTotalCount, xNext: xNext);
 
     /// <summary>
     /// Creates a default error result.
@@ -64,7 +64,7 @@ public readonly struct ListPetsResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="ListPetsResult"/> with status default.</returns>
-    public static ListPetsResult Default(int statusCode, Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static ListPetsResult Default(int statusCode, Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonDateTime.Mutable.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonDateTime.Mutable.cs
@@ -499,7 +499,7 @@ public readonly partial struct JsonDateTime
 
         private Source(NodaTime.OffsetDateTime value) { SimpleTypesBacking.Initialize(ref _simpleTypeBacking, value, static (v, buffer, out written) => JsonElementHelpers.TryFormatOffsetDateTime(v, buffer, out written)); _kind = Kind.StringSimpleType; }
 
-        private Source(DateTimeOffset value) { SimpleTypesBacking.Initialize(ref _simpleTypeBacking, value, static (v, buffer, out written) => Utf8Formatter.TryFormat(v, buffer, out written)); _kind = Kind.StringSimpleType; }
+        private Source(DateTimeOffset value) { SimpleTypesBacking.Initialize(ref _simpleTypeBacking, value, static (v, buffer, out written) => Utf8Formatter.TryFormat(v, buffer, out written, 'O')); _kind = Kind.StringSimpleType; }
 
         public static implicit operator Source(JsonDateTime instance) => new(JsonElement.From(instance));
 
@@ -514,6 +514,9 @@ public readonly partial struct JsonDateTime
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static implicit operator Source(NodaTime.OffsetDateTime value) => new (value);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator Source(DateTimeOffset value) => new (value);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static Source RawString(ReadOnlySpan<byte> value, bool requiresUnescaping) => new(value, requiresUnescaping);

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/ShowPetByIdResult.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/ShowPetByIdResult.cs
@@ -41,7 +41,7 @@ public readonly struct ShowPetByIdResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="ShowPetByIdResult"/> with status 200.</returns>
-    public static ShowPetByIdResult Ok(Petstore.EndToEnd.Server.Pet.Source body, JsonWorkspace workspace) => new(200, Petstore.EndToEnd.Server.Pet.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static ShowPetByIdResult Ok(Petstore.EndToEnd.Server.Pet.Source body, JsonWorkspace workspace) => new(200, Petstore.EndToEnd.Server.Pet.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a 404 NotFound result.
@@ -49,7 +49,7 @@ public readonly struct ShowPetByIdResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="ShowPetByIdResult"/> with status 404.</returns>
-    public static ShowPetByIdResult NotFound(Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(404, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static ShowPetByIdResult NotFound(Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(404, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/StartVetChatResult.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/StartVetChatResult.cs
@@ -19,12 +19,17 @@ namespace Petstore.EndToEnd.Server;
 /// </summary>
 public readonly struct StartVetChatResult
 {
-    private StartVetChatResult(int statusCode, JsonElement body = default, string? contentType = null)
+    private StartVetChatResult(int statusCode, JsonElement body = default, string? contentType = null, StartVetChatStreamWriterInvoker? streamWriter = null, object? streamWriterContext = null)
     {
         this.StatusCode = statusCode;
         this.Body = body;
         this.ContentType = contentType;
+        this.streamWriter = streamWriter;
+        this.streamWriterContext = streamWriterContext;
     }
+
+    private readonly StartVetChatStreamWriterInvoker? streamWriter;
+    private readonly object? streamWriterContext;
 
     /// <summary>Gets the HTTP status code.</summary>
     public int StatusCode { get; }
@@ -35,11 +40,26 @@ public readonly struct StartVetChatResult
     /// <summary>Gets the content type for the response body.</summary>
     public string? ContentType { get; }
 
+    /// <summary>Gets a value indicating whether this result has a streaming response body.</summary>
+    public bool HasStreamingBody => this.streamWriter is not null;
+
     /// <summary>
     /// Creates a 200 Ok result.
     /// </summary>
+    /// <param name="writer">The callback that appends items to the <see cref="StartVetChatStream"/>.</param>
     /// <returns>A <see cref="StartVetChatResult"/> with status 200.</returns>
-    public static StartVetChatResult Ok() => new(200, default, null);
+    public static StartVetChatResult Ok(StartVetChatStreamWriter writer) => new(200, default, "text/event-stream", streamWriter: static (jsonStreamWriter, context, cancellationToken) => ((StartVetChatStreamWriter)context!)(new StartVetChatStream(jsonStreamWriter), cancellationToken), streamWriterContext: writer);
+
+    /// <typeparam name="TContext">The callback context type.</typeparam>
+    /// <param name="context">The callback context.</param>
+    /// <param name="writer">The callback that appends items to the <see cref="StartVetChatStream"/>.</param>
+    /// <returns>A <see cref="StartVetChatResult"/> with status 200.</returns>
+    public static StartVetChatResult Ok<TContext>(TContext context, StartVetChatStreamWriter<TContext> writer) => new(200, default, "text/event-stream", streamWriter: static (jsonStreamWriter, context, cancellationToken) =>
+        {
+            var wrapper = (StartVetChatStreamWriterContext<TContext>)context!;
+            return wrapper.Writer(new StartVetChatStream(jsonStreamWriter), wrapper.Context, cancellationToken);
+        },
+        streamWriterContext: new StartVetChatStreamWriterContext<TContext>(context, writer));
 
     /// <summary>
     /// Creates a 401 Unauthorized result.
@@ -47,7 +67,7 @@ public readonly struct StartVetChatResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="StartVetChatResult"/> with status 401.</returns>
-    public static StartVetChatResult Unauthorized(Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static StartVetChatResult Unauthorized(Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.
@@ -74,4 +94,87 @@ public readonly struct StartVetChatResult
             this.Body.WriteTo(writer);
         }
     }
+
+    /// <summary>
+    /// Writes the streaming response body.
+    /// </summary>
+    /// <param name="writer">The stream writer.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the stream has been written.</returns>
+    public ValueTask WriteStreamAsync(JsonStreamWriter writer, CancellationToken cancellationToken = default)
+    {
+        return this.streamWriter is null
+            ? ValueTask.CompletedTask
+            : this.streamWriter(writer, this.streamWriterContext, cancellationToken);
+    }
+
+    private delegate ValueTask StartVetChatStreamWriterInvoker(JsonStreamWriter writer, object? context, CancellationToken cancellationToken);
+
+    private sealed class StartVetChatStreamWriterContext<TContext>
+    {
+        public StartVetChatStreamWriterContext(TContext context, StartVetChatStreamWriter<TContext> writer)
+        {
+            this.Context = context;
+            this.Writer = writer;
+        }
+
+        public TContext Context { get; }
+
+        public StartVetChatStreamWriter<TContext> Writer { get; }
+    }
 }
+
+/// <summary>
+/// Writes items for the StartVetChat streaming response.
+/// </summary>
+public readonly struct StartVetChatStream
+{
+    private readonly JsonStreamWriter writer;
+
+    internal StartVetChatStream(JsonStreamWriter writer)
+    {
+        this.writer = writer;
+    }
+
+    /// <summary>
+    /// Appends a <see cref="Petstore.EndToEnd.Server.ChatChunk"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendChatChunk(in Petstore.EndToEnd.Server.ChatChunk.Source item, CancellationToken cancellationToken = default)
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+        using JsonDocumentBuilder<Petstore.EndToEnd.Server.ChatChunk.Mutable> builder = Petstore.EndToEnd.Server.ChatChunk.CreateBuilder(workspace, item);
+        return this.writer.WriteItemAsync(builder.RootElement, cancellationToken);
+    }
+
+    /// <summary>
+    /// Appends a <see cref="Petstore.EndToEnd.Server.ChatChunk"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendChatChunk(Petstore.EndToEnd.Server.ChatChunk item, CancellationToken cancellationToken = default)
+    {
+        return this.writer.WriteItemAsync(item, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Callback used to write a StartVetChatStream response.
+/// </summary>
+/// <param name="stream">The StartVetChatStream writer.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask StartVetChatStreamWriter(StartVetChatStream stream, CancellationToken cancellationToken);
+
+/// <summary>
+/// Callback used to write a StartVetChatStream response with a context value.
+/// </summary>
+/// <typeparam name="TContext">The callback context type.</typeparam>
+/// <param name="stream">The StartVetChatStream writer.</param>
+/// <param name="context">The callback context.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask StartVetChatStreamWriter<TContext>(StartVetChatStream stream, TContext context, CancellationToken cancellationToken);

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/StreamPetActivityResult.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/StreamPetActivityResult.cs
@@ -19,12 +19,17 @@ namespace Petstore.EndToEnd.Server;
 /// </summary>
 public readonly struct StreamPetActivityResult
 {
-    private StreamPetActivityResult(int statusCode, JsonElement body = default, string? contentType = null)
+    private StreamPetActivityResult(int statusCode, JsonElement body = default, string? contentType = null, StreamPetActivityStreamWriterInvoker? streamWriter = null, object? streamWriterContext = null)
     {
         this.StatusCode = statusCode;
         this.Body = body;
         this.ContentType = contentType;
+        this.streamWriter = streamWriter;
+        this.streamWriterContext = streamWriterContext;
     }
+
+    private readonly StreamPetActivityStreamWriterInvoker? streamWriter;
+    private readonly object? streamWriterContext;
 
     /// <summary>Gets the HTTP status code.</summary>
     public int StatusCode { get; }
@@ -35,11 +40,26 @@ public readonly struct StreamPetActivityResult
     /// <summary>Gets the content type for the response body.</summary>
     public string? ContentType { get; }
 
+    /// <summary>Gets a value indicating whether this result has a streaming response body.</summary>
+    public bool HasStreamingBody => this.streamWriter is not null;
+
     /// <summary>
     /// Creates a 200 Ok result.
     /// </summary>
+    /// <param name="writer">The callback that appends items to the <see cref="StreamPetActivityStream"/>.</param>
     /// <returns>A <see cref="StreamPetActivityResult"/> with status 200.</returns>
-    public static StreamPetActivityResult Ok() => new(200, default, null);
+    public static StreamPetActivityResult Ok(StreamPetActivityStreamWriter writer) => new(200, default, "application/x-ndjson", streamWriter: static (jsonStreamWriter, context, cancellationToken) => ((StreamPetActivityStreamWriter)context!)(new StreamPetActivityStream(jsonStreamWriter), cancellationToken), streamWriterContext: writer);
+
+    /// <typeparam name="TContext">The callback context type.</typeparam>
+    /// <param name="context">The callback context.</param>
+    /// <param name="writer">The callback that appends items to the <see cref="StreamPetActivityStream"/>.</param>
+    /// <returns>A <see cref="StreamPetActivityResult"/> with status 200.</returns>
+    public static StreamPetActivityResult Ok<TContext>(TContext context, StreamPetActivityStreamWriter<TContext> writer) => new(200, default, "application/x-ndjson", streamWriter: static (jsonStreamWriter, context, cancellationToken) =>
+        {
+            var wrapper = (StreamPetActivityStreamWriterContext<TContext>)context!;
+            return wrapper.Writer(new StreamPetActivityStream(jsonStreamWriter), wrapper.Context, cancellationToken);
+        },
+        streamWriterContext: new StreamPetActivityStreamWriterContext<TContext>(context, writer));
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.
@@ -62,4 +82,87 @@ public readonly struct StreamPetActivityResult
             this.Body.WriteTo(writer);
         }
     }
+
+    /// <summary>
+    /// Writes the streaming response body.
+    /// </summary>
+    /// <param name="writer">The stream writer.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the stream has been written.</returns>
+    public ValueTask WriteStreamAsync(JsonStreamWriter writer, CancellationToken cancellationToken = default)
+    {
+        return this.streamWriter is null
+            ? ValueTask.CompletedTask
+            : this.streamWriter(writer, this.streamWriterContext, cancellationToken);
+    }
+
+    private delegate ValueTask StreamPetActivityStreamWriterInvoker(JsonStreamWriter writer, object? context, CancellationToken cancellationToken);
+
+    private sealed class StreamPetActivityStreamWriterContext<TContext>
+    {
+        public StreamPetActivityStreamWriterContext(TContext context, StreamPetActivityStreamWriter<TContext> writer)
+        {
+            this.Context = context;
+            this.Writer = writer;
+        }
+
+        public TContext Context { get; }
+
+        public StreamPetActivityStreamWriter<TContext> Writer { get; }
+    }
 }
+
+/// <summary>
+/// Writes items for the StreamPetActivity streaming response.
+/// </summary>
+public readonly struct StreamPetActivityStream
+{
+    private readonly JsonStreamWriter writer;
+
+    internal StreamPetActivityStream(JsonStreamWriter writer)
+    {
+        this.writer = writer;
+    }
+
+    /// <summary>
+    /// Appends a <see cref="Petstore.EndToEnd.Server.ActivityEvent"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendActivityEvent(in Petstore.EndToEnd.Server.ActivityEvent.Source item, CancellationToken cancellationToken = default)
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+        using JsonDocumentBuilder<Petstore.EndToEnd.Server.ActivityEvent.Mutable> builder = Petstore.EndToEnd.Server.ActivityEvent.CreateBuilder(workspace, item);
+        return this.writer.WriteItemAsync(builder.RootElement, cancellationToken);
+    }
+
+    /// <summary>
+    /// Appends a <see cref="Petstore.EndToEnd.Server.ActivityEvent"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendActivityEvent(Petstore.EndToEnd.Server.ActivityEvent item, CancellationToken cancellationToken = default)
+    {
+        return this.writer.WriteItemAsync(item, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Callback used to write a StreamPetActivityStream response.
+/// </summary>
+/// <param name="stream">The StreamPetActivityStream writer.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask StreamPetActivityStreamWriter(StreamPetActivityStream stream, CancellationToken cancellationToken);
+
+/// <summary>
+/// Callback used to write a StreamPetActivityStream response with a context value.
+/// </summary>
+/// <typeparam name="TContext">The callback context type.</typeparam>
+/// <param name="stream">The StreamPetActivityStream writer.</param>
+/// <param name="context">The callback context.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask StreamPetActivityStreamWriter<TContext>(StreamPetActivityStream stream, TContext context, CancellationToken cancellationToken);

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/SubmitAdoptionApplicationResult.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/SubmitAdoptionApplicationResult.cs
@@ -41,7 +41,7 @@ public readonly struct SubmitAdoptionApplicationResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="SubmitAdoptionApplicationResult"/> with status 202.</returns>
-    public static SubmitAdoptionApplicationResult Accepted(Petstore.EndToEnd.Server.PostAdoptionApplyAccepted.Source body, JsonWorkspace workspace) => new(202, Petstore.EndToEnd.Server.PostAdoptionApplyAccepted.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static SubmitAdoptionApplicationResult Accepted(Petstore.EndToEnd.Server.PostAdoptionApplyAccepted.Source body, JsonWorkspace workspace) => new(202, Petstore.EndToEnd.Server.PostAdoptionApplyAccepted.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a default error result.
@@ -50,7 +50,7 @@ public readonly struct SubmitAdoptionApplicationResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="SubmitAdoptionApplicationResult"/> with status default.</returns>
-    public static SubmitAdoptionApplicationResult Default(int statusCode, Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static SubmitAdoptionApplicationResult Default(int statusCode, Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(statusCode, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/UploadPetPhotoResult.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/UploadPetPhotoResult.cs
@@ -41,7 +41,7 @@ public readonly struct UploadPetPhotoResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="UploadPetPhotoResult"/> with status 201.</returns>
-    public static UploadPetPhotoResult Created(Petstore.EndToEnd.Server.PhotoMetadata.Source body, JsonWorkspace workspace) => new(201, Petstore.EndToEnd.Server.PhotoMetadata.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static UploadPetPhotoResult Created(Petstore.EndToEnd.Server.PhotoMetadata.Source body, JsonWorkspace workspace) => new(201, Petstore.EndToEnd.Server.PhotoMetadata.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Creates a 401 Unauthorized result.
@@ -49,7 +49,7 @@ public readonly struct UploadPetPhotoResult
     /// <param name="body">The response body.</param>
     /// <param name="workspace">The workspace for building the response value.</param>
     /// <returns>A <see cref="UploadPetPhotoResult"/> with status 401.</returns>
-    public static UploadPetPhotoResult Unauthorized(Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body).RootElement, "application/json");
+    public static UploadPetPhotoResult Unauthorized(Petstore.EndToEnd.Server.Error.Source body, JsonWorkspace workspace) => new(401, Petstore.EndToEnd.Server.Error.CreateBuilder(workspace, body, 30).RootElement, "application/json");
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Program.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Program.cs
@@ -58,6 +58,7 @@ using HttpClient httpClient = new() { BaseAddress = new Uri(serverUrl) };
 await using HttpClientTransport transport = new(httpClient);
 await using ApiPetsClient petsClient = new(transport);
 await using ApiAdoptionClient adoptionClient = new(transport);
+await using ApiChatClient chatClient = new(transport);
 
 // ════════════════════════════════════════════════════════════════════
 // SCENARIO 1: Create a pet (with cookie authentication)
@@ -252,13 +253,87 @@ await using (SubmitAdoptionApplicationResponse adoptionResponse = await adoption
 Console.WriteLine();
 
 // ════════════════════════════════════════════════════════════════════
-// SCENARIO 6: Validation failure — missing required header
+// SCENARIO 6: Streaming responses — SSE and NDJSON
+// ════════════════════════════════════════════════════════════════════
+// Demonstrates both streaming media types generated from OpenAPI
+// itemSchema responses. The SSE response is read item-by-item by the
+// generated client, and the NDJSON response is read line-by-line.
+
+Console.WriteLine("━━━ Scenario 6: Streaming responses (SSE + NDJSON) ━━━");
+Console.WriteLine("  → POST /pets/pet-1/chat  (Accept: text/event-stream)");
+
+await using (StartVetChatResponse chatResponse = await chatClient.StartVetChatAsync(
+    petId: "pet-1"u8,
+    session_token: "admin-token-123"u8,
+    body: new Petstore.EndToEnd.Client.PostPetsByPetIdChatBody.Source(
+        static (ref Petstore.EndToEnd.Client.PostPetsByPetIdChatBody.Builder b) =>
+            b.Create(message: "Bella has been coughing since this morning. What should I do?"u8))))
+{
+    Console.WriteLine($"  ← {chatResponse.StatusCode} text/event-stream");
+
+    if (chatResponse.StatusCode == 200)
+    {
+        int chunkNumber = 0;
+        await foreach (ParsedJsonDocument<Petstore.EndToEnd.Client.ChatChunk> chunkDocument in chatResponse.EnumerateOkItems())
+        {
+            using (chunkDocument)
+            {
+                Petstore.EndToEnd.Client.ChatChunk chunk = chunkDocument.RootElement;
+                Console.WriteLine($"     SSE chunk {++chunkNumber}: id={chunk.Id}, delta={chunk.Delta}, done={chunk.Done}");
+            }
+        }
+    }
+    else
+    {
+        chatResponse.MatchResult<bool>(
+            matchUnauthorized: static (error) =>
+            {
+                Console.WriteLine($"     Unauthorized: {error}");
+                return false;
+            },
+            matchDefault: static (statusCode) =>
+            {
+                Console.WriteLine($"     Unexpected status: {statusCode}");
+                return false;
+            });
+    }
+}
+
+Console.WriteLine("  → GET /pets/pet-1/activity  (Accept: application/x-ndjson)");
+
+await using (StreamPetActivityResponse activityResponse = await chatClient.StreamPetActivityAsync(
+    petId: "pet-1"u8))
+{
+    Console.WriteLine($"  ← {activityResponse.StatusCode} application/x-ndjson");
+
+    if (activityResponse.StatusCode == 200)
+    {
+        int eventNumber = 0;
+        await foreach (ParsedJsonDocument<Petstore.EndToEnd.Client.ActivityEvent> activityDocument in activityResponse.EnumerateOkItems())
+        {
+            using (activityDocument)
+            {
+                Petstore.EndToEnd.Client.ActivityEvent activity = activityDocument.RootElement;
+                Console.WriteLine($"     NDJSON event {++eventNumber}: {activity.EventId} [{activity.Type}] {activity.Description} at {activity.Timestamp}");
+            }
+        }
+    }
+    else
+    {
+        Console.WriteLine($"     Unexpected status: {activityResponse.StatusCode}");
+    }
+}
+
+Console.WriteLine();
+
+// ════════════════════════════════════════════════════════════════════
+// SCENARIO 7: Validation failure — missing required header
 // ════════════════════════════════════════════════════════════════════
 // The generated server validates that x-request-id is required.
 // Calling without it triggers a 400 with a ProblemDetails body.
 // We bypass the client validation to demonstrate server-side enforcement.
 
-Console.WriteLine("━━━ Scenario 6: Server-side validation (missing required header) ━━━");
+Console.WriteLine("━━━ Scenario 7: Server-side validation (missing required header) ━━━");
 Console.WriteLine("  → GET /pets  (no x-request-id header)");
 
 // Use raw HttpClient to bypass client-side validation
@@ -272,11 +347,11 @@ using (HttpResponseMessage rawResponse = await httpClient.GetAsync("/pets"))
 Console.WriteLine();
 
 // ════════════════════════════════════════════════════════════════════
-// SCENARIO 7: Create without cookie (server rejects)
+// SCENARIO 8: Create without cookie (server rejects)
 // ════════════════════════════════════════════════════════════════════
 // The server validates that session_token cookie is required.
 
-Console.WriteLine("━━━ Scenario 7: Server-side validation (missing cookie) ━━━");
+Console.WriteLine("━━━ Scenario 8: Server-side validation (missing cookie) ━━━");
 Console.WriteLine("  → POST /pets  (no session_token cookie)");
 
 using (HttpRequestMessage postRequest = new(HttpMethod.Post, "/pets"))
@@ -481,18 +556,33 @@ internal sealed class PetstoreHandler
     public ValueTask<StartVetChatResult> HandleStartVetChatAsync(
         StartVetChatParams parameters, JsonWorkspace workspace, CancellationToken cancellationToken)
     {
-        return new(StartVetChatResult.Unauthorized(
-            body: new Petstore.EndToEnd.Server.Error.Source(
-                static (ref Petstore.EndToEnd.Server.Error.Builder eb) =>
-                    eb.Create(code: 401, message: "Authentication required"u8)),
-            workspace: workspace));
+        Console.WriteLine("       [Server] HandleStartVetChatAsync called");
+        Console.WriteLine($"       [Server]   petId = {parameters.PetId}");
+        Console.WriteLine($"       [Server]   session_token = {parameters.SessionToken}");
+        Console.WriteLine($"       [Server]   body = {parameters.Body}");
+
+        return new(StartVetChatResult.Ok(static async (stream, cancellationToken) =>
+        {
+            Console.WriteLine("       [Server]   → streaming 2 SSE chat chunks");
+
+            Petstore.EndToEnd.Server.ChatChunk greeting = Petstore.EndToEnd.Server.ChatChunk.ParseValue("""{"id":"chunk-1","delta":"Thanks for the update about Bella. ","done":false}"""u8);
+            await stream.AppendChatChunk(greeting, cancellationToken).ConfigureAwait(false);
+
+            Petstore.EndToEnd.Server.ChatChunk advice = Petstore.EndToEnd.Server.ChatChunk.ParseValue("""{"id":"chunk-2","delta":"Please keep her calm and call the clinic if breathing becomes laboured.","done":true}"""u8);
+            await stream.AppendChatChunk(advice, cancellationToken).ConfigureAwait(false);
+        }));
     }
 
     public ValueTask<StreamPetActivityResult> HandleStreamPetActivityAsync(
         StreamPetActivityParams parameters, JsonWorkspace workspace, CancellationToken cancellationToken)
     {
+        Console.WriteLine("       [Server] HandleStreamPetActivityAsync called");
+        Console.WriteLine($"       [Server]   petId = {parameters.PetId}");
+
         return new(StreamPetActivityResult.Ok(static async (stream, cancellationToken) =>
         {
+            Console.WriteLine("       [Server]   → streaming 2 NDJSON activity events");
+
             Petstore.EndToEnd.Server.ActivityEvent checkIn = Petstore.EndToEnd.Server.ActivityEvent.ParseValue("""{"eventId":"evt-1","timestamp":"2026-05-30T18:00:00Z","type":"check-in","description":"Bella checked in at reception"}"""u8);
             await stream.AppendActivityEvent(checkIn, cancellationToken).ConfigureAwait(false);
 

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Program.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Program.cs
@@ -491,7 +491,14 @@ internal sealed class PetstoreHandler
     public ValueTask<StreamPetActivityResult> HandleStreamPetActivityAsync(
         StreamPetActivityParams parameters, JsonWorkspace workspace, CancellationToken cancellationToken)
     {
-        return new(StreamPetActivityResult.Ok());
+        return new(StreamPetActivityResult.Ok(static async (stream, cancellationToken) =>
+        {
+            Petstore.EndToEnd.Server.ActivityEvent checkIn = Petstore.EndToEnd.Server.ActivityEvent.ParseValue("""{"eventId":"evt-1","timestamp":"2026-05-30T18:00:00Z","type":"check-in","description":"Bella checked in at reception"}"""u8);
+            await stream.AppendActivityEvent(checkIn, cancellationToken).ConfigureAwait(false);
+
+            Petstore.EndToEnd.Server.ActivityEvent exam = Petstore.EndToEnd.Server.ActivityEvent.ParseValue("""{"eventId":"evt-2","timestamp":"2026-05-30T18:05:00Z","type":"exam","description":"Initial examination started"}"""u8);
+            await stream.AppendActivityEvent(exam, cancellationToken).ConfigureAwait(false);
+        }));
     }
 
     // ─── Adoption ───────────────────────────────────────────────────

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Properties/launchSettings.json
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "OpenApiEndToEnd": {
       "commandName": "Project",
-      "launchBrowser": true,
+      "launchBrowser": false,
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       },

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/README.md
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/README.md
@@ -14,7 +14,8 @@ generated from the same OpenAPI specification.
 | Client-side request building and serialization | Generated `ApiPetsClient`, `ApiAdoptionClient` |
 | Client-side typed response parsing with `MatchResult()` | Response dispatch |
 | Form URL-encoded request/response round-trip | Scenario 5 |
-| ProblemDetails error responses for validation failures | Scenarios 6–7 |
+| Streaming SSE and NDJSON responses | Scenario 6 |
+| ProblemDetails error responses for validation failures | Scenarios 7–8 |
 
 ## Running It
 
@@ -22,7 +23,7 @@ generated from the same OpenAPI specification.
 dotnet run --project docs/ExampleRecipes/033-OpenApiEndToEnd
 ```
 
-The application starts an ASP.NET server on a random port, runs 7 scenarios, and exits.
+The application starts an ASP.NET server on a random port, runs 8 scenarios, writes the generated client/server round-trip to the console, and exits. The launch profile is configured not to open a browser because the sample is a console-driven walkthrough.
 
 ## How It Works
 
@@ -72,8 +73,9 @@ response.MatchResult<string>(
 3. **Show pet by ID** — GET with path parameter → 200
 4. **Show non-existent pet** — GET → 404 typed error
 5. **Submit adoption** — POST with `application/x-www-form-urlencoded` → 202 JSON response
-6. **Missing required header** — Raw GET without `x-request-id` → 400 ProblemDetails
-7. **Missing cookie** — Raw POST without `session_token` → 400 ProblemDetails
+6. **Streaming responses** — Generated client reads SSE chat chunks and NDJSON activity events
+7. **Missing required header** — Raw GET without `x-request-id` → 400 ProblemDetails
+8. **Missing cookie** — Raw POST without `session_token` → 400 ProblemDetails
 
 ## Regenerating
 

--- a/docs/ExampleRecipes/037-AsyncApiConsumer/Program.cs
+++ b/docs/ExampleRecipes/037-AsyncApiConsumer/Program.cs
@@ -7,6 +7,10 @@ using Corvus.Text.Json.AsyncApi;
 using Corvus.Text.Json.AsyncApi.Testing;
 using Streetlights.Client;
 
+const string StreetlightId = "lamp-42";
+const string TelemetryChannelTemplate = "smartylighting.streetlights.1.0.action.{streetlightId}.lighting.measured";
+string exampleBrokerChannel = $"smartylighting.streetlights.1.0.action.{StreetlightId}.lighting.measured";
+
 // ── Setting up the transport ─────────────────────────────────────────────────
 await using InMemoryMessageTransport transport = new();
 
@@ -32,14 +36,29 @@ ReceiveLightMeasurementConsumer consumer = new(
 await consumer.StartAsync();
 Console.WriteLine("Consumer started, waiting for messages...");
 
-// ── Publishing a message ─────────────────────────────────────────────────────
-// InMemoryMessageTransport automatically delivers published messages to active
-// subscribers — just like a real broker (Kafka/NATS/MQTT). No manual delivery needed.
+// ── Simulating telemetry arriving from a streetlight ─────────────────────────
+// A real consumer would not write directly to its transport. The streetlight
+// device, or a telemetry gateway in front of it, would publish to a concrete
+// broker channel such as:
+Console.WriteLine($"Simulating telemetry from {StreetlightId} on {exampleBrokerChannel}");
+//
+// In this recipe there is no external Kafka/NATS/MQTT broker, so the
+// InMemoryMessageTransport acts as the broker and test harness. Publishing to it
+// simulates the external telemetry arriving and automatically delivers the
+// message to active subscribers.
+//
+// The generated consumer subscribes to the AsyncAPI channel address template:
+//   smartylighting.streetlights.1.0.action.{streetlightId}.lighting.measured
+// The {streetlightId} segment is a template parameter from the AsyncAPI
+// document. It is not the literal channel a physical streetlight would publish
+// to; the concrete broker channel would contain an actual ID such as lamp-42.
+// The in-memory testing transport uses exact string matching, so this sample
+// publishes to the same template key the generated consumer subscribed to.
 using ParsedJsonDocument<LightMeasuredPayload> measurement = ParsedJsonDocument<LightMeasuredPayload>.Parse(
     """{"lumens":512,"sentAt":"2026-05-25T10:30:00Z"}"""u8.ToArray());
 
 await transport.PublishAsync(
-    System.Text.Encoding.UTF8.GetBytes("smartylighting.streetlights.1.0.action.{streetlightId}.lighting.measured"),
+    System.Text.Encoding.UTF8.GetBytes(TelemetryChannelTemplate),
     measurement.RootElement);
 
 Console.WriteLine($"Handler received {handler.ReceivedCount} message(s)");
@@ -50,7 +69,7 @@ using ParsedJsonDocument<LightMeasuredPayload> measurement2 = ParsedJsonDocument
     """{"lumens":2048,"sentAt":"2026-05-25T10:31:00Z"}"""u8.ToArray());
 
 await transport.PublishAsync(
-    System.Text.Encoding.UTF8.GetBytes("smartylighting.streetlights.1.0.action.{streetlightId}.lighting.measured"),
+    System.Text.Encoding.UTF8.GetBytes(TelemetryChannelTemplate),
     measurement2.RootElement);
 
 Console.WriteLine($"Handler received {handler.ReceivedCount} total message(s)");

--- a/docs/ExampleRecipes/037-AsyncApiConsumer/README.md
+++ b/docs/ExampleRecipes/037-AsyncApiConsumer/README.md
@@ -77,6 +77,10 @@ await consumer.StopAsync();     // Unsubscribe and clean up
 
 Unlike manual `DeliverAsync()` calls, `InMemoryMessageTransport.PublishAsync()` **automatically delivers** to active subscribers — just like a real broker (Kafka/NATS/MQTT). When you publish to a channel, any consumer subscribed to that channel immediately receives it.
 
+In a production consumer, your application would not normally publish directly to the same transport it consumes from. The physical streetlight, or a telemetry gateway representing it, would publish the measurement to the broker. This recipe writes to `InMemoryMessageTransport` only to simulate that external telemetry source in a self-contained console app.
+
+The AsyncAPI document defines the receive channel as the address template `smartylighting.streetlights.1.0.action.{streetlightId}.lighting.measured`. The `{streetlightId}` segment is a template parameter, not a literal broker channel. A real device would publish to a concrete channel such as `smartylighting.streetlights.1.0.action.lamp-42.lighting.measured`; the generated consumer subscribes using the template, and the in-memory testing transport uses exact string matching, so the sample publishes to that same template key to trigger the generated subscriber.
+
 ## Running
 
 ```bash
@@ -87,12 +91,13 @@ Expected output:
 
 ```text
 Consumer started, waiting for messages...
+Simulating telemetry from lamp-42 on smartylighting.streetlights.1.0.action.lamp-42.lighting.measured
   Received: lumens=512, sentAt=2026-05-25T10:30:00Z
 Handler received 1 message(s)
 Last lumens: 512
-  Error on smartylighting.streetlights.1.0.action.{streetlightId}.lighting.measured: ...
-After invalid: handler still has 1 message(s)
-Errors logged: 1
+  Received: lumens=2048, sentAt=2026-05-25T10:31:00Z
+Handler received 2 total message(s)
+Last lumens: 2048
 Consumer stopped
 ```
 

--- a/docs/ExampleRecipes/038-AsyncApiEndToEnd/Program.cs
+++ b/docs/ExampleRecipes/038-AsyncApiEndToEnd/Program.cs
@@ -9,13 +9,12 @@ using Corvus.Text.Json.AsyncApi.Testing;
 using Streetlights.Client;
 
 // ── End-to-end: Producer + Consumer with InMemoryMessageTransport ────────────
-// This example demonstrates a complete AsyncAPI workflow using InMemoryMessageTransport.
-// The transport automatically delivers published messages to matching subscribers,
-// simulating a real broker's behavior.
+// This example demonstrates the full publish -> transport -> consume pipeline
+// using InMemoryMessageTransport for testing without a real broker.
 
 await using InMemoryMessageTransport transport = new();
 
-// ── Set up the consumer (receives measurements from streetlights) ────────────
+// ── Set up the consumer side ─────────────────────────────────────────────────
 LightMeasurementHandler handler = new();
 ReceiveLightMeasurementConsumer consumer = new(
     transport,
@@ -24,64 +23,62 @@ ReceiveLightMeasurementConsumer consumer = new(
 
 await consumer.StartAsync();
 
-// ── Set up the producer (sends commands to streetlights) ─────────────────────
-TurnOnProducer commandProducer = new(transport, ValidationMode.Basic);
+// ── Set up the producer side ─────────────────────────────────────────────────
+TurnOnProducer producer = new(transport, ValidationMode.Basic);
 
-// ── Example 1: Publish a command ─────────────────────────────────────────────
-// In a real system, this would tell a streetlight to turn on.
-await commandProducer.PublishTurnOnOffAsync(
+// ── Publish a command ────────────────────────────────────────────────────────
+// The generated producer serializes and publishes to the concrete command
+// channel for lamp-42. There is no command consumer in this recipe, so the
+// transport captures the outbound command but does not invoke the measurement
+// handler.
+await producer.PublishTurnOnOffAsync(
     payload: new TurnOnOffPayload.Source((ref TurnOnOffPayload.Builder b) =>
     {
         b.Create(command: "on"u8, sentAt: DateTimeOffset.UtcNow);
     }),
     streetlightId: "lamp-42");
 
-Console.WriteLine($"Command published. Transport captured: {transport.PublishedMessages.Count} messages");
+Console.WriteLine($"Published command; measurement handler received: {handler.ReceivedCount}");
 
-// ── Example 2: Simulate a streetlight publishing measurements ────────────────
-// In a real system, sensor hardware would do this. Here we manually publish
-// to the consumer's channel to demonstrate the complete flow.
-using ParsedJsonDocument<LightMeasuredPayload> measurementDoc = ParsedJsonDocument<LightMeasuredPayload>.Parse(
-    """{"lumens":1024,"sentAt":"2026-05-25T12:00:00Z"}"""u8.ToArray());
+// ── Deliver telemetry to the consumer ────────────────────────────────────────
+// The measurement is not produced by the command producer. In a real system, a
+// streetlight or telemetry gateway would publish this to the broker, and the
+// broker would deliver the raw bytes to the generated consumer. DeliverAsync
+// simulates that broker delivery path.
+const string MeasuredChannelTemplate = "smartylighting.streetlights.1.0.action.{streetlightId}.lighting.measured";
+ReadOnlyMemory<byte> sensorReading = """{"lumens":1024,"sentAt":"2026-05-25T12:00:00Z"}"""u8.ToArray();
+await transport.DeliverAsync<LightMeasuredPayload>(
+    MeasuredChannelTemplate,
+    sensorReading);
 
-await transport.PublishAsync(
-    channelUtf8: Encoding.UTF8.GetBytes("smartylighting.streetlights.1.0.action.lamp-42.lighting.measured"),
-    payload: measurementDoc.RootElement);
-
-Console.WriteLine($"Measurement published and delivered, handler received: {handler.ReceivedCount}");
+Console.WriteLine($"Delivered sensor reading; measurement handler received: {handler.ReceivedCount}");
 Console.WriteLine($"Last measurement: {handler.LastLumens} lumens");
 
-// ── Example 3: Schema validation protects consumers ──────────────────────────
-// Invalid data is caught before reaching your handler (lumens must be >= 0).
-try
-{
-    using ParsedJsonDocument<LightMeasuredPayload> badDoc = ParsedJsonDocument<LightMeasuredPayload>.Parse(
-        """{"lumens":-5,"sentAt":"2026-05-25T12:00:00Z"}"""u8.ToArray());
+// ── Validation protects the consumer ─────────────────────────────────────────
+// Bad data from the broker is caught before reaching your handler. The default
+// error policy dead-letters invalid messages.
+ReadOnlyMemory<byte> badData = """{"lumens":-5,"sentAt":"2026-05-25T12:01:00Z"}"""u8.ToArray();
+await transport.DeliverAsync<LightMeasuredPayload>(
+    MeasuredChannelTemplate,
+    badData);
 
-    await transport.PublishAsync(
-        channelUtf8: Encoding.UTF8.GetBytes("smartylighting.streetlights.1.0.action.lamp-42.lighting.measured"),
-        payload: badDoc.RootElement);
-}
-catch (InvalidOperationException ex)
-{
-    Console.WriteLine($"Validation prevented invalid publish: {ex.Message.Split('\n')[0]}");
-}
-
-Console.WriteLine($"After invalid attempt: handler still has {handler.ReceivedCount} valid messages");
+Console.WriteLine($"After bad data: handler still has {handler.ReceivedCount} valid message(s)");
 
 // ── Inspect transport state ──────────────────────────────────────────────────
-Console.WriteLine($"\nTransport state:");
+Console.WriteLine();
+Console.WriteLine("Transport state:");
 Console.WriteLine($"  Published messages: {transport.PublishedMessages.Count}");
+Console.WriteLine($"  Dead-lettered: {transport.DeadLetteredMessages.Count}");
 
 foreach (PublishedMessage msg in transport.PublishedMessages)
 {
-    string preview = Encoding.UTF8.GetString(msg.PayloadBytes[..Math.Min(60, msg.PayloadBytes.Length)]);
-    Console.WriteLine($"  → {msg.Channel[..Math.Min(60, msg.Channel.Length)]}: {preview}...");
+    Console.WriteLine($"  -> {msg.Channel}: {Encoding.UTF8.GetString(msg.PayloadBytes)}");
 }
 
 // ── Clean shutdown ───────────────────────────────────────────────────────────
 await consumer.StopAsync();
-Console.WriteLine("\nConsumer stopped. End-to-end demo complete.");
+Console.WriteLine();
+Console.WriteLine("Consumer stopped. End-to-end demo complete.");
 
 // ── Handler implementation ───────────────────────────────────────────────────
 internal sealed class LightMeasurementHandler : IReceiveLightMeasurementHandler
@@ -96,7 +93,7 @@ internal sealed class LightMeasurementHandler : IReceiveLightMeasurementHandler
     {
         this.ReceivedCount++;
         this.LastLumens = (int)payload.Lumens;
-        Console.WriteLine($"  [Handler] Received: lumens={payload.Lumens}, sentAt={payload.SentAt}");
+        Console.WriteLine($"  [Handler] lumens={payload.Lumens}, sentAt={payload.SentAt}");
         return ValueTask.CompletedTask;
     }
 }

--- a/docs/ExampleRecipes/038-AsyncApiEndToEnd/README.md
+++ b/docs/ExampleRecipes/038-AsyncApiEndToEnd/README.md
@@ -1,6 +1,6 @@
-# 038-AsyncApiEndToEnd — Producer + Consumer Integration
+# 038-AsyncApiEndToEnd - Producer + Consumer Integration
 
-Demonstrates a complete AsyncAPI workflow with producer and consumer components using `InMemoryMessageTransport` for testing.
+Demonstrates a complete AsyncAPI workflow with generated producer and consumer components using `InMemoryMessageTransport` for testing.
 
 ## What You'll Learn
 
@@ -8,19 +8,19 @@ Demonstrates a complete AsyncAPI workflow with producer and consumer components 
 |---------|---------------|---------|
 | Publishing messages | `TurnOnProducer` | Schema-validated, type-safe publishing |
 | Consuming messages | `ReceiveLightMeasurementConsumer` + handler | Automatic deserialization and validation |
-| Testing without a broker | `InMemoryMessageTransport` | Fast, reliable tests with automatic message routing |
+| Testing without a broker | `InMemoryMessageTransport` | Fast, reliable tests for producer capture and broker-style delivery |
 | Schema validation | Built into producers/consumers | Invalid data caught before reaching handlers |
 
 ## The Pattern
 
-`InMemoryMessageTransport` simulates a real message broker:
+`InMemoryMessageTransport` lets a test exercise both sides of an AsyncAPI application without Kafka, NATS, MQTT, or another broker:
 
-1. **Subscribe** — consumer registers a handler for a channel
-2. **Publish** — producer sends a message to a channel
-3. **Auto-deliver** — transport automatically delivers to matching subscribers
-4. **Validate** — schema validation happens before delivery
+1. **Start the consumer** - the generated consumer subscribes and forwards valid messages to your handler.
+2. **Publish with the generated producer** - the generated producer validates, serializes, resolves channel parameters, and writes to the transport.
+3. **Deliver broker input** - `DeliverAsync<T>()` simulates raw bytes arriving from a real broker for a subscribed consumer channel.
+4. **Validate before handling** - schema validation runs before your handler sees the typed payload.
 
-This matches how real brokers (Kafka, NATS, MQTT) work: publish to a channel, and all subscribers receive it.
+The command producer and measurement consumer are intentionally different operations. The producer sends a command to a streetlight (`...lamp-42.turn.on`). The consumer receives telemetry from a streetlight (`...{streetlightId}.lighting.measured`). In a real deployment, the telemetry would come from the streetlight or a gateway, not from the command producer. The recipe uses `DeliverAsync` to simulate the broker delivering that incoming telemetry.
 
 ## Quick Start
 
@@ -31,15 +31,15 @@ dotnet run
 
 **Output:**
 ```
-Command published. Transport captured: 1 messages
-  [Handler] Received: lumens=1024, sentAt=2026-05-25T12:00:00+00:00
-Measurement published and delivered, handler received: 1
+Published command; measurement handler received: 0
+  [Handler] lumens=1024, sentAt=2026-05-25T12:00:00+00:00
+Delivered sensor reading; measurement handler received: 1
 Last measurement: 1024 lumens
-Validation prevented invalid publish: ...
-After invalid attempt: handler still has 1 valid messages
+After bad data: handler still has 1 valid message(s)
 
 Transport state:
-  Published messages: 2
+  Published messages: 1
+  Dead-lettered: 1
 Consumer stopped. End-to-end demo complete.
 ```
 
@@ -90,35 +90,51 @@ internal sealed class LightMeasurementHandler : IReceiveLightMeasurementHandler
 ### 3. Publish messages
 
 ```csharp
-// Publish to the subscribed channel
-await transport.PublishAsync(
-    channelUtf8: Encoding.UTF8.GetBytes("smartylighting.streetlights.1.0.action.lamp-42.lighting.measured"),
-    payload: new LightMeasuredPayload.Source((ref LightMeasuredPayload.Builder b) =>
+TurnOnProducer producer = new(transport, ValidationMode.Basic);
+
+await producer.PublishTurnOnOffAsync(
+    payload: new TurnOnOffPayload.Source((ref TurnOnOffPayload.Builder b) =>
     {
-        b.Create(lumens: 1024, sentAt: DateTimeOffset.UtcNow);
-    }));
+        b.Create(command: "on"u8, sentAt: DateTimeOffset.UtcNow);
+    }),
+    streetlightId: "lamp-42");
 ```
 
-The transport:
+The generated producer:
 1. Serializes the payload to JSON
-2. Adds it to `PublishedMessages` (for test assertions)
-3. **Automatically delivers** to the consumer's subscription
-4. Consumer validates the schema
-5. Handler receives the typed payload
+2. Validates the payload before publishing
+3. Resolves `{streetlightId}` to the concrete command channel
+4. Adds the message to `PublishedMessages` for assertions
 
-### 4. Schema validation protects you
+This command is outbound. It is not delivered to the measurement consumer because that consumer is subscribed to the telemetry channel, not the command channel.
+
+### 4. Deliver telemetry from the broker
 
 ```csharp
-// This throws InvalidOperationException before publishing
-await transport.PublishAsync(
-    channelUtf8: Encoding.UTF8.GetBytes("smartylighting.streetlights.1.0.action.lamp-42.lighting.measured"),
-    payload: new LightMeasuredPayload.Source((ref LightMeasuredPayload.Builder b) =>
-    {
-        b.Create(lumens: -5, sentAt: DateTimeOffset.UtcNow); // ❌ lumens must be >= 0
-    }));
+ReadOnlyMemory<byte> sensorReading =
+    """{"lumens":1024,"sentAt":"2026-05-25T12:00:00Z"}"""u8.ToArray();
+
+await transport.DeliverAsync<LightMeasuredPayload>(
+    "smartylighting.streetlights.1.0.action.{streetlightId}.lighting.measured",
+    sensorReading);
 ```
 
-Invalid data never reaches the transport or your handler — it's caught at build time.
+`DeliverAsync<T>()` simulates the broker delivering raw JSON bytes to the subscribed consumer. This is the right model for incoming telemetry: the consumer did not create the message, it receives bytes from the broker and lets generated code parse, validate, and dispatch to the handler.
+
+The generated consumer currently subscribes using the AsyncAPI channel template key. A real broker topic would normally contain a concrete value such as `smartylighting.streetlights.1.0.action.lamp-42.lighting.measured`; this in-memory sample uses the template string because the testing transport matches subscriptions by exact string.
+
+### 5. Schema validation protects consumers
+
+```csharp
+ReadOnlyMemory<byte> badData =
+    """{"lumens":-5,"sentAt":"2026-05-25T12:01:00Z"}"""u8.ToArray();
+
+await transport.DeliverAsync<LightMeasuredPayload>(
+    "smartylighting.streetlights.1.0.action.{streetlightId}.lighting.measured",
+    badData);
+```
+
+Invalid data is parsed and routed to the generated consumer, but schema validation fails before your handler is called. The default error policy dead-letters the message, so `handler.ReceivedCount` stays unchanged and `transport.DeadLetteredMessages.Count` increases.
 
 ## Testing Patterns
 
@@ -127,7 +143,7 @@ Invalid data never reaches the transport or your handler — it's caught at buil
 ```csharp
 int beforeCount = handler.ReceivedCount;
 
-await transport.PublishAsync(...);
+await transport.DeliverAsync<LightMeasuredPayload>(...);
 
 Assert.AreEqual(beforeCount + 1, handler.ReceivedCount);
 Assert.AreEqual(1024, handler.LastLumens);
@@ -136,11 +152,8 @@ Assert.AreEqual(1024, handler.LastLumens);
 ### Pattern 2: Verify published message capture
 
 ```csharp
-int beforeCount = transport.PublishedMessages.Count;
-
 await producer.PublishTurnOnOffAsync(...);
 
-Assert.AreEqual(beforeCount + 1, transport.PublishedMessages.Count);
 PublishedMessage msg = transport.PublishedMessages[^1];
 Assert.AreEqual("smartylighting.streetlights.1.0.action.lamp-42.turn.on", msg.Channel);
 ```

--- a/docs/OpenApi.md
+++ b/docs/OpenApi.md
@@ -339,27 +339,28 @@ public ValueTask<SubmitAdoptionApplicationResult> HandleSubmitAdoptionApplicatio
 
 ### Server-Sent Events (SSE)
 
-For `text/event-stream` responses, the generated code wraps each item you yield in the SSE envelope format (`data: {...}\n\n`):
+For server `text/event-stream` responses with an OpenAPI `itemSchema`, the generated result factory accepts a writer callback. Append typed items to the generated stream; the endpoint registration serializes each item as compact JSON and applies the SSE frame (`data: {...}\n\n`):
 
 ```csharp
-public async ValueTask<StartVetChatResult> HandleStartVetChatAsync(
+public ValueTask<StartVetChatResult> HandleStartVetChatAsync(
     StartVetChatParams parameters, JsonWorkspace workspace, CancellationToken ct)
 {
-    return StartVetChatResult.Ok(StreamChunks(ct));
-
-    async IAsyncEnumerable<ChatChunk.Source> StreamChunks(
-        [System.Runtime.CompilerServices.EnumeratorCancellation] CancellationToken token)
+    return new(StartVetChatResult.Ok(static async (stream, cancellationToken) =>
     {
-        yield return new ChatChunk.Source((ref ChatChunk.Builder b) =>
-            b.Create(delta: "Hello! "u8, done: false));
+        ChatChunk greeting = ChatChunk.ParseValue(
+            """{"delta":"Hello! ","done":false}"""u8);
+        await stream.AppendChatChunk(greeting, cancellationToken);
 
-        yield return new ChatChunk.Source((ref ChatChunk.Builder b) =>
-            b.Create(delta: "How can I help?"u8, done: true));
-    }
+        ChatChunk answer = ChatChunk.ParseValue(
+            """{"delta":"How can I help?","done":true}"""u8);
+        await stream.AppendChatChunk(answer, cancellationToken);
+    }));
 }
 ```
 
-On the client, streaming responses expose `IAsyncEnumerable`:
+There is no generated `End*` method. For SSE, stream completion is the HTTP response completing: when the callback returns, the endpoint flushes the response and closes the response body. If the client disconnects, the callback receives cancellation through the provided token.
+
+On the client, streaming responses expose `IAsyncEnumerable`. Use `EnumerateOkItems()` when you only need JSON payloads, or `EnumerateOkSseItems()` when you also need SSE metadata such as `id` or `event`:
 
 ```csharp
 await foreach (ParsedJsonDocument<ChatChunk> chunk in chatResponse.EnumerateOkItems())
@@ -373,14 +374,29 @@ await foreach (ParsedJsonDocument<ChatChunk> chunk in chatResponse.EnumerateOkIt
 
 ### NDJSON (Newline-Delimited JSON)
 
-For `application/x-ndjson` responses, each item is written as a JSON line:
+For server `application/x-ndjson` responses, the same generated writer callback is used. Each appended item is written as one JSON line (`{...}\n`):
+
+```csharp
+public ValueTask<StreamPetActivityResult> HandleStreamPetActivityAsync(
+    StreamPetActivityParams parameters, JsonWorkspace workspace, CancellationToken ct)
+{
+    return new(StreamPetActivityResult.Ok(static async (stream, cancellationToken) =>
+    {
+        ActivityEvent checkIn = ActivityEvent.ParseValue(
+            """{"eventId":"evt-1","timestamp":"2026-05-30T18:00:00Z","type":"check-in","description":"Bella checked in"}"""u8);
+        await stream.AppendActivityEvent(checkIn, cancellationToken);
+    }));
+}
+```
+
+The client reads each JSON line as a pooled typed document:
 
 ```csharp
 await foreach (ParsedJsonDocument<ActivityEvent> doc in activityResponse.EnumerateOkItems())
 {
     using (doc)
     {
-        Console.WriteLine($"[{doc.RootElement.Timestamp}] {doc.RootElement.Event}");
+        Console.WriteLine($"[{doc.RootElement.Timestamp}] {doc.RootElement.Type}: {doc.RootElement.Description}");
     }
 }
 ```

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -463,7 +463,8 @@ example-recipes:
       - {index: 6, language: csharp, lines: [124, 138], category: compilable, verified: false}
       - {index: 7, language: csharp, lines: [146, 150], category: compilable, verified: false}
       - {index: 8, language: bash, lines: [154, 157]}
-      - {index: 9, language: , lines: [163, 178]}
+      - {index: 9, language: bash, lines: [163, 165]}
+      - {index: 10, language: , lines: [171, 186]}
   - path: "docs/ExampleRecipes/033-OpenApiEndToEnd/README.md"
     companion_project: "docs/ExampleRecipes/033-OpenApiEndToEnd/"
     blocks:

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -466,10 +466,10 @@ example-recipes:
   - path: "docs/ExampleRecipes/033-OpenApiEndToEnd/README.md"
     companion_project: "docs/ExampleRecipes/033-OpenApiEndToEnd/"
     blocks:
-      - {index: 0, language: bash, lines: [21, 23]}
-      - {index: 1, language: csharp, lines: [43, 45], category: compilable, verified: false}
-      - {index: 2, language: csharp, lines: [57, 66], category: compilable, verified: false}
-      - {index: 3, language: bash, lines: [82, 92]}
+      - {index: 0, language: bash, lines: [22, 24]}
+      - {index: 1, language: csharp, lines: [44, 46], category: compilable, verified: false}
+      - {index: 2, language: csharp, lines: [58, 67], category: compilable, verified: false}
+      - {index: 3, language: bash, lines: [84, 94]}
   - path: "docs/ExampleRecipes/034-OpenApiCallbackServer/README.md"
     companion_project: "docs/ExampleRecipes/034-OpenApiCallbackServer/"
     blocks:

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -459,10 +459,10 @@ example-recipes:
       - {index: 3, language: csharp, lines: [71, 78], category: compilable, verified: false}
       - {index: 4, language: csharp, lines: [92, 106], category: compilable, verified: false}
       - {index: 5, language: csharp, lines: [112, 118], category: compilable, verified: false}
-      - {index: 6, language: csharp, lines: [124, 130], category: compilable, verified: false}
-      - {index: 7, language: csharp, lines: [136, 140], category: compilable, verified: false}
-      - {index: 8, language: bash, lines: [144, 147]}
-      - {index: 9, language: , lines: [153, 168]}
+      - {index: 6, language: csharp, lines: [124, 138], category: compilable, verified: false}
+      - {index: 7, language: csharp, lines: [146, 150], category: compilable, verified: false}
+      - {index: 8, language: bash, lines: [154, 157]}
+      - {index: 9, language: , lines: [163, 178]}
   - path: "docs/ExampleRecipes/033-OpenApiEndToEnd/README.md"
     companion_project: "docs/ExampleRecipes/033-OpenApiEndToEnd/"
     blocks:
@@ -1210,49 +1210,50 @@ main-docs:
       - {index: 16, language: csharp, lines: [285, 301], category: compilable, verified: false}
       - {index: 17, language: csharp, lines: [307, 318], category: compilable, verified: false}
       - {index: 18, language: csharp, lines: [322, 336], category: compilable, verified: false}
-      - {index: 19, language: csharp, lines: [344, 360], category: compilable, verified: false}
-      - {index: 20, language: csharp, lines: [364, 372], category: compilable, verified: false}
-      - {index: 21, language: csharp, lines: [378, 386], category: compilable, verified: false}
-      - {index: 22, language: csharp, lines: [392, 401], category: compilable, verified: false}
-      - {index: 23, language: csharp, lines: [405, 410], category: compilable, verified: false}
-      - {index: 24, language: csharp, lines: [416, 433], category: compilable, verified: false}
-      - {index: 25, language: csharp, lines: [441, 454], category: fragment, verified: false}
-      - {index: 26, language: csharp, lines: [490, 500], category: fragment, verified: false}
-      - {index: 27, language: csharp, lines: [504, 526], category: fragment, verified: false}
-      - {index: 28, language: csharp, lines: [530, 560], category: fragment, verified: false}
-      - {index: 29, language: csharp, lines: [564, 574], category: fragment, verified: false}
-      - {index: 30, language: csharp, lines: [580, 605], category: fragment, verified: false}
-      - {index: 31, language: csharp, lines: [613, 633], category: fragment, verified: false}
-      - {index: 32, language: csharp, lines: [639, 644], category: fragment, verified: false}
-      - {index: 33, language: csharp, lines: [650, 668], category: fragment, verified: false}
-      - {index: 34, language: csharp, lines: [672, 679], category: fragment, verified: false}
-      - {index: 35, language: csharp, lines: [685, 691], category: fragment, verified: false}
-      - {index: 36, language: csharp, lines: [697, 705], category: fragment, verified: false}
-      - {index: 37, language: csharp, lines: [717, 723], category: fragment, verified: false}
-      - {index: 38, language: csharp, lines: [727, 736], category: fragment, verified: false}
-      - {index: 39, language: csharp, lines: [748, 777], category: fragment, verified: false}
-      - {index: 40, language: csharp, lines: [781, 807], category: fragment, verified: false}
-      - {index: 41, language: csharp, lines: [811, 824], category: fragment, verified: false}
-      - {index: 42, language: csharp, lines: [841, 856], category: compilable, verified: false}
-      - {index: 43, language: csharp, lines: [864, 880], category: compilable, verified: false}
-      - {index: 44, language: csharp, lines: [888, 899], category: compilable, verified: false}
-      - {index: 45, language: , lines: [909, 917]}
-      - {index: 46, language: bash, lines: [930, 934]}
-      - {index: 47, language: csharp, lines: [943, 954], category: compilable, verified: false}
-      - {index: 48, language: bash, lines: [960, 964]}
-      - {index: 49, language: csharp, lines: [972, 986], category: compilable, verified: false}
-      - {index: 50, language: csharp, lines: [1002, 1015], category: compilable, verified: false}
-      - {index: 51, language: csharp, lines: [1025, 1042], category: compilable, verified: false}
-      - {index: 52, language: json, lines: [1048, 1092]}
-      - {index: 53, language: bash, lines: [1098, 1100]}
-      - {index: 54, language: bash, lines: [1116, 1118]}
-      - {index: 55, language: bash, lines: [1124, 1126]}
-      - {index: 56, language: bash, lines: [1134, 1136]}
-      - {index: 57, language: bash, lines: [1144, 1146]}
-      - {index: 58, language: bash, lines: [1174, 1191]}
-      - {index: 59, language: bash, lines: [1195, 1205]}
-      - {index: 60, language: bash, lines: [1213, 1225]}
-      - {index: 61, language: bash, lines: [1231, 1246]}
+      - {index: 19, language: csharp, lines: [344, 359], category: compilable, verified: false}
+      - {index: 20, language: csharp, lines: [365, 373], category: compilable, verified: false}
+      - {index: 21, language: csharp, lines: [379, 390], category: compilable, verified: false}
+      - {index: 22, language: csharp, lines: [394, 402], category: compilable, verified: false}
+      - {index: 23, language: csharp, lines: [408, 417], category: compilable, verified: false}
+      - {index: 24, language: csharp, lines: [421, 426], category: compilable, verified: false}
+      - {index: 25, language: csharp, lines: [432, 449], category: fragment, verified: false}
+      - {index: 26, language: csharp, lines: [457, 470], category: fragment, verified: false}
+      - {index: 27, language: csharp, lines: [506, 516], category: fragment, verified: false}
+      - {index: 28, language: csharp, lines: [520, 542], category: fragment, verified: false}
+      - {index: 29, language: csharp, lines: [546, 576], category: fragment, verified: false}
+      - {index: 30, language: csharp, lines: [580, 590], category: fragment, verified: false}
+      - {index: 31, language: csharp, lines: [596, 621], category: fragment, verified: false}
+      - {index: 32, language: csharp, lines: [629, 649], category: fragment, verified: false}
+      - {index: 33, language: csharp, lines: [655, 660], category: fragment, verified: false}
+      - {index: 34, language: csharp, lines: [666, 684], category: fragment, verified: false}
+      - {index: 35, language: csharp, lines: [688, 695], category: fragment, verified: false}
+      - {index: 36, language: csharp, lines: [701, 707], category: fragment, verified: false}
+      - {index: 37, language: csharp, lines: [713, 721], category: fragment, verified: false}
+      - {index: 38, language: csharp, lines: [733, 739], category: fragment, verified: false}
+      - {index: 39, language: csharp, lines: [743, 752], category: fragment, verified: false}
+      - {index: 40, language: csharp, lines: [764, 793], category: fragment, verified: false}
+      - {index: 41, language: csharp, lines: [797, 823], category: fragment, verified: false}
+      - {index: 42, language: csharp, lines: [827, 840], category: compilable, verified: false}
+      - {index: 43, language: csharp, lines: [857, 872], category: compilable, verified: false}
+      - {index: 44, language: csharp, lines: [880, 896], category: compilable, verified: false}
+      - {index: 45, language: csharp, lines: [904, 915], category: compilable, verified: false}
+      - {index: 46, language: , lines: [925, 933]}
+      - {index: 47, language: bash, lines: [946, 950]}
+      - {index: 48, language: csharp, lines: [959, 970], category: compilable, verified: false}
+      - {index: 49, language: bash, lines: [976, 980]}
+      - {index: 50, language: csharp, lines: [988, 1002], category: compilable, verified: false}
+      - {index: 51, language: csharp, lines: [1018, 1031], category: compilable, verified: false}
+      - {index: 52, language: csharp, lines: [1041, 1058], category: compilable, verified: false}
+      - {index: 53, language: json, lines: [1064, 1108]}
+      - {index: 54, language: bash, lines: [1114, 1116]}
+      - {index: 55, language: bash, lines: [1132, 1134]}
+      - {index: 56, language: bash, lines: [1140, 1142]}
+      - {index: 57, language: bash, lines: [1150, 1152]}
+      - {index: 58, language: bash, lines: [1160, 1162]}
+      - {index: 59, language: bash, lines: [1190, 1207]}
+      - {index: 60, language: bash, lines: [1211, 1221]}
+      - {index: 61, language: bash, lines: [1229, 1241]}
+      - {index: 62, language: bash, lines: [1247, 1262]}
   - path: "docs/ParsedJsonDocument.md"
     blocks:
       - {index: 0, language: csharp, lines: [40, 56], category: compilable, verified: false}

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -638,21 +638,21 @@ main-docs:
       - {index: 43, language: csharp, lines: [986, 994], category: compilable, verified: false}
       - {index: 44, language: csharp, lines: [1002, 1015], category: compilable, verified: false}
       - {index: 45, language: csharp, lines: [1019, 1041], category: compilable, verified: false}
-      - {index: 46, language: csharp, lines: [1061, 1075], category: compilable, verified: false}
-      - {index: 47, language: json, lines: [1081, 1101]}
-      - {index: 48, language: json, lines: [1115, 1129]}
-      - {index: 49, language: csharp, lines: [1133, 1142], category: compilable, verified: false}
-      - {index: 50, language: csharp, lines: [1152, 1160], category: compilable, verified: false}
-      - {index: 51, language: csharp, lines: [1173, 1190], category: compilable, verified: false}
-      - {index: 52, language: bash, lines: [1198, 1200]}
-      - {index: 53, language: csharp, lines: [1202, 1213], category: compilable, verified: false}
-      - {index: 54, language: bash, lines: [1223, 1225]}
-      - {index: 55, language: bash, lines: [1243, 1261]}
-      - {index: 56, language: bash, lines: [1265, 1267]}
-      - {index: 57, language: , lines: [1271, 1281]}
-      - {index: 58, language: bash, lines: [1294, 1300]}
-      - {index: 59, language: csharp, lines: [1336, 1341], category: compilable, verified: false}
-      - {index: 60, language: , lines: [1355, 1360]}
+      - {index: 46, language: csharp, lines: [1064, 1078], category: compilable, verified: false}
+      - {index: 47, language: json, lines: [1084, 1104]}
+      - {index: 48, language: json, lines: [1118, 1132]}
+      - {index: 49, language: csharp, lines: [1136, 1145], category: compilable, verified: false}
+      - {index: 50, language: csharp, lines: [1155, 1163], category: compilable, verified: false}
+      - {index: 51, language: csharp, lines: [1176, 1193], category: compilable, verified: false}
+      - {index: 52, language: bash, lines: [1201, 1203]}
+      - {index: 53, language: csharp, lines: [1205, 1216], category: compilable, verified: false}
+      - {index: 54, language: bash, lines: [1226, 1228]}
+      - {index: 55, language: bash, lines: [1246, 1264]}
+      - {index: 56, language: bash, lines: [1268, 1270]}
+      - {index: 57, language: , lines: [1274, 1284]}
+      - {index: 58, language: bash, lines: [1297, 1303]}
+      - {index: 59, language: csharp, lines: [1339, 1344], category: compilable, verified: false}
+      - {index: 60, language: , lines: [1358, 1363]}
   - path: "docs/AsyncApiMessageResumption.md"
     blocks:
       - {index: 0, language: , lines: [26, 32]}

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -500,8 +500,8 @@ example-recipes:
       - {index: 2, language: csharp, lines: [37, 44], category: compilable, verified: false}
       - {index: 3, language: csharp, lines: [52, 59], category: compilable, verified: false}
       - {index: 4, language: csharp, lines: [70, 74], category: compilable, verified: false}
-      - {index: 5, language: bash, lines: [82, 84]}
-      - {index: 6, language: text, lines: [88, 97]}
+      - {index: 5, language: bash, lines: [86, 88]}
+      - {index: 6, language: text, lines: [92, 102]}
   - path: "docs/ExampleRecipes/038-AsyncApiEndToEnd/README.md"
     companion_project: "docs/ExampleRecipes/038-AsyncApiEndToEnd/"
     blocks:

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -409,6 +409,7 @@ example-recipes:
       - {index: 5, language: csharp, lines: [175, 189], category: compilable, verified: false}
       - {index: 6, language: csharp, lines: [197, 201], category: compilable, verified: false}
       - {index: 7, language: csharp, lines: [207, 221], category: compilable, verified: false}
+      - {index: 8, language: bash, lines: [232, 235]}
   - path: "docs/ExampleRecipes/030-OpenApiServer/README.md"
     companion_project: "docs/ExampleRecipes/030-OpenApiServer/"
     blocks:

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -510,16 +510,17 @@ example-recipes:
       - {index: 2, language: csharp, lines: [50, 52], category: compilable, verified: false}
       - {index: 3, language: csharp, lines: [58, 66], category: compilable, verified: false}
       - {index: 4, language: csharp, lines: [72, 88], category: compilable, verified: false}
-      - {index: 5, language: csharp, lines: [92, 100], category: compilable, verified: false}
-      - {index: 6, language: csharp, lines: [111, 119], category: compilable, verified: false}
-      - {index: 7, language: csharp, lines: [127, 134], category: compilable, verified: false}
-      - {index: 8, language: csharp, lines: [138, 146], category: compilable, verified: false}
-      - {index: 9, language: csharp, lines: [150, 156], category: compilable, verified: false}
-      - {index: 10, language: csharp, lines: [162, 178], category: compilable, verified: false}
-      - {index: 11, language: csharp, lines: [186, 194], category: compilable, verified: false}
-      - {index: 12, language: csharp, lines: [198, 208], category: compilable, verified: false}
-      - {index: 13, language: csharp, lines: [212, 222], category: compilable, verified: false}
-      - {index: 14, language: bash, lines: [239, 241]}
+      - {index: 5, language: csharp, lines: [92, 101], category: compilable, verified: false}
+      - {index: 6, language: csharp, lines: [113, 120], category: compilable, verified: false}
+      - {index: 7, language: csharp, lines: [128, 135], category: compilable, verified: false}
+      - {index: 8, language: csharp, lines: [143, 150], category: compilable, verified: false}
+      - {index: 9, language: csharp, lines: [154, 159], category: compilable, verified: false}
+      - {index: 10, language: csharp, lines: [163, 169], category: compilable, verified: false}
+      - {index: 11, language: csharp, lines: [175, 191], category: compilable, verified: false}
+      - {index: 12, language: csharp, lines: [199, 207], category: compilable, verified: false}
+      - {index: 13, language: csharp, lines: [211, 221], category: compilable, verified: false}
+      - {index: 14, language: csharp, lines: [225, 235], category: compilable, verified: false}
+      - {index: 15, language: bash, lines: [252, 254]}
   - path: "docs/ExampleRecipes/039-AsyncApiAuthentication/README.md"
     companion_project: "docs/ExampleRecipes/039-AsyncApiAuthentication/"
     blocks:

--- a/docs/website/build.ps1
+++ b/docs/website/build.ps1
@@ -115,6 +115,15 @@ if (-not $canonicalBranch) {
     Write-Warning "Could not detect branch — using default: $canonicalBranch"
 }
 
+# GitHub's /blob/{ref}/... route needs the ref as one URL path segment. Branch
+# names can contain characters such as '%' and '/', so prefer the commit SHA in
+# CI and URL-escape the fallback branch name for local builds.
+$canonicalBlobRef = $env:GITHUB_SHA
+if (-not $canonicalBlobRef) {
+    $canonicalBlobRef = $canonicalBranch
+}
+$canonicalBlobRef = [System.Uri]::EscapeDataString($canonicalBlobRef)
+
 # V5 paths
 $v5SrcDir = Join-Path $repoRoot "src"
 $v5ApiContentDir = Join-Path $siteDir "content\Api-v5"
@@ -554,7 +563,7 @@ foreach ($dir in $recipeDirs) {
         $body = $body -replace [regex]::Escape("../$($entry.Key)/"), "/examples/$($entry.Value).html"
         $body = $body -replace [regex]::Escape("../$($entry.Key)"), "/examples/$($entry.Value).html"
     }
-    $ghRecipeBase = "$canonicalRepoUrl/blob/$canonicalBranch/docs/ExampleRecipes/$($dir.Name)"
+    $ghRecipeBase = "$canonicalRepoUrl/blob/$canonicalBlobRef/docs/ExampleRecipes/$($dir.Name)"
     $body = $body -replace '\./Program\.cs', "$ghRecipeBase/Program.cs"
 
     # Extract first sentence as description
@@ -754,7 +763,7 @@ foreach ($descriptorFile in $descriptorFiles) {
 
     # Rewrite links to files that aren't website pages (e.g. copilot/ instructions)
     # Point them at the GitHub source
-    $docBody = $docBody -replace '\(copilot/([^)]+\.md)\)', "($canonicalRepoUrl/blob/$canonicalBranch/docs/copilot/`$1)"
+    $docBody = $docBody -replace '\(copilot/([^)]+\.md)\)', "($canonicalRepoUrl/blob/$canonicalBlobRef/docs/copilot/`$1)"
 
     # Rewrite links to ExampleRecipes from doc pages:
     #   ../ExampleRecipes/029-OpenApiClient/  -> /examples/open-api-client.html

--- a/docs/website/tools/XmlDocToMarkdown/Program.cs
+++ b/docs/website/tools/XmlDocToMarkdown/Program.cs
@@ -395,8 +395,9 @@ if (File.Exists(pdbPath))
     if (!string.IsNullOrEmpty(repoRoot) && !string.IsNullOrEmpty(repoUrl))
     {
         Console.WriteLine($"  Repo URL: {repoUrl}");
-        Console.WriteLine($"  Branch: {branch}");
-        sourceResolver = new SourceLinkResolver(pdbPath, Path.GetFullPath(assemblyPaths[0]), repoUrl, branch, repoRoot);
+        string sourceRef = Environment.GetEnvironmentVariable("GITHUB_SHA") ?? branch;
+        Console.WriteLine($"  Source ref: {sourceRef}");
+        sourceResolver = new SourceLinkResolver(pdbPath, Path.GetFullPath(assemblyPaths[0]), repoUrl, sourceRef, repoRoot);
         sourceResolver.Build();
     }
     else

--- a/docs/website/tools/XmlDocToMarkdown/SourceLinkResolver.cs
+++ b/docs/website/tools/XmlDocToMarkdown/SourceLinkResolver.cs
@@ -60,8 +60,8 @@ public sealed class SourceLinkResolver : IDisposable
     /// </summary>
     public SourceLinkResolver(string pdbPath, string assemblyPath, string repoUrl, string branch, string repoRoot)
     {
-        _branch = branch;
-        _repoBaseUrl = $"{repoUrl.TrimEnd('/')}/blob/{branch}/";
+        _branch = Uri.EscapeDataString(branch);
+        _repoBaseUrl = $"{repoUrl.TrimEnd('/')}/blob/{_branch}/";
         _localPathPrefix = repoRoot.TrimEnd('\\', '/').Replace('\\', '/') + "/";
 
         // Open PDB

--- a/src/Corvus.Text.Json.OpenApi/JsonStreamWriter.cs
+++ b/src/Corvus.Text.Json.OpenApi/JsonStreamWriter.cs
@@ -1,0 +1,81 @@
+// <copyright file="JsonStreamWriter.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.IO.Pipelines;
+using Corvus.Text.Json;
+using Corvus.Text.Json.Internal;
+
+namespace Corvus.Text.Json.OpenApi;
+
+/// <summary>
+/// Writes JSON stream items using the media framing required by OpenAPI <c>itemSchema</c> responses.
+/// </summary>
+public readonly struct JsonStreamWriter
+{
+    private static ReadOnlySpan<byte> SseDataPrefix => "data: "u8;
+
+    private static ReadOnlySpan<byte> SseDataSuffix => "\n\n"u8;
+
+    private static ReadOnlySpan<byte> NewLine => "\n"u8;
+
+    private readonly PipeWriter pipeWriter;
+    private readonly Utf8JsonWriter jsonWriter;
+    private readonly JsonStreamWriterFormat format;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="JsonStreamWriter"/> struct.
+    /// </summary>
+    /// <param name="pipeWriter">The pipe writer to which the stream should be written.</param>
+    /// <param name="jsonWriter">The JSON writer used to serialize each item.</param>
+    /// <param name="contentType">The response content type.</param>
+    public JsonStreamWriter(PipeWriter pipeWriter, Utf8JsonWriter jsonWriter, string contentType)
+    {
+        this.pipeWriter = pipeWriter;
+        this.jsonWriter = jsonWriter;
+        this.format = contentType.StartsWith("text/event-stream", StringComparison.OrdinalIgnoreCase)
+            ? JsonStreamWriterFormat.ServerSentEvents
+            : JsonStreamWriterFormat.NewlineDelimitedJson;
+    }
+
+    /// <summary>
+    /// Writes a single stream item.
+    /// </summary>
+    /// <typeparam name="T">The JSON element type.</typeparam>
+    /// <param name="item">The item to write.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public async ValueTask WriteItemAsync<T>(T item, CancellationToken cancellationToken = default)
+        where T : struct, IJsonElement<T>
+    {
+        if (this.format == JsonStreamWriterFormat.ServerSentEvents)
+        {
+            Write(this.pipeWriter, SseDataPrefix);
+        }
+
+        item.WriteTo(this.jsonWriter);
+        this.jsonWriter.Flush();
+
+        Write(this.pipeWriter, this.format == JsonStreamWriterFormat.ServerSentEvents ? SseDataSuffix : NewLine);
+
+        FlushResult result = await this.pipeWriter.FlushAsync(cancellationToken).ConfigureAwait(false);
+        if (result.IsCanceled)
+        {
+            throw new OperationCanceledException(cancellationToken);
+        }
+
+        this.jsonWriter.Reset(this.pipeWriter);
+    }
+
+    private static void Write(PipeWriter writer, ReadOnlySpan<byte> value)
+    {
+        value.CopyTo(writer.GetSpan(value.Length));
+        writer.Advance(value.Length);
+    }
+
+    private enum JsonStreamWriterFormat
+    {
+        NewlineDelimitedJson,
+        ServerSentEvents,
+    }
+}

--- a/src/Corvus.Text.Json.OpenApi32/OpenApi32CodeGenerator.cs
+++ b/src/Corvus.Text.Json.OpenApi32/OpenApi32CodeGenerator.cs
@@ -8,6 +8,7 @@ using Corvus.Text.Json;
 using Corvus.Text.Json.Internal;
 using Corvus.Text.Json.OpenApi;
 using Corvus.Text.Json.OpenApi.CodeGeneration;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 
 namespace Corvus.Text.Json.OpenApi32;
@@ -3098,6 +3099,50 @@ public sealed class OpenApi32CodeGenerator
         }
 
         return null;
+    }
+
+    private static List<ContentInfo> GetStreamingContent(ResponseInfo response)
+    {
+        List<ContentInfo> streamingContent = [];
+
+        foreach (ContentInfo content in response.Content)
+        {
+            if (content.ItemSchemaPointer is not null)
+            {
+                streamingContent.Add(content);
+            }
+        }
+
+        return streamingContent;
+    }
+
+    private static string GetStreamingFactoryName(string baseName, string mediaType, bool includeMediaTypeSuffix)
+    {
+        if (!includeMediaTypeSuffix)
+        {
+            return baseName;
+        }
+
+        if (mediaType.StartsWith("text/event-stream", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"{baseName}Sse";
+        }
+
+        if (mediaType.StartsWith("application/x-ndjson", StringComparison.OrdinalIgnoreCase))
+        {
+            return $"{baseName}Ndjson";
+        }
+
+        return $"{baseName}{CodeEmitHelpers.SanitizeIdentifier(mediaType)}";
+    }
+
+    private static string GetSimpleTypeIdentifier(string typeName)
+    {
+        int dotIndex = typeName.LastIndexOf('.');
+        string simpleName = dotIndex >= 0 ? typeName[(dotIndex + 1)..] : typeName;
+        int genericIndex = simpleName.IndexOf('<');
+
+        return genericIndex >= 0 ? simpleName[..genericIndex] : simpleName;
     }
 
     /// <summary>
@@ -6722,6 +6767,10 @@ public sealed class OpenApi32CodeGenerator
         }
 
         bool hasHeaders = allHeaders.Count > 0;
+        bool hasStreamingResponses = op.Responses.Any(r => GetStreamingContent(r).Count > 0);
+        string streamTypeName = $"{op.MethodName}Stream";
+        string streamWriterDelegateName = $"{op.MethodName}StreamWriter";
+        string streamWriterInvokerName = $"{op.MethodName}StreamWriterInvoker";
 
         w.WriteLine("/// <summary>");
         w.WriteLine($"/// Result type for the {op.MethodName} operation.");
@@ -6733,6 +6782,11 @@ public sealed class OpenApi32CodeGenerator
         if (hasHeaders)
         {
             w.Write($"private {structName}(int statusCode, JsonElement body, string? contentType");
+            if (hasStreamingResponses)
+            {
+                w.Write($", {streamWriterInvokerName}? streamWriter = null, object? streamWriterContext = null");
+            }
+
             foreach (var (_, typeName, fieldName, _) in allHeaders)
             {
                 w.Write($", {typeName} {fieldName} = default");
@@ -6743,6 +6797,12 @@ public sealed class OpenApi32CodeGenerator
             w.WriteLine("this.StatusCode = statusCode;");
             w.WriteLine("this.Body = body;");
             w.WriteLine("this.ContentType = contentType;");
+            if (hasStreamingResponses)
+            {
+                w.WriteLine("this.streamWriter = streamWriter;");
+                w.WriteLine("this.streamWriterContext = streamWriterContext;");
+            }
+
             foreach (var (_, _, fieldName, propertyName) in allHeaders)
             {
                 w.WriteLine($"this.{propertyName} = {fieldName};");
@@ -6752,15 +6812,34 @@ public sealed class OpenApi32CodeGenerator
         }
         else
         {
-            w.WriteLine($"private {structName}(int statusCode, JsonElement body = default, string? contentType = null)");
+            w.Write($"private {structName}(int statusCode, JsonElement body = default, string? contentType = null");
+            if (hasStreamingResponses)
+            {
+                w.Write($", {streamWriterInvokerName}? streamWriter = null, object? streamWriterContext = null");
+            }
+
+            w.WriteLine(")");
             w.OpenBrace();
             w.WriteLine("this.StatusCode = statusCode;");
             w.WriteLine("this.Body = body;");
             w.WriteLine("this.ContentType = contentType;");
+            if (hasStreamingResponses)
+            {
+                w.WriteLine("this.streamWriter = streamWriter;");
+                w.WriteLine("this.streamWriterContext = streamWriterContext;");
+            }
+
             w.CloseBrace();
         }
 
         w.WriteLine();
+        if (hasStreamingResponses)
+        {
+            w.WriteLine($"private readonly {streamWriterInvokerName}? streamWriter;");
+            w.WriteLine("private readonly object? streamWriterContext;");
+            w.WriteLine();
+        }
+
         w.WriteLine("/// <summary>Gets the HTTP status code.</summary>");
         w.WriteLine("public int StatusCode { get; }");
         w.WriteLine();
@@ -6769,6 +6848,13 @@ public sealed class OpenApi32CodeGenerator
         w.WriteLine();
         w.WriteLine("/// <summary>Gets the content type for the response body.</summary>");
         w.WriteLine("public string? ContentType { get; }");
+
+        if (hasStreamingResponses)
+        {
+            w.WriteLine();
+            w.WriteLine("/// <summary>Gets a value indicating whether this result has a streaming response body.</summary>");
+            w.WriteLine("public bool HasStreamingBody => this.streamWriter is not null;");
+        }
 
         // Header properties
         foreach (var (header, typeName, _, propertyName) in allHeaders)
@@ -6804,7 +6890,7 @@ public sealed class OpenApi32CodeGenerator
                 w.WriteLine($"/// {CodeEmitHelpers.EscapeXml(defaultDesc)}");
                 w.WriteLine("/// </summary>");
 
-                this.EmitServerResultFactory(w, structName, factoryName, typeName, respHeaders, resp.StatusCode, hasHeaders);
+                this.EmitServerResultFactory(w, structName, factoryName, typeName, resp, respHeaders, resp.StatusCode, hasHeaders, streamTypeName, streamWriterDelegateName);
             }
             else
             {
@@ -6814,7 +6900,7 @@ public sealed class OpenApi32CodeGenerator
                 w.WriteLine($"/// {CodeEmitHelpers.EscapeXml(desc)}");
                 w.WriteLine("/// </summary>");
 
-                this.EmitServerResultFactory(w, structName, factoryName, typeName, respHeaders, resp.StatusCode, hasHeaders);
+                this.EmitServerResultFactory(w, structName, factoryName, typeName, resp, respHeaders, resp.StatusCode, hasHeaders, streamTypeName, streamWriterDelegateName);
             }
         }
 
@@ -6903,9 +6989,139 @@ public sealed class OpenApi32CodeGenerator
             w.CloseBrace();
         }
 
+        if (hasStreamingResponses)
+        {
+            w.WriteLine();
+            w.WriteLine("/// <summary>");
+            w.WriteLine("/// Writes the streaming response body.");
+            w.WriteLine("/// </summary>");
+            w.WriteLine("/// <param name=\"writer\">The stream writer.</param>");
+            w.WriteLine("/// <param name=\"cancellationToken\">The cancellation token.</param>");
+            w.WriteLine("/// <returns>A value task that completes when the stream has been written.</returns>");
+            w.WriteLine("public ValueTask WriteStreamAsync(JsonStreamWriter writer, CancellationToken cancellationToken = default)");
+            w.OpenBrace();
+            w.WriteLine("return this.streamWriter is null");
+            w.PushIndent();
+            w.WriteLine("? ValueTask.CompletedTask");
+            w.WriteLine(": this.streamWriter(writer, this.streamWriterContext, cancellationToken);");
+            w.PopIndent();
+            w.CloseBrace();
+            w.WriteLine();
+            w.WriteLine($"private delegate ValueTask {streamWriterInvokerName}(JsonStreamWriter writer, object? context, CancellationToken cancellationToken);");
+            w.WriteLine();
+            w.WriteLine($"private sealed class {streamWriterDelegateName}Context<TContext>");
+            w.OpenBrace();
+            w.WriteLine($"public {streamWriterDelegateName}Context(TContext context, {streamWriterDelegateName}<TContext> writer)");
+            w.OpenBrace();
+            w.WriteLine("this.Context = context;");
+            w.WriteLine("this.Writer = writer;");
+            w.CloseBrace();
+            w.WriteLine();
+            w.WriteLine("public TContext Context { get; }");
+            w.WriteLine();
+            w.WriteLine($"public {streamWriterDelegateName}<TContext> Writer {{ get; }}");
+            w.CloseBrace();
+        }
+
         w.CloseBrace();
 
+        if (hasStreamingResponses)
+        {
+            this.EmitServerStreamingTypes(w, op, streamTypeName, streamWriterDelegateName);
+        }
+
         return new GeneratedFile($"{structName}.cs", w.ToString());
+    }
+
+    private void EmitServerStreamingTypes(
+        IndentedWriter w,
+        OperationInfo op,
+        string streamTypeName,
+        string streamWriterDelegateName)
+    {
+        List<string> itemTypeNames = [];
+        foreach (ResponseInfo response in op.Responses)
+        {
+            foreach (ContentInfo content in GetStreamingContent(response))
+            {
+                if (content.ItemSchemaPointer is not null)
+                {
+                    string typeName = this.ResolveSchemaTypeName(content.ItemSchemaPointer);
+                    if (!itemTypeNames.Contains(typeName))
+                    {
+                        itemTypeNames.Add(typeName);
+                    }
+                }
+            }
+        }
+
+        w.WriteLine();
+        w.WriteLine("/// <summary>");
+        w.WriteLine($"/// Writes items for the {op.MethodName} streaming response.");
+        w.WriteLine("/// </summary>");
+        w.WriteLine($"public readonly struct {streamTypeName}");
+        w.OpenBrace();
+        w.WriteLine("private readonly JsonStreamWriter writer;");
+        w.WriteLine();
+        w.WriteLine($"internal {streamTypeName}(JsonStreamWriter writer)");
+        w.OpenBrace();
+        w.WriteLine("this.writer = writer;");
+        w.CloseBrace();
+
+        HashSet<string> emittedMethodNames = [];
+        foreach (string itemTypeName in itemTypeNames)
+        {
+            string methodName = $"Append{GetSimpleTypeIdentifier(itemTypeName)}";
+            if (!emittedMethodNames.Add(methodName))
+            {
+                methodName = $"Append{CodeEmitHelpers.SanitizeIdentifier(itemTypeName)}";
+            }
+
+            w.WriteLine();
+            w.WriteLine("/// <summary>");
+            w.WriteLine($"/// Appends a <see cref=\"{itemTypeName}\"/> item to the response stream.");
+            w.WriteLine("/// </summary>");
+            w.WriteLine("/// <param name=\"item\">The item to append.</param>");
+            w.WriteLine("/// <param name=\"cancellationToken\">The cancellation token.</param>");
+            w.WriteLine("/// <returns>A value task that completes when the item has been flushed.</returns>");
+            w.WriteLine($"public ValueTask {methodName}(in {itemTypeName}.Source item, CancellationToken cancellationToken = default)");
+            w.OpenBrace();
+            w.WriteLine("using JsonWorkspace workspace = JsonWorkspace.Create();");
+            w.WriteLine($"using JsonDocumentBuilder<{itemTypeName}.Mutable> builder = {itemTypeName}.CreateBuilder(workspace, item);");
+            w.WriteLine("return this.writer.WriteItemAsync(builder.RootElement, cancellationToken);");
+            w.CloseBrace();
+            w.WriteLine();
+            w.WriteLine("/// <summary>");
+            w.WriteLine($"/// Appends a <see cref=\"{itemTypeName}\"/> item to the response stream.");
+            w.WriteLine("/// </summary>");
+            w.WriteLine("/// <param name=\"item\">The item to append.</param>");
+            w.WriteLine("/// <param name=\"cancellationToken\">The cancellation token.</param>");
+            w.WriteLine("/// <returns>A value task that completes when the item has been flushed.</returns>");
+            w.WriteLine($"public ValueTask {methodName}({itemTypeName} item, CancellationToken cancellationToken = default)");
+            w.OpenBrace();
+            w.WriteLine("return this.writer.WriteItemAsync(item, cancellationToken);");
+            w.CloseBrace();
+        }
+
+        w.CloseBrace();
+        w.WriteLine();
+        w.WriteLine("/// <summary>");
+        w.WriteLine($"/// Callback used to write a {streamTypeName} response.");
+        w.WriteLine("/// </summary>");
+        w.WriteLine($"/// <param name=\"stream\">The {streamTypeName} writer.</param>");
+        w.WriteLine("/// <param name=\"cancellationToken\">The cancellation token.</param>");
+        w.WriteLine("/// <returns>A value task that completes when the stream has been written.</returns>");
+        w.WriteLine($"public delegate ValueTask {streamWriterDelegateName}({streamTypeName} stream, CancellationToken cancellationToken);");
+        w.WriteLine();
+        w.WriteLine("/// <summary>");
+        w.WriteLine($"/// Callback used to write a {streamTypeName} response with a context value.");
+        w.WriteLine("/// </summary>");
+        w.WriteLine("/// <typeparam name=\"TContext\">The callback context type.</typeparam>");
+        w.WriteLine($"/// <param name=\"stream\">The {streamTypeName} writer.</param>");
+        w.WriteLine("/// <param name=\"context\">The callback context.</param>");
+        w.WriteLine("/// <param name=\"cancellationToken\">The cancellation token.</param>");
+        w.WriteLine("/// <returns>A value task that completes when the stream has been written.</returns>");
+        w.WriteLine($"public delegate ValueTask {streamWriterDelegateName}<TContext>({streamTypeName} stream, TContext context, CancellationToken cancellationToken);");
     }
 
     private void EmitServerResultFactory(
@@ -6913,13 +7129,32 @@ public sealed class OpenApi32CodeGenerator
         string structName,
         string factoryName,
         string? bodyTypeName,
+        ResponseInfo response,
         List<(HeaderInfo Header, string TypeName, string FieldName, string PropertyName)> respHeaders,
         string statusCode,
-        bool structHasHeaders)
+        bool structHasHeaders,
+        string streamTypeName,
+        string streamWriterDelegateName)
     {
         bool isDefault = statusCode == "default";
-        bool hasBody = bodyTypeName is not null;
+        List<ContentInfo> streamingContent = GetStreamingContent(response);
+        bool hasStreamingBody = streamingContent.Count > 0;
+        bool hasBody = bodyTypeName is not null && !hasStreamingBody;
         bool hasRespHeaders = respHeaders.Count > 0;
+
+        if (hasStreamingBody)
+        {
+            this.EmitServerStreamingResultFactories(
+                w,
+                structName,
+                factoryName,
+                streamingContent,
+                respHeaders,
+                statusCode,
+                streamTypeName,
+                streamWriterDelegateName);
+            return;
+        }
 
         // Parameters
         StringBuilder paramList = new();
@@ -6990,6 +7225,107 @@ public sealed class OpenApi32CodeGenerator
         else
         {
             w.WriteLine($"public static {structName} {factoryName}({paramList}) => new({statusExpr}, {bodyExpr}, {contentTypeExpr});");
+        }
+    }
+
+    private void EmitServerStreamingResultFactories(
+        IndentedWriter w,
+        string structName,
+        string factoryName,
+        List<ContentInfo> streamingContent,
+        List<(HeaderInfo Header, string TypeName, string FieldName, string PropertyName)> respHeaders,
+        string statusCode,
+        string streamTypeName,
+        string streamWriterDelegateName)
+    {
+        bool isDefault = statusCode == "default";
+        bool includeMediaTypeSuffix = streamingContent.Count > 1;
+        string statusExpr = isDefault ? "statusCode" : statusCode;
+
+        foreach (ContentInfo content in streamingContent)
+        {
+            string methodName = GetStreamingFactoryName(factoryName, content.MediaType, includeMediaTypeSuffix);
+            string contentTypeExpr = SymbolDisplay.FormatLiteral(content.MediaType, quote: true);
+            string writerParam = $"{streamWriterDelegateName} writer";
+            string contextWriterParam = $"{streamWriterDelegateName}<TContext> writer";
+
+            StringBuilder commonParams = new();
+            if (isDefault)
+            {
+                commonParams.Append("int statusCode, ");
+            }
+
+            commonParams.Append(writerParam);
+            foreach (var (_, typeName, fieldName, _) in respHeaders)
+            {
+                commonParams.Append($", {typeName} {fieldName} = default");
+            }
+
+            StringBuilder contextParams = new();
+            if (isDefault)
+            {
+                contextParams.Append("int statusCode, ");
+            }
+
+            contextParams.Append($"TContext context, {contextWriterParam}");
+            foreach (var (_, typeName, fieldName, _) in respHeaders)
+            {
+                contextParams.Append($", {typeName} {fieldName} = default");
+            }
+
+            if (isDefault)
+            {
+                w.WriteLine("/// <param name=\"statusCode\">The HTTP status code.</param>");
+            }
+
+            w.WriteLine($"/// <param name=\"writer\">The callback that appends items to the <see cref=\"{streamTypeName}\"/>.</param>");
+            foreach (var (header, _, fieldName, _) in respHeaders)
+            {
+                w.WriteLine($"/// <param name=\"{fieldName}\">The value for the <c>{header.HeaderName}</c> response header.</param>");
+            }
+
+            w.WriteLine($"/// <returns>A <see cref=\"{structName}\"/> with status {statusCode}.</returns>");
+            StringBuilder ctorArgs = new();
+            ctorArgs.Append($"{statusExpr}, default, {contentTypeExpr}, streamWriter: static (jsonStreamWriter, context, cancellationToken) => (({streamWriterDelegateName})context!)(new {streamTypeName}(jsonStreamWriter), cancellationToken), streamWriterContext: writer");
+            foreach (var (_, _, fieldName, _) in respHeaders)
+            {
+                ctorArgs.Append($", {fieldName}: {fieldName}");
+            }
+
+            w.WriteLine($"public static {structName} {methodName}({commonParams}) => new({ctorArgs});");
+            w.WriteLine();
+            w.WriteLine($"/// <typeparam name=\"TContext\">The callback context type.</typeparam>");
+            if (isDefault)
+            {
+                w.WriteLine("/// <param name=\"statusCode\">The HTTP status code.</param>");
+            }
+
+            w.WriteLine($"/// <param name=\"context\">The callback context.</param>");
+            w.WriteLine($"/// <param name=\"writer\">The callback that appends items to the <see cref=\"{streamTypeName}\"/>.</param>");
+            foreach (var (header, _, fieldName, _) in respHeaders)
+            {
+                w.WriteLine($"/// <param name=\"{fieldName}\">The value for the <c>{header.HeaderName}</c> response header.</param>");
+            }
+
+            w.WriteLine($"/// <returns>A <see cref=\"{structName}\"/> with status {statusCode}.</returns>");
+            StringBuilder contextCtorArgs = new();
+            contextCtorArgs.Append($"{statusExpr}, default, {contentTypeExpr}, streamWriter: static (jsonStreamWriter, context, cancellationToken) =>");
+            w.WriteLine($"public static {structName} {methodName}<TContext>({contextParams}) => new({contextCtorArgs}");
+            w.PushIndent();
+            w.WriteLine("{");
+            w.PushIndent();
+            w.WriteLine($"var wrapper = ({streamWriterDelegateName}Context<TContext>)context!;");
+            w.WriteLine($"return wrapper.Writer(new {streamTypeName}(jsonStreamWriter), wrapper.Context, cancellationToken);");
+            w.PopIndent();
+            w.WriteLine("},");
+            w.Write($"streamWriterContext: new {streamWriterDelegateName}Context<TContext>(context, writer)");
+            foreach (var (_, _, fieldName, _) in respHeaders)
+            {
+                w.Write($", {fieldName}: {fieldName}");
+            }
+
+            w.WriteLine(");");
+            w.PopIndent();
         }
     }
 
@@ -7077,6 +7413,7 @@ public sealed class OpenApi32CodeGenerator
                 string paramsName = $"{op.MethodName}Params";
                 string resultName = $"{op.MethodName}Result";
                 bool hasBody = op.RequestBody is not null;
+                bool opHasStreamingResponses = op.Responses.Any(r => GetStreamingContent(r).Count > 0);
 
                 w.WriteLine();
 
@@ -7288,7 +7625,31 @@ public sealed class OpenApi32CodeGenerator
                     w.WriteLine();
                 }
 
-                w.WriteLine("if (!result.Body.IsUndefined())");
+                if (opHasStreamingResponses)
+                {
+                    w.WriteLine("if (result.HasStreamingBody)");
+                    w.OpenBrace();
+                    w.WriteLine("context.Response.ContentType = result.ContentType!;");
+                    w.WriteLine("Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);");
+                    w.WriteLine("try");
+                    w.OpenBrace();
+                    w.WriteLine("JsonStreamWriter streamWriter = new(context.Response.BodyWriter, writer, result.ContentType!);");
+                    w.WriteLine("await result.WriteStreamAsync(streamWriter, context.RequestAborted).ConfigureAwait(false);");
+                    w.CloseBrace();
+                    w.WriteLine("finally");
+                    w.OpenBrace();
+                    w.WriteLine("workspace.ReturnWriter(writer);");
+                    w.CloseBrace();
+                    w.WriteLine();
+                    w.WriteLine("await context.Response.BodyWriter.FlushAsync(context.RequestAborted).ConfigureAwait(false);");
+                    w.CloseBrace();
+                    w.WriteLine("else if (!result.Body.IsUndefined())");
+                }
+                else
+                {
+                    w.WriteLine("if (!result.Body.IsUndefined())");
+                }
+
                 w.OpenBrace();
                 w.WriteLine("context.Response.ContentType = result.ContentType ?? \"application/json\";");
                 w.WriteLine("Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);");

--- a/tests/Corvus.Text.Json.OpenApi.CodeGeneration.Tests/OpenApi32CodeGeneratorTests.cs
+++ b/tests/Corvus.Text.Json.OpenApi.CodeGeneration.Tests/OpenApi32CodeGeneratorTests.cs
@@ -1024,6 +1024,32 @@ public class OpenApi32CodeGeneratorTests
     }
 
     [TestMethod]
+    public void GenerateServer_StreamingResultStruct_HasPushWriterFactory()
+    {
+        Dictionary<string, string> schemaTypeMap = BuildFullCovspecSchemaTypeMap();
+        OpenApi32CodeGenerator generator = new("CovTest.Server", schemaTypeMap);
+        IReadOnlyList<GeneratedFile> files = generator.GenerateServer(covspecRoot);
+
+        GeneratedFile streamEventsResult = files.First(f => f.FileName == "StreamEventsResult.cs");
+
+        Assert.IsTrue(
+            streamEventsResult.Content.Contains("public static StreamEventsResult Ok(StreamEventsStreamWriter writer)"),
+            "Expected Ok factory to accept a stream writer callback");
+        Assert.IsTrue(
+            streamEventsResult.Content.Contains("public static StreamEventsResult Ok<TContext>(TContext context, StreamEventsStreamWriter<TContext> writer)"),
+            "Expected context overload for static stream writer callbacks");
+        Assert.IsTrue(
+            streamEventsResult.Content.Contains("public ValueTask AppendStreamEventItem(in CovTest.Client.StreamEventItem.Source item, CancellationToken cancellationToken = default)"),
+            "Expected generated stream type to append item sources");
+        Assert.IsTrue(
+            streamEventsResult.Content.Contains("public bool HasStreamingBody => this.streamWriter is not null;"),
+            "Expected streaming result marker");
+        Assert.IsFalse(
+            streamEventsResult.Content.Contains("public static StreamEventsResult Ok() =>"),
+            "Did not expect parameterless Ok() for itemSchema streaming responses");
+    }
+
+    [TestMethod]
     public void GenerateServer_ProducesEndpointRegistration()
     {
         Dictionary<string, string> schemaTypeMap = BuildFullCovspecSchemaTypeMap();

--- a/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/Generated/ApiEndpointRegistration.cs
+++ b/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/Generated/ApiEndpointRegistration.cs
@@ -1961,7 +1961,23 @@ public static class ApiEndpointRegistration
                 }
 
                 context.Response.StatusCode = result.StatusCode;
-                if (!result.Body.IsUndefined())
+                if (result.HasStreamingBody)
+                {
+                    context.Response.ContentType = result.ContentType!;
+                    Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);
+                    try
+                    {
+                        JsonStreamWriter streamWriter = new(context.Response.BodyWriter, writer, result.ContentType!);
+                        await result.WriteStreamAsync(streamWriter, context.RequestAborted).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        workspace.ReturnWriter(writer);
+                    }
+
+                    await context.Response.BodyWriter.FlushAsync(context.RequestAborted).ConfigureAwait(false);
+                }
+                else if (!result.Body.IsUndefined())
                 {
                     context.Response.ContentType = result.ContentType ?? "application/json";
                     Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);
@@ -2097,7 +2113,23 @@ public static class ApiEndpointRegistration
                 }
 
                 context.Response.StatusCode = result.StatusCode;
-                if (!result.Body.IsUndefined())
+                if (result.HasStreamingBody)
+                {
+                    context.Response.ContentType = result.ContentType!;
+                    Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);
+                    try
+                    {
+                        JsonStreamWriter streamWriter = new(context.Response.BodyWriter, writer, result.ContentType!);
+                        await result.WriteStreamAsync(streamWriter, context.RequestAborted).ConfigureAwait(false);
+                    }
+                    finally
+                    {
+                        workspace.ReturnWriter(writer);
+                    }
+
+                    await context.Response.BodyWriter.FlushAsync(context.RequestAborted).ConfigureAwait(false);
+                }
+                else if (!result.Body.IsUndefined())
                 {
                     context.Response.ContentType = result.ContentType ?? "application/json";
                     Utf8JsonWriter writer = workspace.RentWriter(context.Response.BodyWriter);

--- a/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/Generated/MoveResourceResult.cs
+++ b/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/Generated/MoveResourceResult.cs
@@ -19,12 +19,17 @@ namespace CanonTests32.Server;
 /// </summary>
 public readonly struct MoveResourceResult
 {
-    private MoveResourceResult(int statusCode, JsonElement body = default, string? contentType = null)
+    private MoveResourceResult(int statusCode, JsonElement body = default, string? contentType = null, MoveResourceStreamWriterInvoker? streamWriter = null, object? streamWriterContext = null)
     {
         this.StatusCode = statusCode;
         this.Body = body;
         this.ContentType = contentType;
+        this.streamWriter = streamWriter;
+        this.streamWriterContext = streamWriterContext;
     }
+
+    private readonly MoveResourceStreamWriterInvoker? streamWriter;
+    private readonly object? streamWriterContext;
 
     /// <summary>Gets the HTTP status code.</summary>
     public int StatusCode { get; }
@@ -35,11 +40,26 @@ public readonly struct MoveResourceResult
     /// <summary>Gets the content type for the response body.</summary>
     public string? ContentType { get; }
 
+    /// <summary>Gets a value indicating whether this result has a streaming response body.</summary>
+    public bool HasStreamingBody => this.streamWriter is not null;
+
     /// <summary>
     /// Creates a 200 Ok result.
     /// </summary>
+    /// <param name="writer">The callback that appends items to the <see cref="MoveResourceStream"/>.</param>
     /// <returns>A <see cref="MoveResourceResult"/> with status 200.</returns>
-    public static MoveResourceResult Ok() => new(200, default, null);
+    public static MoveResourceResult Ok(MoveResourceStreamWriter writer) => new(200, default, "application/x-ndjson", streamWriter: static (jsonStreamWriter, context, cancellationToken) => ((MoveResourceStreamWriter)context!)(new MoveResourceStream(jsonStreamWriter), cancellationToken), streamWriterContext: writer);
+
+    /// <typeparam name="TContext">The callback context type.</typeparam>
+    /// <param name="context">The callback context.</param>
+    /// <param name="writer">The callback that appends items to the <see cref="MoveResourceStream"/>.</param>
+    /// <returns>A <see cref="MoveResourceResult"/> with status 200.</returns>
+    public static MoveResourceResult Ok<TContext>(TContext context, MoveResourceStreamWriter<TContext> writer) => new(200, default, "application/x-ndjson", streamWriter: static (jsonStreamWriter, context, cancellationToken) =>
+        {
+            var wrapper = (MoveResourceStreamWriterContext<TContext>)context!;
+            return wrapper.Writer(new MoveResourceStream(jsonStreamWriter), wrapper.Context, cancellationToken);
+        },
+        streamWriterContext: new MoveResourceStreamWriterContext<TContext>(context, writer));
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.
@@ -62,4 +82,87 @@ public readonly struct MoveResourceResult
             this.Body.WriteTo(writer);
         }
     }
+
+    /// <summary>
+    /// Writes the streaming response body.
+    /// </summary>
+    /// <param name="writer">The stream writer.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the stream has been written.</returns>
+    public ValueTask WriteStreamAsync(JsonStreamWriter writer, CancellationToken cancellationToken = default)
+    {
+        return this.streamWriter is null
+            ? ValueTask.CompletedTask
+            : this.streamWriter(writer, this.streamWriterContext, cancellationToken);
+    }
+
+    private delegate ValueTask MoveResourceStreamWriterInvoker(JsonStreamWriter writer, object? context, CancellationToken cancellationToken);
+
+    private sealed class MoveResourceStreamWriterContext<TContext>
+    {
+        public MoveResourceStreamWriterContext(TContext context, MoveResourceStreamWriter<TContext> writer)
+        {
+            this.Context = context;
+            this.Writer = writer;
+        }
+
+        public TContext Context { get; }
+
+        public MoveResourceStreamWriter<TContext> Writer { get; }
+    }
 }
+
+/// <summary>
+/// Writes items for the MoveResource streaming response.
+/// </summary>
+public readonly struct MoveResourceStream
+{
+    private readonly JsonStreamWriter writer;
+
+    internal MoveResourceStream(JsonStreamWriter writer)
+    {
+        this.writer = writer;
+    }
+
+    /// <summary>
+    /// Appends a <see cref="CanonTests32.Server.ItemSchema"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendItemSchema(in CanonTests32.Server.ItemSchema.Source item, CancellationToken cancellationToken = default)
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+        using JsonDocumentBuilder<CanonTests32.Server.ItemSchema.Mutable> builder = CanonTests32.Server.ItemSchema.CreateBuilder(workspace, item);
+        return this.writer.WriteItemAsync(builder.RootElement, cancellationToken);
+    }
+
+    /// <summary>
+    /// Appends a <see cref="CanonTests32.Server.ItemSchema"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendItemSchema(CanonTests32.Server.ItemSchema item, CancellationToken cancellationToken = default)
+    {
+        return this.writer.WriteItemAsync(item, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Callback used to write a MoveResourceStream response.
+/// </summary>
+/// <param name="stream">The MoveResourceStream writer.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask MoveResourceStreamWriter(MoveResourceStream stream, CancellationToken cancellationToken);
+
+/// <summary>
+/// Callback used to write a MoveResourceStream response with a context value.
+/// </summary>
+/// <typeparam name="TContext">The callback context type.</typeparam>
+/// <param name="stream">The MoveResourceStream writer.</param>
+/// <param name="context">The callback context.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask MoveResourceStreamWriter<TContext>(MoveResourceStream stream, TContext context, CancellationToken cancellationToken);

--- a/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/Generated/StreamEventsResult.cs
+++ b/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/Generated/StreamEventsResult.cs
@@ -19,12 +19,17 @@ namespace CanonTests32.Server;
 /// </summary>
 public readonly struct StreamEventsResult
 {
-    private StreamEventsResult(int statusCode, JsonElement body = default, string? contentType = null)
+    private StreamEventsResult(int statusCode, JsonElement body = default, string? contentType = null, StreamEventsStreamWriterInvoker? streamWriter = null, object? streamWriterContext = null)
     {
         this.StatusCode = statusCode;
         this.Body = body;
         this.ContentType = contentType;
+        this.streamWriter = streamWriter;
+        this.streamWriterContext = streamWriterContext;
     }
+
+    private readonly StreamEventsStreamWriterInvoker? streamWriter;
+    private readonly object? streamWriterContext;
 
     /// <summary>Gets the HTTP status code.</summary>
     public int StatusCode { get; }
@@ -35,11 +40,26 @@ public readonly struct StreamEventsResult
     /// <summary>Gets the content type for the response body.</summary>
     public string? ContentType { get; }
 
+    /// <summary>Gets a value indicating whether this result has a streaming response body.</summary>
+    public bool HasStreamingBody => this.streamWriter is not null;
+
     /// <summary>
     /// Creates a 200 Ok result.
     /// </summary>
+    /// <param name="writer">The callback that appends items to the <see cref="StreamEventsStream"/>.</param>
     /// <returns>A <see cref="StreamEventsResult"/> with status 200.</returns>
-    public static StreamEventsResult Ok() => new(200, default, null);
+    public static StreamEventsResult Ok(StreamEventsStreamWriter writer) => new(200, default, "application/x-ndjson", streamWriter: static (jsonStreamWriter, context, cancellationToken) => ((StreamEventsStreamWriter)context!)(new StreamEventsStream(jsonStreamWriter), cancellationToken), streamWriterContext: writer);
+
+    /// <typeparam name="TContext">The callback context type.</typeparam>
+    /// <param name="context">The callback context.</param>
+    /// <param name="writer">The callback that appends items to the <see cref="StreamEventsStream"/>.</param>
+    /// <returns>A <see cref="StreamEventsResult"/> with status 200.</returns>
+    public static StreamEventsResult Ok<TContext>(TContext context, StreamEventsStreamWriter<TContext> writer) => new(200, default, "application/x-ndjson", streamWriter: static (jsonStreamWriter, context, cancellationToken) =>
+        {
+            var wrapper = (StreamEventsStreamWriterContext<TContext>)context!;
+            return wrapper.Writer(new StreamEventsStream(jsonStreamWriter), wrapper.Context, cancellationToken);
+        },
+        streamWriterContext: new StreamEventsStreamWriterContext<TContext>(context, writer));
 
     /// <summary>
     /// Validates the response body against the schema for the current status code.
@@ -62,4 +82,87 @@ public readonly struct StreamEventsResult
             this.Body.WriteTo(writer);
         }
     }
+
+    /// <summary>
+    /// Writes the streaming response body.
+    /// </summary>
+    /// <param name="writer">The stream writer.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the stream has been written.</returns>
+    public ValueTask WriteStreamAsync(JsonStreamWriter writer, CancellationToken cancellationToken = default)
+    {
+        return this.streamWriter is null
+            ? ValueTask.CompletedTask
+            : this.streamWriter(writer, this.streamWriterContext, cancellationToken);
+    }
+
+    private delegate ValueTask StreamEventsStreamWriterInvoker(JsonStreamWriter writer, object? context, CancellationToken cancellationToken);
+
+    private sealed class StreamEventsStreamWriterContext<TContext>
+    {
+        public StreamEventsStreamWriterContext(TContext context, StreamEventsStreamWriter<TContext> writer)
+        {
+            this.Context = context;
+            this.Writer = writer;
+        }
+
+        public TContext Context { get; }
+
+        public StreamEventsStreamWriter<TContext> Writer { get; }
+    }
 }
+
+/// <summary>
+/// Writes items for the StreamEvents streaming response.
+/// </summary>
+public readonly struct StreamEventsStream
+{
+    private readonly JsonStreamWriter writer;
+
+    internal StreamEventsStream(JsonStreamWriter writer)
+    {
+        this.writer = writer;
+    }
+
+    /// <summary>
+    /// Appends a <see cref="CanonTests32.Server.ItemSchema1"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendItemSchema1(in CanonTests32.Server.ItemSchema1.Source item, CancellationToken cancellationToken = default)
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+        using JsonDocumentBuilder<CanonTests32.Server.ItemSchema1.Mutable> builder = CanonTests32.Server.ItemSchema1.CreateBuilder(workspace, item);
+        return this.writer.WriteItemAsync(builder.RootElement, cancellationToken);
+    }
+
+    /// <summary>
+    /// Appends a <see cref="CanonTests32.Server.ItemSchema1"/> item to the response stream.
+    /// </summary>
+    /// <param name="item">The item to append.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns>A value task that completes when the item has been flushed.</returns>
+    public ValueTask AppendItemSchema1(CanonTests32.Server.ItemSchema1 item, CancellationToken cancellationToken = default)
+    {
+        return this.writer.WriteItemAsync(item, cancellationToken);
+    }
+}
+
+/// <summary>
+/// Callback used to write a StreamEventsStream response.
+/// </summary>
+/// <param name="stream">The StreamEventsStream writer.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask StreamEventsStreamWriter(StreamEventsStream stream, CancellationToken cancellationToken);
+
+/// <summary>
+/// Callback used to write a StreamEventsStream response with a context value.
+/// </summary>
+/// <typeparam name="TContext">The callback context type.</typeparam>
+/// <param name="stream">The StreamEventsStream writer.</param>
+/// <param name="context">The callback context.</param>
+/// <param name="cancellationToken">The cancellation token.</param>
+/// <returns>A value task that completes when the stream has been written.</returns>
+public delegate ValueTask StreamEventsStreamWriter<TContext>(StreamEventsStream stream, TContext context, CancellationToken cancellationToken);

--- a/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/GeneratedServerEndToEndTests.cs
+++ b/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/GeneratedServerEndToEndTests.cs
@@ -557,7 +557,12 @@ public class GeneratedServerEndToEndTests
     {
         HttpRequestMessage request = new(new HttpMethod("MOVE"), "/resources/res-1?destination=https://example.com/new");
         HttpResponseMessage response = await client!.SendAsync(request);
+
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.AreEqual("application/x-ndjson", response.Content.Headers.ContentType?.MediaType);
+
+        string body = await response.Content.ReadAsStringAsync();
+        Assert.AreEqual("{\"progress\":0,\"status\":\"started\"}\n{\"progress\":100,\"status\":\"completed\"}\n", body);
     }
 
     [TestMethod]
@@ -644,6 +649,10 @@ public class GeneratedServerEndToEndTests
     {
         HttpResponseMessage response = await client!.GetAsync("/events/stream");
         Assert.AreEqual(HttpStatusCode.OK, response.StatusCode);
+        Assert.AreEqual("application/x-ndjson", response.Content.Headers.ContentType?.MediaType);
+
+        string body = await response.Content.ReadAsStringAsync();
+        Assert.AreEqual("{\"eventId\":\"evt-1\",\"eventType\":\"created\",\"data\":{\"id\":1}}\n{\"eventId\":\"evt-2\",\"eventType\":\"updated\",\"data\":{\"id\":2}}\n", body);
     }
 
     // =====================================================================

--- a/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/JsonStreamWriterTests.cs
+++ b/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/JsonStreamWriterTests.cs
@@ -1,0 +1,52 @@
+// <copyright file="JsonStreamWriterTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.Buffers;
+using System.IO.Pipelines;
+using Corvus.Text.Json;
+using Corvus.Text.Json.OpenApi;
+
+namespace Corvus.Text.Json.OpenApi32.Server.Runtime.Tests;
+
+[TestClass]
+public sealed class JsonStreamWriterTests
+{
+    [TestMethod]
+    public async Task WriteItemAsync_WithServerSentEventsContentType_WritesSseDataFrames()
+    {
+        Pipe pipe = new();
+        Utf8JsonWriter jsonWriter = new(pipe.Writer);
+        JsonStreamWriter streamWriter = new(pipe.Writer, jsonWriter, "text/event-stream");
+
+        await streamWriter.WriteItemAsync(JsonElement.ParseValue("""{"message":"hello"}"""u8));
+        await streamWriter.WriteItemAsync(JsonElement.ParseValue("""{"message":"goodbye"}"""u8));
+        await pipe.Writer.CompleteAsync();
+
+        ReadResult readResult = await pipe.Reader.ReadAsync();
+        string body = System.Text.Encoding.UTF8.GetString(readResult.Buffer.ToArray());
+
+        Assert.AreEqual("data: {\"message\":\"hello\"}\n\ndata: {\"message\":\"goodbye\"}\n\n", body);
+        pipe.Reader.AdvanceTo(readResult.Buffer.End);
+        await pipe.Reader.CompleteAsync();
+    }
+
+    [TestMethod]
+    public async Task WriteItemAsync_WithNdjsonContentType_WritesNewlineDelimitedJson()
+    {
+        Pipe pipe = new();
+        Utf8JsonWriter jsonWriter = new(pipe.Writer);
+        JsonStreamWriter streamWriter = new(pipe.Writer, jsonWriter, "application/x-ndjson");
+
+        await streamWriter.WriteItemAsync(JsonElement.ParseValue("""{"message":"hello"}"""u8));
+        await streamWriter.WriteItemAsync(JsonElement.ParseValue("""{"message":"goodbye"}"""u8));
+        await pipe.Writer.CompleteAsync();
+
+        ReadResult readResult = await pipe.Reader.ReadAsync();
+        string body = System.Text.Encoding.UTF8.GetString(readResult.Buffer.ToArray());
+
+        Assert.AreEqual("{\"message\":\"hello\"}\n{\"message\":\"goodbye\"}\n", body);
+        pipe.Reader.AdvanceTo(readResult.Buffer.End);
+        await pipe.Reader.CompleteAsync();
+    }
+}

--- a/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/MockHandlers.cs
+++ b/tests/Corvus.Text.Json.OpenApi32.Server.Runtime.Tests/MockHandlers.cs
@@ -160,10 +160,24 @@ internal sealed class MockDefaultHandler : IApiDefaultHandler
         => new(PurgeResourceResult.NoContent());
 
     public ValueTask<MoveResourceResult> HandleMoveResourceAsync(MoveResourceParams parameters, JsonWorkspace workspace, CancellationToken cancellationToken = default)
-        => new(MoveResourceResult.Ok());
+        => new(MoveResourceResult.Ok(static async (stream, cancellationToken) =>
+        {
+            ItemSchema started = ItemSchema.ParseValue("""{"progress":0,"status":"started"}"""u8);
+            await stream.AppendItemSchema(started, cancellationToken).ConfigureAwait(false);
+
+            ItemSchema completed = ItemSchema.ParseValue("""{"progress":100,"status":"completed"}"""u8);
+            await stream.AppendItemSchema(completed, cancellationToken).ConfigureAwait(false);
+        }));
 
     public ValueTask<StreamEventsResult> HandleStreamEventsAsync(StreamEventsParams parameters, JsonWorkspace workspace, CancellationToken cancellationToken = default)
-        => new(StreamEventsResult.Ok());
+        => new(StreamEventsResult.Ok(static async (stream, cancellationToken) =>
+        {
+            ItemSchema1 created = ItemSchema1.ParseValue("""{"eventId":"evt-1","eventType":"created","data":{"id":1}}"""u8);
+            await stream.AppendItemSchema1(created, cancellationToken).ConfigureAwait(false);
+
+            ItemSchema1 updated = ItemSchema1.ParseValue("""{"eventId":"evt-2","eventType":"updated","data":{"id":2}}"""u8);
+            await stream.AppendItemSchema1(updated, cancellationToken).ConfigureAwait(false);
+        }));
 
     public ValueTask<SearchWithQuerystringResult> HandleSearchWithQuerystringAsync(SearchWithQuerystringParams parameters, JsonWorkspace workspace, CancellationToken cancellationToken = default)
     {


### PR DESCRIPTION
## Summary

- Fix OpenAPI 3.2 server `itemSchema` streaming responses so generated server handlers can write SSE and NDJSON bodies.
- Add generated push-writer streaming APIs and runtime stream framing support.
- Update OpenAPI documentation and example recipes so the streaming/client/server samples run headlessly and produce useful console output.
- Include follow-up recipe documentation fixes for TOON and AsyncAPI examples made while validating the docs/examples branch.

Closes #761

## Validation

- Built and ran the affected OpenAPI example recipes.
- Built and ran the affected AsyncAPI example recipes.
- Updated and checked the documentation code sample catalog for changed docs.