### PR TITLE
Update JSON-Schema-Test-Suite submodule and regenerate fixtures (#795)

### DIFF
--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2019-09/minProperties.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2019-09/minProperties.cs
@@ -67,6 +67,20 @@ public class SuiteMinPropertiesValidation
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("null");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("true");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
     public class Fixture
     {
         public CompiledEvaluator Evaluator { get; private set; }

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2019-09/optional/format/date.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2019-09/optional/format/date.cs
@@ -96,20 +96,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWith29DaysInFebruaryNormal()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2021-02-29\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
-    public void TestAValidDateStringWith29DaysInFebruaryLeap()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-02-29\"");
-        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
     public void TestAInvalidDateStringWith30DaysInFebruaryLeap()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-02-30\"");
@@ -257,13 +243,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWithInvalidMonth()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-13-01\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
     public void TestAnInvalidDateString()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"06/19/1963\"");
@@ -295,13 +274,6 @@ public class SuiteValidationOfDateStrings
     public void TestInvalidMonth()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"1998-13-01\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
-    public void TestInvalidMonthDayCombination()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"1998-04-31\"");
         Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
@@ -358,6 +330,153 @@ public class SuiteValidationOfDateStrings
     public void TestAnInvalidTimeStringInDateTimeFormat()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-11-28T23:55:45Z\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestYear0000IsALeapYear04000()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0000-02-29\"");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0100IsNotALeapYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0100-02-29\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0400IsALeapYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0400-02-29\"");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestCenturyYear2100IsNotALeapYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2100-02-29\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidLeadingWhitespaceIsNotPermitted()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\" 2024-01-15\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingWhitespaceIsNotPermitted()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2024-01-15 \"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidMonth00IsNotValidPerDateMonthRange0112()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2024-00-15\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidDay00IsNotValidPerDateMdayMinimumOf01()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2024-01-00\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidEmptyString()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidEmbeddedWhitespaceBetweenYearAndMonth()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020 -01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingCharacterAfterValidFullDate()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-01-01X\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingZAfterFullDate()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-01-01Z\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidFullDateFollowedBySpaceAndTimeComponent()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-01-01 00:00:00Z\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestValidFourDigitYear0001()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0001-01-01\"");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTwoDigitYearN2Digits()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"20-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidThreeDigitYearN1Digits()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"998-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidFiveDigitYearN1Digits()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"12020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidPositiveSignPrefixOnYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"+2020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidNegativeSignPrefixOnYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"-2020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidNonAsciiBengaliDigitInYearField()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"২020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidAlphabeticCharactersInYearField()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"YYYY-01-01\"");
         Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2019-09/optional/format/hostname.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2019-09/optional/format/hostname.cs
@@ -159,13 +159,6 @@ public class SuiteValidationOfHostNames
     }
 
     [TestMethod]
-    public void TestContainsInThe3rdAnd4thPosition()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"XN--aa---o47jg78q\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
     public void TestContainsUnderscore()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"host_name\"");
@@ -487,6 +480,13 @@ public class SuiteValidationOfALabelPunycodeHostNames
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"xn--ngba5hb2804a\"");
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestContainsInThe3rdAnd4thPosition()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"XN--aa---o47jg78q\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
     public class Fixture

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2019-09/propertyNames.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2019-09/propertyNames.cs
@@ -67,6 +67,20 @@ public class SuitePropertyNamesValidation
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("null");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("true");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
     public class Fixture
     {
         public CompiledEvaluator Evaluator { get; private set; }

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2019-09/unevaluatedProperties.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2019-09/unevaluatedProperties.cs
@@ -2434,3 +2434,105 @@ public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocation
         }
     }
 }
