### PR TITLE
Fix playground samples after .Models sub-namespace change

### DIFF
--- a/docs/playground-asyncapi/src/Corvus.Text.Json.AsyncApi.Playground/Samples/iot-sensors/usercode.cs
+++ b/docs/playground-asyncapi/src/Corvus.Text.Json.AsyncApi.Playground/Samples/iot-sensors/usercode.cs
@@ -4,6 +4,7 @@ using Corvus.Text.Json;
 using Corvus.Text.Json.AsyncApi;
 using Corvus.Text.Json.AsyncApi.Testing;
 using Playground;
+using Playground.Models;
 
 // This example demonstrates the full publish → transport → consume pipeline
 // using InMemoryMessageTransport for testing without a real broker.

--- a/docs/playground-asyncapi/src/Corvus.Text.Json.AsyncApi.Playground/Samples/streetlights/usercode.cs
+++ b/docs/playground-asyncapi/src/Corvus.Text.Json.AsyncApi.Playground/Samples/streetlights/usercode.cs
@@ -3,6 +3,7 @@ using System.Text;
 using Corvus.Text.Json.AsyncApi;
 using Corvus.Text.Json.AsyncApi.Testing;
 using Playground;
+using Playground.Models;
 
 // ── Setting up the transport ─────────────────────────────────────────────────
 // In production, you would use a real transport (NATS, Kafka, AMQP, etc.).

--- a/docs/playground-openapi/src/Corvus.Text.Json.OpenApi.Playground/Samples/petstore-advanced/usercode.cs
+++ b/docs/playground-openapi/src/Corvus.Text.Json.OpenApi.Playground/Samples/petstore-advanced/usercode.cs
@@ -3,6 +3,7 @@ using Corvus.Text.Json;
 using Corvus.Text.Json.OpenApi;
 using Corvus.Text.Json.OpenApi.HttpTransport;
 using Playground;
+using Playground.Models;
 
 HttpClient httpClient = new(new PlaygroundHttpMessageHandler()) { BaseAddress = new Uri("https://petstore.example.com/v2") };
 await using HttpClientTransport transport = new(httpClient, disposeClient: true);

--- a/docs/playground-openapi/src/Corvus.Text.Json.OpenApi.Playground/Samples/petstore-client/usercode.cs
+++ b/docs/playground-openapi/src/Corvus.Text.Json.OpenApi.Playground/Samples/petstore-client/usercode.cs
@@ -3,6 +3,7 @@ using Corvus.Text.Json;
 using Corvus.Text.Json.OpenApi;
 using Corvus.Text.Json.OpenApi.HttpTransport;
 using Playground;
+using Playground.Models;
 
 // ── Setting up the client ────────────────────────────────────────────────────
 HttpClient httpClient = new(new PlaygroundHttpMessageHandler()) { BaseAddress = new Uri("https://petstore.example.com/v1") };


### PR DESCRIPTION
Fixes #767

Adds `using Playground.Models;` to all four playground `usercode.cs` samples that reference generated model types after the `.Models` sub-namespace change in #765.

**Fixed samples:**
- `playground-openapi` / `petstore-client`
- `playground-openapi` / `petstore-advanced`
- `playground-asyncapi` / `streetlights`
- `playground-asyncapi` / `iot-sensors`

Both playground solutions build clean (0 errors, 0 warnings).
