### PR TITLE
fix(docs): correct Getting Started code samples to match generated types

### DIFF
--- a/docs/website/site/content/GettingStarted/CreateAndMutate.md
+++ b/docs/website/site/content/GettingStarted/CreateAndMutate.md
@@ -13,7 +13,7 @@ using JsonWorkspace workspace = JsonWorkspace.Create();
 
 using var builder = Person.CreateBuilder(
     workspace,
-    name: Person.PersonNameEntity.Build(
+    name: Person.PersonName.Build(
         (ref nb) => nb.Create(familyName: "Oldroyd"u8, givenName: "Michael"u8)),
     age: 30,
     email: "michael@example.com"u8);
@@ -31,10 +31,10 @@ Use `NestedType.Build()` to compose nested values as parameters:
 ```csharp
 using var builder = Person.CreateBuilder(
     workspace,
-    name: Person.PersonNameEntity.Build(
+    name: Person.PersonName.Build(
         (ref nb) => nb.Create(familyName: "Oldroyd"u8, givenName: "Michael"u8)),
     age: 30,
-    address: Person.AddressEntity.Build((ref ab) => ab.Create(
+    address: Person.Address.Build((ref ab) => ab.Create(
         street: "123 Main St"u8,
         city: "Springfield"u8)));
 ```
@@ -46,9 +46,9 @@ Build array properties by adding elements inside the builder delegate:
 ```csharp
 using var builder = Person.CreateBuilder(
     workspace,
-    name: Person.PersonNameEntity.Build(
+    name: Person.PersonName.Build(
         (ref nb) => nb.Create(familyName: "Oldroyd"u8, givenName: "Michael"u8)),
-    hobbies: Person.HobbiesEntity.Build((ref hb) =>
+    hobbies: Person.JsonStringArray.Build((ref hb) =>
     {
         hb.AddItem("reading"u8);
         hb.AddItem("hiking"u8);
@@ -64,8 +64,8 @@ For scenarios that require logic inside the builder (e.g., conditional propertie
 using var builder = TargetType.CreateBuilder(workspace, (ref TargetType.Builder b) =>
 {
     b.Create(
-        fullName: TargetType.FullNameEntity.From(source.Name),
-        identifier: TargetType.IdentifierEntity.From(source.Id));
+        fullName: TargetType.FullName.From(source.Name),
+        identifier: TargetType.Identifier.From(source.Id));
 });
 ```
 
@@ -111,7 +111,7 @@ You can make multiple modifications to the *same* entity without re-obtaining it
 Person.Mutable root = builder.RootElement;
 root.SetAge(31);
 root.SetEmail("michael@example.com"u8);
-root.Address.SetCity("London"u8);
+root.AddressValue.SetCity("London"u8);
 ```
 
 A root element is always live, so it never needs to be re-obtained. Intermediate child references, however, *will* be invalidated by sibling mutations — always navigate from the root to access different children:
@@ -119,7 +119,7 @@ A root element is always live, so it never needs to be re-obtained. Intermediate
 ```csharp
 Person.Mutable root = builder.RootElement;  // always live — cache freely
 root.RemoveEmail();              // structural change
-root.Address.SetCity("London"u8); // still valid — root is always live
+root.AddressValue.SetCity("London"u8); // still valid — root is always live
 ```
 
 To avoid expensive lookups, you can make multiple modifications to the *same* entity. Its own version is refreshed when it is modified.
@@ -127,9 +127,9 @@ To avoid expensive lookups, you can make multiple modifications to the *same* en
 ```csharp
 Person.Mutable root = builder.RootElement;  // always live — cache freely
 root.RemoveEmail();              // structural change
-Person.AddressEntity.Mutable address = root.Address;
-address.SetCity("London"u8); // still valid — root is always live
-address.SetZipCode("SE3"u8); // still valid — root is always live
+Person.Address.Mutable address = root.AddressValue;
+address.SetCity("London"u8); // valid — navigated from always-live root
+address.SetZipCode("SE3"u8); // still valid — same entity, version refreshed
 ```
 
 ## Removing properties
@@ -151,7 +151,7 @@ using var targetBuilder = targetDoc.RootElement.CreateBuilder(workspace);
 
 Person.Mutable target = targetBuilder.RootElement;
 
-// Both documents use the same PersonNameEntity type — direct assignment
+// Both documents use the same PersonName type — direct assignment
 target.SetName(sourceDoc.RootElement.Name);
 ```
 
@@ -171,7 +171,7 @@ In practice, you often need to map between types generated from *different* sche
 }
 ```
 
-Both schemas have an email property based on `"type": "string", "format": "email"`, but the Employee schema adds a `maxLength` constraint. That extra constraint means the code generator produces a distinct `Employee.WorkEmailEntity` type rather than reusing the shared global email type. Because the underlying JSON is structurally compatible, you can use `TTarget.From()` to reinterpret the value without copying:
+Both schemas have an email property based on `"type": "string", "format": "email"`, but the Employee schema adds a `maxLength` constraint. That extra constraint means the code generator produces a distinct `Employee.WorkEmail` type rather than reusing the shared global email type. Because the underlying JSON is structurally compatible, you can use `TTarget.From()` to reinterpret the value without copying:
 
 ```csharp
 using ParsedJsonDocument<Employee> employeeDoc =