+
+[TestCategory("Draft201909")]
+[TestClass]
+public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocationWithPatternProperties
+{
+    private static Fixture? s_fixture;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        s_fixture = new Fixture();
+        await s_fixture.InitializeAsync();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanupMethod()
+    {
+        s_fixture = null;
+    }
+
+    [TestMethod]
+    public void TestWithOnlyTheNestedEvaluatedProperty()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("{\n                    \"foo\": { \"bar\": \"foo\" }\n                }");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestWithAnUnevaluatedPropertyThatExistsAtAnotherLocation()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("{\n                    \"foo\": { \"bar\": \"foo\" },\n                    \"bar\": \"bar\"\n                }");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    public class Fixture
+    {
+        public CompiledEvaluator Evaluator { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            this.Evaluator = await TestEvaluatorHelper.GenerateEvaluatorForVirtualFileAsync(
+                "tests/draft2019-09/unevaluatedProperties.json",
+                "{\n            \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n            \"properties\": {\n                \"foo\": {\n                    \"patternProperties\": {\n                        \"^bar$\": { \"type\": \"string\" }\n                    }\n                }\n            },\n            \"unevaluatedProperties\": false\n        }",
+                "StandaloneEvaluatorTestSuite.Draft201909.UnevaluatedProperties",
+                "../../../../../JSON-Schema-Test-Suite/remotes",
+                "https://json-schema.org/draft/2019-09/schema",
+                validateFormat: false,
+                Assembly.GetExecutingAssembly());
+        }
+    }
+}
+
+[TestCategory("Draft201909")]
+[TestClass]
+public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocationWithAdditionalProperties
+{
+    private static Fixture? s_fixture;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        s_fixture = new Fixture();
+        await s_fixture.InitializeAsync();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanupMethod()
+    {
+        s_fixture = null;
+    }
+
+    [TestMethod]
+    public void TestWithOnlyTheNestedEvaluatedProperty()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("{\n                    \"foo\": { \"bar\": \"foo\" }\n                }");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestWithAnUnevaluatedPropertyThatExistsAtAnotherLocation()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("{\n                    \"foo\": { \"bar\": \"foo\" },\n                    \"bar\": \"bar\"\n                }");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    public class Fixture
+    {
+        public CompiledEvaluator Evaluator { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            this.Evaluator = await TestEvaluatorHelper.GenerateEvaluatorForVirtualFileAsync(
+                "tests/draft2019-09/unevaluatedProperties.json",
+                "{\n            \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n            \"properties\": {\n                \"foo\": {\n                    \"additionalProperties\": { \"type\": \"string\" }\n                }\n            },\n            \"unevaluatedProperties\": false\n        }",
+                "StandaloneEvaluatorTestSuite.Draft201909.UnevaluatedProperties",
+                "../../../../../JSON-Schema-Test-Suite/remotes",
+                "https://json-schema.org/draft/2019-09/schema",
+                validateFormat: false,
+                Assembly.GetExecutingAssembly());
+        }
+    }
+}

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2020-12/minProperties.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2020-12/minProperties.cs
@@ -67,6 +67,20 @@ public class SuiteMinPropertiesValidation
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("null");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("true");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
     public class Fixture
     {
         public CompiledEvaluator Evaluator { get; private set; }

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2020-12/optional/format/date.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2020-12/optional/format/date.cs
@@ -96,20 +96,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWith29DaysInFebruaryNormal()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2021-02-29\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
-    public void TestAValidDateStringWith29DaysInFebruaryLeap()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-02-29\"");
-        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
     public void TestAInvalidDateStringWith30DaysInFebruaryLeap()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-02-30\"");
@@ -257,13 +243,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWithInvalidMonth()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-13-01\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
     public void TestAnInvalidDateString()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"06/19/1963\"");
@@ -295,13 +274,6 @@ public class SuiteValidationOfDateStrings
     public void TestInvalidMonth()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"1998-13-01\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
-    public void TestInvalidMonthDayCombination()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"1998-04-31\"");
         Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
@@ -358,6 +330,153 @@ public class SuiteValidationOfDateStrings
     public void TestAnInvalidTimeStringInDateTimeFormat()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-11-28T23:55:45Z\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestYear0000IsALeapYear04000()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0000-02-29\"");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0100IsNotALeapYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0100-02-29\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0400IsALeapYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0400-02-29\"");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestCenturyYear2100IsNotALeapYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2100-02-29\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidLeadingWhitespaceIsNotPermitted()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\" 2024-01-15\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingWhitespaceIsNotPermitted()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2024-01-15 \"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidMonth00IsNotValidPerDateMonthRange0112()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2024-00-15\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidDay00IsNotValidPerDateMdayMinimumOf01()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2024-01-00\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidEmptyString()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidEmbeddedWhitespaceBetweenYearAndMonth()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020 -01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingCharacterAfterValidFullDate()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-01-01X\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingZAfterFullDate()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-01-01Z\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidFullDateFollowedBySpaceAndTimeComponent()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-01-01 00:00:00Z\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestValidFourDigitYear0001()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0001-01-01\"");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTwoDigitYearN2Digits()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"20-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidThreeDigitYearN1Digits()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"998-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidFiveDigitYearN1Digits()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"12020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidPositiveSignPrefixOnYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"+2020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidNegativeSignPrefixOnYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"-2020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidNonAsciiBengaliDigitInYearField()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"২020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidAlphabeticCharactersInYearField()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"YYYY-01-01\"");
         Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2020-12/optional/format/hostname.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2020-12/optional/format/hostname.cs
@@ -159,13 +159,6 @@ public class SuiteValidationOfHostNames
     }
 
     [TestMethod]
-    public void TestContainsInThe3rdAnd4thPosition()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"XN--aa---o47jg78q\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
     public void TestContainsUnderscore()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"host_name\"");
@@ -487,6 +480,13 @@ public class SuiteValidationOfALabelPunycodeHostNames
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"xn--ngba5hb2804a\"");
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestContainsInThe3rdAnd4thPosition()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"XN--aa---o47jg78q\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
     public class Fixture

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2020-12/propertyNames.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2020-12/propertyNames.cs
@@ -67,6 +67,20 @@ public class SuitePropertyNamesValidation
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("null");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("true");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
     public class Fixture
     {
         public CompiledEvaluator Evaluator { get; private set; }

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2020-12/unevaluatedProperties.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft2020-12/unevaluatedProperties.cs
@@ -2434,3 +2434,105 @@ public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocation
         }
     }
 }
