### PR TITLE
Add JSDoc comments to module export in monaco-editor-shim.js

### DIFF
--- a/docs/playground-jsonata/monaco-editor-shim.js
+++ b/docs/playground-jsonata/monaco-editor-shim.js
@@ -1,2 +1,6 @@
-// Shim for monaco-editor: returns the global `monaco` object loaded by BlazorMonaco.
+/**
+ * Shim for monaco-editor: returns the global `monaco` object loaded by BlazorMonaco.
+ * @module monaco-editor-shim
+ * @returns {object} The monaco editor instance or an empty object if not available.
+ */
 module.exports = (typeof monaco !== 'undefined') ? monaco : {};


### PR DESCRIPTION
### 问题背景
模块导出 `monaco-editor-shim.js` 缺乏详细的 JSDoc 注释，这可能降低代码的可读性、维护性，并影响自动化文档生成工具的效率。为提升代码质量和文档一致性，需要添加标准化的 JSDoc 注释。

### 修改内容
在文件 `docs/playground-jsonata/monaco-editor-shim.js` 中，将原有的单行注释替换为完整的 JSDoc 注释，包括：
- `@module` 标签指定模块名
- 描述模块的功能（作为 BlazorMonaco 加载的 monaco 编辑器 shim）
- `@returns` 标签指定返回值类型（monaco 编辑器实例或空对象）

### 验证方式
1. **代码审查**：检查 JSDoc 注释语法是否正确，并确保符合项目现有的代码风格和命名约定。
2. **文档生成测试**：如果有文档生成工具（如 JSDoc），运行它验证新注释是否被正确解析并输出到生成的文档中。
3. **功能不变性**：确认模块导出行为未改变，仍返回相同的 monaco 对象或空对象。