@@ -180,9 +180,9 @@ using var personBuilder = personDoc.RootElement.CreateBuilder(workspace);
 
 Person.Mutable person = personBuilder.RootElement;
 
-// Employee.WorkEmailEntity and Person.EmailEntity are different C# types
+// Employee.WorkEmail and the Person email type are different C# types
 // but both wrap "type": "string", "format": "email" — From() bridges them
-person.SetEmail(Person.EmailEntity.From(employeeDoc.RootElement.WorkEmail));
+person.SetEmail(JsonEmail.From(employeeDoc.RootElement.WorkEmail));
 
 // Simple string values can also be assigned directly via implicit conversion
 person.Name.SetGivenName(employeeDoc.RootElement.FullName);
@@ -211,8 +211,8 @@ using ParsedJsonDocument<Person> doc =
 using var builder = doc.RootElement.CreateBuilder(workspace);
 
 // Parse a Location with city and country
-using ParsedJsonDocument<Person.AddressEntity.LocationEntity> locationDoc =
-    ParsedJsonDocument<Person.AddressEntity.LocationEntity>.Parse(
+using ParsedJsonDocument<Person.Location> locationDoc =
+    ParsedJsonDocument<Person.Location>.Parse(
         """
         {
           "city": "Springfield",
@@ -222,9 +222,9 @@ using ParsedJsonDocument<Person.AddressEntity.LocationEntity> locationDoc =
 
 // Apply merges the location properties into the address
 Person.Mutable root = builder.RootElement;
-root.Address.Apply(locationDoc.RootElement);
+root.AddressValue.Apply(locationDoc.RootElement);
 
-Console.WriteLine(root.Address.ToString());
+Console.WriteLine(root.AddressValue.ToString());
 // {"street":"123 Main St","zipCode":"SP1 1AA","city":"Springfield","country":"UK"}
 ```
 
@@ -310,7 +310,7 @@ builder.RootElement.SetAge(31);
 Person frozen = builder.RootElement.Freeze();
 
 // Or freeze a nested element to get an immutable copy of just that subtree
-Person.PersonNameEntity frozenName = builder.RootElement.Name.Freeze();
+Person.PersonName frozenName = builder.RootElement.Name.Freeze();
 
 // Both are valid for the lifetime of the workspace
 ```

--- a/docs/website/site/content/GettingStarted/DefineSchema.md
+++ b/docs/website/site/content/GettingStarted/DefineSchema.md
@@ -128,5 +128,5 @@ Values are converted to .NET primitives like `string`, `int`, or `LocalDate` onl
 - **No redundant copying** — the underlying UTF-8 bytes are shared, not cloned.
 - **Conversion cost is deferred** — you only pay for what you access.
 
-The code generator walks the schema tree from the root type and generates C# for every schema it encounters. Each schema element typically produces multiple partial-class files by concern (e.g., `Person.cs`, `Person.JsonSchema.cs`, `Person.Mutable.cs`). Nested entity types like `PersonName` become nested structs within the parent type (e.g., `Person.PersonNameEntity`).
+The code generator walks the schema tree from the root type and generates C# for every schema it encounters. Each schema element typically produces multiple partial-class files by concern (e.g., `Person.cs`, `Person.JsonSchema.cs`, `Person.Mutable.cs`). Nested definitions like `PersonName` become nested structs within the parent type (e.g., `Person.PersonName`). When a property name would clash with a nested type name (e.g., the `address` property and the `Address` type), the property accessor gets a `Value` suffix (e.g., `person.AddressValue`).
 

--- a/docs/website/site/content/GettingStarted/UseGeneratedTypes.md
+++ b/docs/website/site/content/GettingStarted/UseGeneratedTypes.md
@@ -17,25 +17,16 @@ using ParsedJsonDocument<Person> doc =
 Person person = doc.RootElement;
 ```
 
-### ParseValue (convenience)
-
-Returns a self-owned value — no explicit disposal needed, but the backing memory is not shared:
-
-```csharp
-Person person = Person.ParseValue(
-    """{"name":{"familyName":"Oldroyd","givenName":"Michael"},"age":30}""");
-```
-
 ### Other sources
 
 ```csharp
 // From UTF-8 bytes
-Person person = Person.ParseValue(
-    """{"name":{"familyName":"Oldroyd"},"age":30}"""u8);
+using ParsedJsonDocument<Person> doc2 = ParsedJsonDocument<Person>.Parse(
+    """{"name":{"familyName":"Oldroyd"},"age":30}"""u8.ToArray());
 
 // From a stream
 using FileStream stream = File.OpenRead("person.json");
-using ParsedJsonDocument<Person> doc = ParsedJsonDocument<Person>.Parse(stream);
+using ParsedJsonDocument<Person> doc3 = ParsedJsonDocument<Person>.Parse(stream);
 ```
 
 ## Property access
@@ -75,12 +66,16 @@ JsonElement age = person["age"];
 
 ### TryGetProperty
 
+For dynamic property access when you don't know the property name at compile time:
+
 ```csharp
 if (person.TryGetProperty("email"u8, out JsonElement email))
 {
-    Console.WriteLine((string)email);
+    Console.WriteLine(email.GetString());
 }
 ```
+
+> **Tip:** Prefer the strongly-typed property accessors (e.g., `person.Email`) over `TryGetProperty()` whenever the property is known at compile time. The typed accessors return the correct generated type, support direct conversions, and are validated by the compiler.
 
 ## Array access
 
@@ -97,14 +92,17 @@ foreach (var hobby in person.Hobbies.EnumerateArray())
 }
 ```
 
-When `otherNames` is an array (rather than a single string), you can enumerate it in the same way:
+When `otherNames` is an array (rather than a single string), you can use `TryGetAsPersonNameElementArray` to access the strongly-typed array variant:
 
 ```csharp
 // otherNames uses oneOf — it can be a single string or an array
-// Use AsPersonNameElementArray to access the array variant
-foreach (var name in person.Name.OtherNames.AsPersonNameElementArray.EnumerateArray())
+// Use TryGetAsPersonNameElementArray to access the array variant
+if (person.Name.OtherNamesValue.TryGetAsPersonNameElementArray(out var otherNamesArray))
 {
-    Console.WriteLine((string)name);
+    foreach (var name in otherNamesArray.EnumerateArray())
+    {
+        Console.WriteLine((string)name);
+    }
 }
 ```
 
@@ -271,8 +269,11 @@ When you attempt to cast an undefined or null value to a .NET type, it throws an
 Generated types support value equality:
 
 ```csharp
-Person a = Person.ParseValue(json);
-Person b = Person.ParseValue(json);
+using ParsedJsonDocument<Person> docA = ParsedJsonDocument<Person>.Parse(json);
+using ParsedJsonDocument<Person> docB = ParsedJsonDocument<Person>.Parse(json);
+
+Person a = docA.RootElement;
+Person b = docB.RootElement;
 
 bool equal = a.Equals(b);  // true — deep JSON equality
 bool same  = a == b;        // operator overload
@@ -294,11 +295,11 @@ JSON Schema supports composition keywords like `oneOf`, `anyOf`, and `allOf` tha
 The generated type provides a `Match()` method that dispatches to a typed delegate for each variant. Each variant gets its own named parameter, and a `defaultMatch` fallback handles values that don't conform to any variant:
 
 ```csharp
-string result = person.Name.OtherNames.Match(
-    matchPersonNameElement: static (v) => $"Single name: {(string)v}",
-    matchPersonNameElementArray: static (v)
+string result = person.Name.OtherNamesValue.Match(
+    matchPersonNameElement: static (in v) => $"Single name: {(string)v}",
+    matchPersonNameElementArray: static (in v)
         => $"Multiple names: {string.Join(", ", v.EnumerateArray().Select(n => (string)n))}",
-    defaultMatch: static (_) => "Unknown format");
+    defaultMatch: static (in _) => "Unknown format");
 
 Console.WriteLine(result);
 ```
@@ -308,10 +309,10 @@ Console.WriteLine(result);
 There is also a context-passing overload for when you need to pass state into the matchers without capturing:
 
 ```csharp
-string result = person.Name.OtherNames.Match(
+string result = person.Name.OtherNamesValue.Match(
     separator,  // context passed to each matcher
-    matchPersonNameElement: static (v, sep) => (string)v,
-    matchPersonNameElementArray: static (v, sep)
+    matchPersonNameElement: static (in v, in sep) => (string)v,
+    matchPersonNameElementArray: static (in v, in sep)
         => string.Join(sep, v.EnumerateArray().Select(n => (string)n)),
-    defaultMatch: static (_, sep) => string.Empty);
+    defaultMatch: static (in _, in sep) => string.Empty);
 ```


### PR DESCRIPTION
## Summary

Fixes compilation errors in the Getting Started documentation by correcting code samples to match the actual generated type names, property accessors, and API signatures.

## Changes

### UseGeneratedTypes.md
- Removed deprecated `ParseValue` section (API is obsolete)
- Fixed `TryGetProperty` example: `(string)email` → `email.GetString()` (no explicit string cast on `JsonElement`)
- Fixed `Match()` examples: added required `in` keyword on lambda parameters
- Fixed `OtherNamesValue` property name (was `OtherNames`)
- Fixed array access pattern to use `TryGetAsPersonNameElementArray`
- Fixed equality example to use `ParsedJsonDocument`

### CreateAndMutate.md
- Fixed all `Entity` suffixes in `CreateBuilder` examples (e.g., `PersonNameEntity` → `PersonName`)
- Fixed property names (`AddressValue`, `Hobbies` etc.)
- Fixed `Apply()` example with correct types (`Person.Location`)
- Fixed `From()` usage example

### DefineSchema.md
- Fixed explanation of nested type naming and `Value` suffix convention

## Verification

All code samples were tested by creating a fresh console project with the source generator and running each block from the documentation in sequence. Every example compiles and produces the expected output.