+
+[TestCategory("Draft202012")]
+[TestClass]
+public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocationWithPatternProperties
+{
+    private static Fixture? s_fixture;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        s_fixture = new Fixture();
+        await s_fixture.InitializeAsync();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanupMethod()
+    {
+        s_fixture = null;
+    }
+
+    [TestMethod]
+    public void TestWithOnlyTheNestedEvaluatedProperty()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("{\n                    \"foo\": { \"bar\": \"foo\" }\n                }");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestWithAnUnevaluatedPropertyThatExistsAtAnotherLocation()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("{\n                    \"foo\": { \"bar\": \"foo\" },\n                    \"bar\": \"bar\"\n                }");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    public class Fixture
+    {
+        public CompiledEvaluator Evaluator { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            this.Evaluator = await TestEvaluatorHelper.GenerateEvaluatorForVirtualFileAsync(
+                "tests/draft2020-12/unevaluatedProperties.json",
+                "{\n            \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n            \"properties\": {\n                \"foo\": {\n                    \"patternProperties\": {\n                        \"^bar$\": { \"type\": \"string\" }\n                    }\n                }\n            },\n            \"unevaluatedProperties\": false\n        }",
+                "StandaloneEvaluatorTestSuite.Draft202012.UnevaluatedProperties",
+                "../../../../../JSON-Schema-Test-Suite/remotes",
+                "https://json-schema.org/draft/2020-12/schema",
+                validateFormat: false,
+                Assembly.GetExecutingAssembly());
+        }
+    }
+}
+
+[TestCategory("Draft202012")]
+[TestClass]
+public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocationWithAdditionalProperties
+{
+    private static Fixture? s_fixture;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        s_fixture = new Fixture();
+        await s_fixture.InitializeAsync();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanupMethod()
+    {
+        s_fixture = null;
+    }
+
+    [TestMethod]
+    public void TestWithOnlyTheNestedEvaluatedProperty()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("{\n                    \"foo\": { \"bar\": \"foo\" }\n                }");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestWithAnUnevaluatedPropertyThatExistsAtAnotherLocation()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("{\n                    \"foo\": { \"bar\": \"foo\" },\n                    \"bar\": \"bar\"\n                }");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    public class Fixture
+    {
+        public CompiledEvaluator Evaluator { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            this.Evaluator = await TestEvaluatorHelper.GenerateEvaluatorForVirtualFileAsync(
+                "tests/draft2020-12/unevaluatedProperties.json",
+                "{\n            \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n            \"properties\": {\n                \"foo\": {\n                    \"additionalProperties\": { \"type\": \"string\" }\n                }\n            },\n            \"unevaluatedProperties\": false\n        }",
+                "StandaloneEvaluatorTestSuite.Draft202012.UnevaluatedProperties",
+                "../../../../../JSON-Schema-Test-Suite/remotes",
+                "https://json-schema.org/draft/2020-12/schema",
+                validateFormat: false,
+                Assembly.GetExecutingAssembly());
+        }
+    }
+}

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft4/minProperties.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft4/minProperties.cs
@@ -67,6 +67,20 @@ public class SuiteMinPropertiesValidation
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("null");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("true");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
     public class Fixture
     {
         public CompiledEvaluator Evaluator { get; private set; }

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft6/minProperties.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft6/minProperties.cs
@@ -67,6 +67,20 @@ public class SuiteMinPropertiesValidation
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("null");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("true");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
     public class Fixture
     {
         public CompiledEvaluator Evaluator { get; private set; }

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft6/propertyNames.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft6/propertyNames.cs
@@ -67,6 +67,20 @@ public class SuitePropertyNamesValidation
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("null");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("true");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
     public class Fixture
     {
         public CompiledEvaluator Evaluator { get; private set; }

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft7/minProperties.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft7/minProperties.cs
@@ -67,6 +67,20 @@ public class SuiteMinPropertiesValidation
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("null");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("true");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
     public class Fixture
     {
         public CompiledEvaluator Evaluator { get; private set; }

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft7/optional/format/date.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft7/optional/format/date.cs
@@ -96,20 +96,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWith29DaysInFebruaryNormal()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2021-02-29\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
-    public void TestAValidDateStringWith29DaysInFebruaryLeap()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-02-29\"");
-        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
     public void TestAInvalidDateStringWith30DaysInFebruaryLeap()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-02-30\"");
@@ -257,13 +243,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWithInvalidMonth()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-13-01\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
     public void TestAnInvalidDateString()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"06/19/1963\"");
@@ -295,13 +274,6 @@ public class SuiteValidationOfDateStrings
     public void TestInvalidMonth()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"1998-13-01\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
-    public void TestInvalidMonthDayCombination()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"1998-04-31\"");
         Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
@@ -358,6 +330,153 @@ public class SuiteValidationOfDateStrings
     public void TestAnInvalidTimeStringInDateTimeFormat()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-11-28T23:55:45Z\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestYear0000IsALeapYear04000()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0000-02-29\"");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0100IsNotALeapYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0100-02-29\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0400IsALeapYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0400-02-29\"");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestCenturyYear2100IsNotALeapYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2100-02-29\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidLeadingWhitespaceIsNotPermitted()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\" 2024-01-15\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingWhitespaceIsNotPermitted()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2024-01-15 \"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidMonth00IsNotValidPerDateMonthRange0112()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2024-00-15\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidDay00IsNotValidPerDateMdayMinimumOf01()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2024-01-00\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidEmptyString()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidEmbeddedWhitespaceBetweenYearAndMonth()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020 -01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingCharacterAfterValidFullDate()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-01-01X\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingZAfterFullDate()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-01-01Z\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidFullDateFollowedBySpaceAndTimeComponent()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"2020-01-01 00:00:00Z\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestValidFourDigitYear0001()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"0001-01-01\"");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidTwoDigitYearN2Digits()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"20-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidThreeDigitYearN1Digits()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"998-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidFiveDigitYearN1Digits()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"12020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidPositiveSignPrefixOnYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"+2020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidNegativeSignPrefixOnYear()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"-2020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidNonAsciiBengaliDigitInYearField()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"২020-01-01\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestInvalidAlphabeticCharactersInYearField()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"YYYY-01-01\"");
         Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft7/optional/format/hostname.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft7/optional/format/hostname.cs
@@ -159,13 +159,6 @@ public class SuiteValidationOfHostNames
     }
 
     [TestMethod]
-    public void TestContainsInThe3rdAnd4thPosition()
-    {
-        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"XN--aa---o47jg78q\"");
-        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
-    }
-
-    [TestMethod]
     public void TestContainsUnderscore()
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"host_name\"");
@@ -487,6 +480,13 @@ public class SuiteValidationOfALabelPunycodeHostNames
     {
         using var doc = ParsedJsonDocument<JsonElement>.Parse("\"xn--ngba5hb2804a\"");
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestContainsInThe3rdAnd4thPosition()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("\"XN--aa---o47jg78q\"");
+        Assert.IsFalse(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
     public class Fixture

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft7/propertyNames.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/StandaloneEvaluatorTestSuite/tests/draft7/propertyNames.cs
@@ -67,6 +67,20 @@ public class SuitePropertyNamesValidation
         Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("null");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse("true");
+        Assert.IsTrue(s_fixture!.Evaluator.Evaluate(doc.RootElement));
+    }
+
     public class Fixture
     {
         public CompiledEvaluator Evaluator { get; private set; }

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2019-09/minProperties.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2019-09/minProperties.cs
@@ -67,6 +67,20 @@ public class SuiteMinPropertiesValidation
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("null");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("true");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
     public class Fixture
     {
         public DynamicJsonType DynamicJsonType { get; private set; }

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2019-09/optional/format/date.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2019-09/optional/format/date.cs
@@ -96,20 +96,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWith29DaysInFebruaryNormal()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2021-02-29\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
-    public void TestAValidDateStringWith29DaysInFebruaryLeap()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-02-29\"");
-        Assert.IsTrue(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
     public void TestAInvalidDateStringWith30DaysInFebruaryLeap()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-02-30\"");
@@ -257,13 +243,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWithInvalidMonth()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-13-01\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
     public void TestAnInvalidDateString()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"06/19/1963\"");
@@ -295,13 +274,6 @@ public class SuiteValidationOfDateStrings
     public void TestInvalidMonth()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"1998-13-01\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
-    public void TestInvalidMonthDayCombination()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"1998-04-31\"");
         Assert.IsFalse(dynamicInstance.EvaluateSchema());
     }
 
@@ -358,6 +330,153 @@ public class SuiteValidationOfDateStrings
     public void TestAnInvalidTimeStringInDateTimeFormat()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-11-28T23:55:45Z\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestYear0000IsALeapYear04000()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0000-02-29\"");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0100IsNotALeapYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0100-02-29\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0400IsALeapYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0400-02-29\"");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestCenturyYear2100IsNotALeapYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2100-02-29\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidLeadingWhitespaceIsNotPermitted()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\" 2024-01-15\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingWhitespaceIsNotPermitted()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2024-01-15 \"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidMonth00IsNotValidPerDateMonthRange0112()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2024-00-15\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidDay00IsNotValidPerDateMdayMinimumOf01()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2024-01-00\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidEmptyString()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidEmbeddedWhitespaceBetweenYearAndMonth()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020 -01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingCharacterAfterValidFullDate()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-01-01X\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingZAfterFullDate()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-01-01Z\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidFullDateFollowedBySpaceAndTimeComponent()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-01-01 00:00:00Z\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestValidFourDigitYear0001()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0001-01-01\"");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTwoDigitYearN2Digits()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"20-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidThreeDigitYearN1Digits()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"998-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidFiveDigitYearN1Digits()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"12020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidPositiveSignPrefixOnYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"+2020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidNegativeSignPrefixOnYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"-2020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidNonAsciiBengaliDigitInYearField()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"২020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidAlphabeticCharactersInYearField()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"YYYY-01-01\"");
         Assert.IsFalse(dynamicInstance.EvaluateSchema());
     }
 

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2019-09/optional/format/hostname.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2019-09/optional/format/hostname.cs
@@ -159,13 +159,6 @@ public class SuiteValidationOfHostNames
     }
 
     [TestMethod]
-    public void TestContainsInThe3rdAnd4thPosition()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"XN--aa---o47jg78q\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
     public void TestContainsUnderscore()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"host_name\"");
@@ -490,6 +483,13 @@ public class SuiteValidationOfALabelPunycodeHostNames
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"xn--ngba5hb2804a\"");
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestContainsInThe3rdAnd4thPosition()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"XN--aa---o47jg78q\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
     }
 
     public class Fixture

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2019-09/propertyNames.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2019-09/propertyNames.cs
@@ -67,6 +67,20 @@ public class SuitePropertyNamesValidation
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("null");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("true");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
     public class Fixture
     {
         public DynamicJsonType DynamicJsonType { get; private set; }

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2019-09/unevaluatedProperties.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2019-09/unevaluatedProperties.cs
@@ -2560,3 +2560,111 @@ public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocation
         }
     }
 }
+
+[TestCategory("Draft201909")]
+[TestClass]
+public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocationWithPatternProperties
+{
+    private static Fixture? s_fixture;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        s_fixture = new Fixture();
+        await s_fixture.InitializeAsync();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanupMethod()
+    {
+        s_fixture = null;
+    }
+
+    [TestMethod]
+    public void TestWithOnlyTheNestedEvaluatedProperty()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("{\n                    \"foo\": { \"bar\": \"foo\" }\n                }");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestWithAnUnevaluatedPropertyThatExistsAtAnotherLocation()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("{\n                    \"foo\": { \"bar\": \"foo\" },\n                    \"bar\": \"bar\"\n                }");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    public class Fixture
+    {
+        public DynamicJsonType DynamicJsonType { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            this.DynamicJsonType = await TestJsonSchemaCodeGenerator.GenerateTypeForVirtualFile(
+                "tests/draft2019-09/unevaluatedProperties.json",
+                "{\n            \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n            \"properties\": {\n                \"foo\": {\n                    \"patternProperties\": {\n                        \"^bar$\": { \"type\": \"string\" }\n                    }\n                }\n            },\n            \"unevaluatedProperties\": false\n        }",
+                "JsonSchemaTestSuite.Draft201909.UnevaluatedProperties",
+                "../../../../../JSON-Schema-Test-Suite/remotes",
+                "https://json-schema.org/draft/2019-09/schema",
+                validateFormat: false,
+                optionalAsNullable: false,
+                useImplicitOperatorString: false,
+                addExplicitUsings: false,
+                Assembly.GetExecutingAssembly());
+        }
+    }
+}
+
+[TestCategory("Draft201909")]
+[TestClass]
+public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocationWithAdditionalProperties
+{
+    private static Fixture? s_fixture;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        s_fixture = new Fixture();
+        await s_fixture.InitializeAsync();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanupMethod()
+    {
+        s_fixture = null;
+    }
+
+    [TestMethod]
+    public void TestWithOnlyTheNestedEvaluatedProperty()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("{\n                    \"foo\": { \"bar\": \"foo\" }\n                }");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestWithAnUnevaluatedPropertyThatExistsAtAnotherLocation()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("{\n                    \"foo\": { \"bar\": \"foo\" },\n                    \"bar\": \"bar\"\n                }");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    public class Fixture
+    {
+        public DynamicJsonType DynamicJsonType { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            this.DynamicJsonType = await TestJsonSchemaCodeGenerator.GenerateTypeForVirtualFile(
+                "tests/draft2019-09/unevaluatedProperties.json",
+                "{\n            \"$schema\": \"https://json-schema.org/draft/2019-09/schema\",\n            \"properties\": {\n                \"foo\": {\n                    \"additionalProperties\": { \"type\": \"string\" }\n                }\n            },\n            \"unevaluatedProperties\": false\n        }",
+                "JsonSchemaTestSuite.Draft201909.UnevaluatedProperties",
+                "../../../../../JSON-Schema-Test-Suite/remotes",
+                "https://json-schema.org/draft/2019-09/schema",
+                validateFormat: false,
+                optionalAsNullable: false,
+                useImplicitOperatorString: false,
+                addExplicitUsings: false,
+                Assembly.GetExecutingAssembly());
+        }
+    }
+}

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2020-12/minProperties.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2020-12/minProperties.cs
@@ -67,6 +67,20 @@ public class SuiteMinPropertiesValidation
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("null");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("true");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
     public class Fixture
     {
         public DynamicJsonType DynamicJsonType { get; private set; }

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2020-12/optional/format/date.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2020-12/optional/format/date.cs
@@ -96,20 +96,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWith29DaysInFebruaryNormal()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2021-02-29\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
-    public void TestAValidDateStringWith29DaysInFebruaryLeap()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-02-29\"");
-        Assert.IsTrue(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
     public void TestAInvalidDateStringWith30DaysInFebruaryLeap()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-02-30\"");
@@ -257,13 +243,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWithInvalidMonth()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-13-01\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
     public void TestAnInvalidDateString()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"06/19/1963\"");
@@ -295,13 +274,6 @@ public class SuiteValidationOfDateStrings
     public void TestInvalidMonth()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"1998-13-01\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
-    public void TestInvalidMonthDayCombination()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"1998-04-31\"");
         Assert.IsFalse(dynamicInstance.EvaluateSchema());
     }
 
@@ -358,6 +330,153 @@ public class SuiteValidationOfDateStrings
     public void TestAnInvalidTimeStringInDateTimeFormat()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-11-28T23:55:45Z\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestYear0000IsALeapYear04000()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0000-02-29\"");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0100IsNotALeapYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0100-02-29\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0400IsALeapYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0400-02-29\"");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestCenturyYear2100IsNotALeapYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2100-02-29\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidLeadingWhitespaceIsNotPermitted()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\" 2024-01-15\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingWhitespaceIsNotPermitted()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2024-01-15 \"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidMonth00IsNotValidPerDateMonthRange0112()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2024-00-15\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidDay00IsNotValidPerDateMdayMinimumOf01()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2024-01-00\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidEmptyString()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidEmbeddedWhitespaceBetweenYearAndMonth()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020 -01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingCharacterAfterValidFullDate()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-01-01X\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingZAfterFullDate()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-01-01Z\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidFullDateFollowedBySpaceAndTimeComponent()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-01-01 00:00:00Z\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestValidFourDigitYear0001()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0001-01-01\"");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTwoDigitYearN2Digits()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"20-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidThreeDigitYearN1Digits()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"998-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidFiveDigitYearN1Digits()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"12020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidPositiveSignPrefixOnYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"+2020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidNegativeSignPrefixOnYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"-2020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidNonAsciiBengaliDigitInYearField()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"২020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidAlphabeticCharactersInYearField()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"YYYY-01-01\"");
         Assert.IsFalse(dynamicInstance.EvaluateSchema());
     }
 

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2020-12/optional/format/hostname.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2020-12/optional/format/hostname.cs
@@ -159,13 +159,6 @@ public class SuiteValidationOfHostNames
     }
 
     [TestMethod]
-    public void TestContainsInThe3rdAnd4thPosition()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"XN--aa---o47jg78q\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
     public void TestContainsUnderscore()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"host_name\"");
@@ -490,6 +483,13 @@ public class SuiteValidationOfALabelPunycodeHostNames
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"xn--ngba5hb2804a\"");
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestContainsInThe3rdAnd4thPosition()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"XN--aa---o47jg78q\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
     }
 
     public class Fixture

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2020-12/propertyNames.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2020-12/propertyNames.cs
@@ -67,6 +67,20 @@ public class SuitePropertyNamesValidation
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("null");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("true");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
     public class Fixture
     {
         public DynamicJsonType DynamicJsonType { get; private set; }

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2020-12/unevaluatedProperties.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft2020-12/unevaluatedProperties.cs
@@ -2560,3 +2560,111 @@ public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocation
         }
     }
 }
+
+[TestCategory("Draft202012")]
+[TestClass]
+public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocationWithPatternProperties
+{
+    private static Fixture? s_fixture;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        s_fixture = new Fixture();
+        await s_fixture.InitializeAsync();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanupMethod()
+    {
+        s_fixture = null;
+    }
+
+    [TestMethod]
+    public void TestWithOnlyTheNestedEvaluatedProperty()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("{\n                    \"foo\": { \"bar\": \"foo\" }\n                }");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestWithAnUnevaluatedPropertyThatExistsAtAnotherLocation()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("{\n                    \"foo\": { \"bar\": \"foo\" },\n                    \"bar\": \"bar\"\n                }");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    public class Fixture
+    {
+        public DynamicJsonType DynamicJsonType { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            this.DynamicJsonType = await TestJsonSchemaCodeGenerator.GenerateTypeForVirtualFile(
+                "tests/draft2020-12/unevaluatedProperties.json",
+                "{\n            \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n            \"properties\": {\n                \"foo\": {\n                    \"patternProperties\": {\n                        \"^bar$\": { \"type\": \"string\" }\n                    }\n                }\n            },\n            \"unevaluatedProperties\": false\n        }",
+                "JsonSchemaTestSuite.Draft202012.UnevaluatedProperties",
+                "../../../../../JSON-Schema-Test-Suite/remotes",
+                "https://json-schema.org/draft/2020-12/schema",
+                validateFormat: false,
+                optionalAsNullable: false,
+                useImplicitOperatorString: false,
+                addExplicitUsings: false,
+                Assembly.GetExecutingAssembly());
+        }
+    }
+}
+
+[TestCategory("Draft202012")]
+[TestClass]
+public class SuiteEvaluatedPropertiesCollectionNeedsToConsiderInstanceLocationWithAdditionalProperties
+{
+    private static Fixture? s_fixture;
+
+    [ClassInitialize]
+    public static async Task ClassInit(TestContext _)
+    {
+        s_fixture = new Fixture();
+        await s_fixture.InitializeAsync();
+    }
+
+    [ClassCleanup]
+    public static void ClassCleanupMethod()
+    {
+        s_fixture = null;
+    }
+
+    [TestMethod]
+    public void TestWithOnlyTheNestedEvaluatedProperty()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("{\n                    \"foo\": { \"bar\": \"foo\" }\n                }");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestWithAnUnevaluatedPropertyThatExistsAtAnotherLocation()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("{\n                    \"foo\": { \"bar\": \"foo\" },\n                    \"bar\": \"bar\"\n                }");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    public class Fixture
+    {
+        public DynamicJsonType DynamicJsonType { get; private set; }
+
+        public async Task InitializeAsync()
+        {
+            this.DynamicJsonType = await TestJsonSchemaCodeGenerator.GenerateTypeForVirtualFile(
+                "tests/draft2020-12/unevaluatedProperties.json",
+                "{\n            \"$schema\": \"https://json-schema.org/draft/2020-12/schema\",\n            \"properties\": {\n                \"foo\": {\n                    \"additionalProperties\": { \"type\": \"string\" }\n                }\n            },\n            \"unevaluatedProperties\": false\n        }",
+                "JsonSchemaTestSuite.Draft202012.UnevaluatedProperties",
+                "../../../../../JSON-Schema-Test-Suite/remotes",
+                "https://json-schema.org/draft/2020-12/schema",
+                validateFormat: false,
+                optionalAsNullable: false,
+                useImplicitOperatorString: false,
+                addExplicitUsings: false,
+                Assembly.GetExecutingAssembly());
+        }
+    }
+}

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft4/minProperties.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft4/minProperties.cs
@@ -67,6 +67,20 @@ public class SuiteMinPropertiesValidation
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("null");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("true");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
     public class Fixture
     {
         public DynamicJsonType DynamicJsonType { get; private set; }

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft6/minProperties.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft6/minProperties.cs
@@ -67,6 +67,20 @@ public class SuiteMinPropertiesValidation
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("null");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("true");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
     public class Fixture
     {
         public DynamicJsonType DynamicJsonType { get; private set; }

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft6/propertyNames.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft6/propertyNames.cs
@@ -67,6 +67,20 @@ public class SuitePropertyNamesValidation
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("null");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("true");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
     public class Fixture
     {
         public DynamicJsonType DynamicJsonType { get; private set; }

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft7/minProperties.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft7/minProperties.cs
@@ -67,6 +67,20 @@ public class SuiteMinPropertiesValidation
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("null");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("true");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
     public class Fixture
     {
         public DynamicJsonType DynamicJsonType { get; private set; }

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft7/optional/format/date.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft7/optional/format/date.cs
@@ -96,20 +96,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWith29DaysInFebruaryNormal()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2021-02-29\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
-    public void TestAValidDateStringWith29DaysInFebruaryLeap()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-02-29\"");
-        Assert.IsTrue(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
     public void TestAInvalidDateStringWith30DaysInFebruaryLeap()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-02-30\"");
@@ -257,13 +243,6 @@ public class SuiteValidationOfDateStrings
     }
 
     [TestMethod]
-    public void TestAInvalidDateStringWithInvalidMonth()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-13-01\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
     public void TestAnInvalidDateString()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"06/19/1963\"");
@@ -295,13 +274,6 @@ public class SuiteValidationOfDateStrings
     public void TestInvalidMonth()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"1998-13-01\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
-    public void TestInvalidMonthDayCombination()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"1998-04-31\"");
         Assert.IsFalse(dynamicInstance.EvaluateSchema());
     }
 
@@ -358,6 +330,153 @@ public class SuiteValidationOfDateStrings
     public void TestAnInvalidTimeStringInDateTimeFormat()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-11-28T23:55:45Z\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestYear0000IsALeapYear04000()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0000-02-29\"");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0100IsNotALeapYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0100-02-29\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestCenturyYear0400IsALeapYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0400-02-29\"");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestCenturyYear2100IsNotALeapYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2100-02-29\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidLeadingWhitespaceIsNotPermitted()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\" 2024-01-15\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingWhitespaceIsNotPermitted()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2024-01-15 \"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidMonth00IsNotValidPerDateMonthRange0112()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2024-00-15\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidDay00IsNotValidPerDateMdayMinimumOf01()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2024-01-00\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidEmptyString()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidEmbeddedWhitespaceBetweenYearAndMonth()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020 -01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingCharacterAfterValidFullDate()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-01-01X\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTrailingZAfterFullDate()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-01-01Z\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidFullDateFollowedBySpaceAndTimeComponent()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"2020-01-01 00:00:00Z\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestValidFourDigitYear0001()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"0001-01-01\"");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidTwoDigitYearN2Digits()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"20-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidThreeDigitYearN1Digits()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"998-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidFiveDigitYearN1Digits()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"12020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidPositiveSignPrefixOnYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"+2020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidNegativeSignPrefixOnYear()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"-2020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidNonAsciiBengaliDigitInYearField()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"২020-01-01\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestInvalidAlphabeticCharactersInYearField()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"YYYY-01-01\"");
         Assert.IsFalse(dynamicInstance.EvaluateSchema());
     }
 

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft7/optional/format/hostname.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft7/optional/format/hostname.cs
@@ -159,13 +159,6 @@ public class SuiteValidationOfHostNames
     }
 
     [TestMethod]
-    public void TestContainsInThe3rdAnd4thPosition()
-    {
-        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"XN--aa---o47jg78q\"");
-        Assert.IsFalse(dynamicInstance.EvaluateSchema());
-    }
-
-    [TestMethod]
     public void TestContainsUnderscore()
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"host_name\"");
@@ -490,6 +483,13 @@ public class SuiteValidationOfALabelPunycodeHostNames
     {
         var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"xn--ngba5hb2804a\"");
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestContainsInThe3rdAnd4thPosition()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("\"XN--aa---o47jg78q\"");
+        Assert.IsFalse(dynamicInstance.EvaluateSchema());
     }
 
     public class Fixture

--- a/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft7/propertyNames.cs
+++ b/tests/Corvus.Text.Json.SchemaTestSuite.Tests/JsonSchemaTestSuite/tests/draft7/propertyNames.cs
@@ -67,6 +67,20 @@ public class SuitePropertyNamesValidation
         Assert.IsTrue(dynamicInstance.EvaluateSchema());
     }
 
+    [TestMethod]
+    public void TestIgnoresNull()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("null");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void TestIgnoresBooleans()
+    {
+        var dynamicInstance = s_fixture!.DynamicJsonType.ParseInstance("true");
+        Assert.IsTrue(dynamicInstance.EvaluateSchema());
+    }
+
     public class Fixture
     {
         public DynamicJsonType DynamicJsonType { get; private set; }

--- a/update-json-schema-test-suite.ps1
+++ b/update-json-schema-test-suite.ps1
@@ -71,8 +71,9 @@ try {
     Push-Location "bin\Debug\net10.0"
     try {
         Write-Host "  Running V5 generator..."
-        # Run via `dotnet <dll>` so this works on every OS (the apphost is `.exe` on Windows only).
-        & dotnet .\Corvus.JsonSchemaTestSuite.CodeGenerator.dll > $null
+        # Run via `dotnet <dll>` (no `.\` prefix) so this works on every OS — the apphost is
+        # `.exe` on Windows only, and a backslash-prefixed path is not resolved by dotnet on Linux.
+        & dotnet Corvus.JsonSchemaTestSuite.CodeGenerator.dll > $null
         if ($LASTEXITCODE -ne 0) { throw "V5 generator failed" }
     }
     finally {


### PR DESCRIPTION
Closes #795. Updates the `JSON-Schema-Test-Suite` submodule and regenerates the conformance fixtures — the first cross-platform regeneration enabled by the deterministic generator (#801).

## Changes
- **Submodule** `JSON-Schema-Test-Suite`: `c7257e9` → `60755c1` (9 upstream commits).
- **Regenerated** the type, evaluator, and annotation fixtures. Because the generator is now OS-independent, the diff is exactly the new/changed cases — **34 files**, no platform churn:
  - `test(format/date)`: full-date boundary coverage (+ removal of some date cases)
  - null and boolean tests for object-only keywords (`minProperties`, `propertyNames`, …)
  - `unevaluatedProperties` instance-location coverage
  - `hostname` A-label group fix; Draft 3 `ecmascript-regex` look-behind fix
- **Script fix** (commit 1): a residual from #801 — `update-json-schema-test-suite.ps1` invoked the generator as `dotnet .\…dll`; the `.\` prefix isn't resolved by `dotnet` on Linux. Now `dotnet …dll`, so the script runs end-to-end on every OS. (Regeneration here was done with the fixed script on Linux.)

## Verification
- Regenerated via `update-json-schema-test-suite.ps1` on Linux.
- Both projects compile; all new cases pass with **no library change**:
  - `SchemaTestSuite`: **7773 passed, 0 failed** (was 7696)
  - `EvaluatorTestSuite` (incl. annotations): **7984 passed, 0 failed** (was 7907)

## Release impact
New conformance tests only, all passing → **`no_release`**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
