### PR TITLE
Per-format assertion modes (assert/disable/warning) (#749)

### DIFF
--- a/.github/skills/corvus-codegen/SKILL.md
+++ b/.github/skills/corvus-codegen/SKILL.md
@@ -58,7 +58,8 @@ The command is `corvusjson jsonschema` (registered in `CliAppFactory.cs`).
 - `--outputRootTypeName` — name of the root generated type
 - `--outputPath` — output directory
 - `--engine` — `V4` or `V5` (default: V5 for `corvusjson`, V4 for legacy `generatejsonschematypes`)
-- `--assertFormat` — whether format validation asserts (default: true)
+- `--assertFormat` — whether format validation asserts globally (default: true)
+- `--formatMode` — per-format assertion mode overrides as comma-separated `format=mode` pairs (`mode` ∈ `assert`/`disable`/`warning`), e.g. `date-time=disable,time=warning`; repeatable; takes precedence over `--assertFormat`. `warning` (string formats only) validates but always succeeds, emitting a `WARNING` annotation on mismatch
 - `--codeGenerationMode` — `TypeGeneration`, `SchemaEvaluationOnly`, or `Both`
 
 > **IMPORTANT:** Never invent option names. Verify against `GenerateCommand.cs`.
@@ -79,6 +80,7 @@ All read from the source generator (`IncrementalSourceGenerator.cs` lines 111-19
 | `CorvusTextJsonUseImplicitOperatorString` | Generate implicit string conversion operators | true |
 | `CorvusTextJsonUseOptionalNameHeuristics` | Enable optional naming heuristics | true |
 | `CorvusTextJsonAlwaysAssertFormat` | Assert format validation | true |
+| `CorvusTextJsonFormatMode` | Per-format mode overrides as `;`/`,`-separated `format=mode` pairs (`assert`/`disable`/`warning`) | — |
 | `CorvusTextJsonDefaultAccessibility` | `Public` or `Internal` | Public |
 | `CorvusTextJsonDisabledNamingHeuristics` | Semicolon-separated list of heuristics to disable | — |
 | `EmitCompilerGeneratedFiles` | Write generated `.g.cs` to `obj/` for inspection | false |

--- a/Common/tests/TestUtilities/TestEvaluatorHelper.cs
+++ b/Common/tests/TestUtilities/TestEvaluatorHelper.cs
@@ -33,10 +33,13 @@ public class TestEvaluatorHelper
 
     private readonly bool _validateFormat;
 
+    private readonly IReadOnlyDictionary<string, FormatAssertionMode>? _formatModeOverrides;
+
     private TestEvaluatorHelper(
         string remotesBaseDirectory,
         IVocabulary? defaultVocabulary = null,
-        bool validateFormat = true)
+        bool validateFormat = true,
+        IReadOnlyDictionary<string, FormatAssertionMode>? formatModeOverrides = null)
     {
         _remotesBaseDirectory = remotesBaseDirectory;
         _documentResolver =
@@ -50,6 +53,7 @@ public class TestEvaluatorHelper
 
         _jsonSchemaTypeBuilder = new(_documentResolver, _vocabularyRegistry);
         _validateFormat = validateFormat;
+        _formatModeOverrides = formatModeOverrides;
         _defaultVocabulary = defaultVocabulary ?? Corvus.Json.CodeGeneration.Draft202012.VocabularyAnalyser.DefaultVocabulary;
     }
 
@@ -147,6 +151,38 @@ public class TestEvaluatorHelper
         return s_cache.GetOrAdd(key, _ => result);
     }
 
+    /// <summary>
+    /// Generate a compiled standalone evaluator for the given virtual file, applying the supplied
+    /// per-format assertion mode overrides.
+    /// </summary>
+    /// <param name="virtualFilename">The virtual file name.</param>
+    /// <param name="schemaText">The text of the virtual schema file.</param>
+    /// <param name="defaultNamespace">The default namespace for code generation.</param>
+    /// <param name="remotesBaseDirectory">The remotes base directory for the test suite.</param>
+    /// <param name="defaultVocabulary">The default vocabulary for the test run.</param>
+    /// <param name="validateFormat">Whether to assert format globally (maps to <c>alwaysAssertFormat</c>).</param>
+    /// <param name="formatModeOverrides">The per-format assertion mode overrides, keyed by format name.</param>
+    /// <param name="hostAssembly">The host assembly with preserved compilation context.</param>
+    /// <returns>A <see cref="CompiledEvaluator"/> for the schema.</returns>
+    public static async ValueTask<CompiledEvaluator> GenerateEvaluatorForVirtualFileAsync(
+        string virtualFilename,
+        string schemaText,
+        string defaultNamespace,
+        string remotesBaseDirectory,
+        IVocabulary defaultVocabulary,
+        bool validateFormat,
+        IReadOnlyDictionary<string, FormatAssertionMode>? formatModeOverrides,
+        Assembly hostAssembly)
+    {
+        var helper = new TestEvaluatorHelper(
+            remotesBaseDirectory,
+            defaultVocabulary: defaultVocabulary,
+            validateFormat: validateFormat,
+            formatModeOverrides: formatModeOverrides);
+
+        return await helper.GenerateAndCompileAsync(virtualFilename, schemaText, TestJsonSchemaCodeGenerator.ToPascalCase(defaultNamespace), hostAssembly);
+    }
+
     private void RegisterVocabularies()
     {
         Corvus.Json.CodeGeneration.Draft202012.VocabularyAnalyser.RegisterAnalyser(_documentResolver, _vocabularyRegistry);
@@ -169,7 +205,8 @@ public class TestEvaluatorHelper
             defaultNamespace,
             alwaysAssertFormat: _validateFormat,
             addExplicitUsings: true,
-            codeGenerationMode: CodeGenerationMode.SchemaEvaluationOnly);
+            codeGenerationMode: CodeGenerationMode.SchemaEvaluationOnly,
+            formatModeOverrides: _formatModeOverrides);
 
         _jsonSchemaTypeBuilder.AddDocument(path, System.Text.Json.JsonDocument.Parse(jsonSchema));
 

--- a/Common/tests/TestUtilities/TestJsonSchemaCodeGenerator.cs
+++ b/Common/tests/TestUtilities/TestJsonSchemaCodeGenerator.cs
@@ -40,6 +40,8 @@ public class TestJsonSchemaCodeGenerator
 
     private readonly bool _addExplicitUsings;
 
+    private IReadOnlyDictionary<string, FormatAssertionMode>? _formatModeOverrides;
+
     private TestJsonSchemaCodeGenerator(
         string remotesBaseDirectory,
         IVocabulary? defaultVocabulary = null,
@@ -307,6 +309,74 @@ public class TestJsonSchemaCodeGenerator
     }
 
     /// <summary>
+    /// Generates the concatenated source text for the given virtual file, applying the supplied
+    /// per-format assertion mode overrides. Used to assert on the emitted validation code.
+    /// </summary>
+    /// <param name="virtualFilename">The virtual file name.</param>
+    /// <param name="schemaText">The text of the virtual schema file.</param>
+    /// <param name="defaultNamespace">The default namespace for code generation.</param>
+    /// <param name="remotesBaseDirectory">The remotes base directory for the test suite.</param>
+    /// <param name="defaultVocabulary">The default vocabulary for the test run.</param>
+    /// <param name="validateFormat">Whether to assert format globally (maps to <c>alwaysAssertFormat</c>).</param>
+    /// <param name="formatModeOverrides">The per-format assertion mode overrides, keyed by format name.</param>
+    /// <returns>A task which, when complete, provides the concatenated generated source text.</returns>
+    public static async ValueTask<string> GenerateCodeTextForVirtualFile(
+        string virtualFilename,
+        string schemaText,
+        string defaultNamespace,
+        string remotesBaseDirectory,
+        IVocabulary defaultVocabulary,
+        bool validateFormat,
+        IReadOnlyDictionary<string, FormatAssertionMode>? formatModeOverrides)
+    {
+        var generator = new TestJsonSchemaCodeGenerator(
+            remotesBaseDirectory,
+            defaultVocabulary: defaultVocabulary,
+            validateFormat: validateFormat)
+        {
+            _formatModeOverrides = formatModeOverrides,
+        };
+
+        GeneratedCode generatedCode = await generator.GenerateCodeAsync(virtualFilename, schemaText, defaultNamespace: ToPascalCase(defaultNamespace));
+        return string.Join("\n", generatedCode.GeneratedFiles.Select(f => f.FileContent));
+    }
+
+    /// <summary>
+    /// Generates and compiles the type for the given virtual file, applying the supplied per-format
+    /// assertion mode overrides. Used to assert that the emitted validation code compiles.
+    /// </summary>
+    /// <param name="virtualFilename">The virtual file name.</param>
+    /// <param name="schemaText">The text of the virtual schema file.</param>
+    /// <param name="defaultNamespace">The default namespace for code generation.</param>
+    /// <param name="remotesBaseDirectory">The remotes base directory for the test suite.</param>
+    /// <param name="defaultVocabulary">The default vocabulary for the test run.</param>
+    /// <param name="validateFormat">Whether to assert format globally (maps to <c>alwaysAssertFormat</c>).</param>
+    /// <param name="formatModeOverrides">The per-format assertion mode overrides, keyed by format name.</param>
+    /// <param name="hostAssembly">The host assembly with preserved compilation context.</param>
+    /// <returns>A task which, when complete, provides the compiled <see cref="DynamicJsonType"/>.</returns>
+    public static async ValueTask<DynamicJsonType> GenerateTypeForVirtualFile(
+        string virtualFilename,
+        string schemaText,
+        string defaultNamespace,
+        string remotesBaseDirectory,
+        IVocabulary defaultVocabulary,
+        bool validateFormat,
+        IReadOnlyDictionary<string, FormatAssertionMode>? formatModeOverrides,
+        Assembly hostAssembly)
+    {
+        var generator = new TestJsonSchemaCodeGenerator(
+            remotesBaseDirectory,
+            defaultVocabulary: defaultVocabulary,
+            validateFormat: validateFormat)
+        {
+            _formatModeOverrides = formatModeOverrides,
+        };
+
+        GeneratedCode generatedCode = await generator.GenerateCodeAsync(virtualFilename, schemaText, defaultNamespace: ToPascalCase(defaultNamespace));
+        return Compile(generatedCode, hostAssembly);
+    }
+
+    /// <summary>
     /// Compiles the generated code.
     /// </summary>
     /// <param name="code">The generated code.</param>
@@ -390,7 +460,8 @@ public class TestJsonSchemaCodeGenerator
             alwaysAssertFormat: _validateFormat,
             optionalAsNullable: _optionalAsNullable,
             useImplicitOperatorString: _useImplicitOperatorString,
-            addExplicitUsings: _addExplicitUsings);
+            addExplicitUsings: _addExplicitUsings,
+            formatModeOverrides: _formatModeOverrides);
 
         _jsonSchemaTypeBuilder.AddDocument(path, System.Text.Json.JsonDocument.Parse(jsonSchema));
 

--- a/docs/CodeGenerator.md
+++ b/docs/CodeGenerator.md
@@ -58,7 +58,8 @@ corvusjson jsonschema <schemaFile> [OPTIONS]
 | `--rootPath` | — | JSON Pointer to the root element (e.g., `#/definitions/Person`) |
 | `--rebaseToRootPath` | `false` | Rebase the document as if rooted at `--rootPath` |
 | `--useSchema` | Auto-detect | Fallback schema draft: `Draft4`, `Draft6`, `Draft7`, `Draft201909`, `Draft202012`, `OpenApi30` |
-| `--assertFormat` | `true` | Enforce `format` keyword as a validation assertion |
+| `--assertFormat` | `true` | Enforce `format` keyword as a validation assertion (global default) |
+| `--formatMode` | — | Per-format assertion mode overrides as comma-separated `format=mode` pairs, where `mode` is `assert`, `disable`, or `warning` (e.g. `date-time=disable,time=warning`). Repeatable. An override takes precedence over `--assertFormat`. Warning mode applies to string formats only. |
 | `--optionalAsNullable` | `None` | How to handle optional properties: `None` or `NullOrUndefined` |
 | `--useImplicitOperatorString` | `false` | Use implicit (vs explicit) conversion to `string` |
 | `--disableOptionalNamingHeuristics` | `false` | Disable all optional naming heuristics at once (see [Naming Heuristics](#naming-heuristics)) |
@@ -109,6 +110,7 @@ corvusjson config myconfig.json [--engine V5]
     "outputPath": "Generated/",
     "useSchema": "Draft202012",
     "assertFormat": true,
+    "formatMode": { "date-time": "disable", "time": "warning" },
     "optionalAsNullable": "None",
     "typesToGenerate": [
         {
@@ -152,6 +154,7 @@ The `config` command is ideal when you have multiple schemas to generate from, s
 | `outputMapFile` | No | — | Path for a JSON manifest listing every generated file, useful for build systems that need to track outputs. |
 | `useSchema` | No | `Draft202012` | Fallback schema draft when vocabulary analysis cannot determine the draft from the `$schema` keyword. Values: `Draft4`, `Draft6`, `Draft7`, `Draft201909`, `Draft202012`, `OpenApi30`. |
 | `assertFormat` | No | `true` | When `true`, the `format` keyword is enforced as a validation assertion. When `false`, `format` is treated as an annotation only (per the JSON Schema specification). |
+| `formatMode` | No | — | A dictionary of per-format assertion mode overrides. Keys are format names (e.g. `date-time`); values are `assert`, `disable`, or `warning`. An override takes precedence over `assertFormat` and the vocabulary's format-assertion behaviour. `assert` validates and fails on a non-conformant value; `disable` makes the format annotation-only; `warning` validates but always succeeds, emitting a `WARNING` annotation on a mismatch. Warning mode applies to string formats only; for a numeric format it falls back to `assert`. |
 | `optionalAsNullable` | No | `None` | Controls how optional properties are represented in generated types. `None`: optional properties use the same type as required properties — you check for `Undefined` explicitly. `NullOrUndefined`: optional properties generate as .NET nullable types (`T?`), and both JSON `null` and missing properties map to C# `null`. |
 | `additionalFiles` | No | — | Pre-load external schema files so `$ref` references can resolve without network access (see below). |
 | `namedTypes` | No | — | Explicitly assign .NET names to specific schema definitions that would otherwise get auto-generated names (see below). |

--- a/docs/SourceGenerator.md
+++ b/docs/SourceGenerator.md
@@ -141,6 +141,7 @@ Control the generator's behaviour with MSBuild properties in your `.csproj`:
   <CorvusTextJsonFallbackVocabulary>Draft202012</CorvusTextJsonFallbackVocabulary>
   <CorvusTextJsonOptionalAsNullable>NullOrUndefined</CorvusTextJsonOptionalAsNullable>
   <CorvusTextJsonAlwaysAssertFormat>true</CorvusTextJsonAlwaysAssertFormat>
+  <CorvusTextJsonFormatMode>date-time=disable;time=warning</CorvusTextJsonFormatMode>
 </PropertyGroup>
 ```
 
@@ -149,6 +150,7 @@ Control the generator's behaviour with MSBuild properties in your `.csproj`:
 | `CorvusTextJsonFallbackVocabulary` | `Draft202012` | Fallback schema vocabulary when the `$schema` keyword is omitted. Values: `Draft4`, `Draft6`, `Draft7`, `Draft201909`, `Draft202012`, `OpenApi30`. |
 | `CorvusTextJsonOptionalAsNullable` | — | When set to `NullOrUndefined`, optional properties generate as .NET nullable types (`T?`). JSON `null` or missing values map to C# `null`. When set to `NullOrUndefinedExceptNonNullDefaulted`, this applies to all optional properties *except* those that declare a non-null `default`, which are generated as the non-nullable type `T` (the default is returned when the property is absent); an optional property whose `default` is JSON `null` stays nullable. When omitted, optional properties use the full type and you check for `Undefined` explicitly. |
 | `CorvusTextJsonAlwaysAssertFormat` | `true` | When `true`, the `format` keyword is enforced as a validation assertion. When `false`, it is treated as an annotation only. |
+| `CorvusTextJsonFormatMode` | — | Per-format assertion mode overrides as semicolon-separated `format=mode` pairs, where `mode` is `assert`, `disable`, or `warning` (e.g. `date-time=disable;time=warning`). An override takes precedence over `CorvusTextJsonAlwaysAssertFormat`. `disable` makes the format annotation-only; `warning` validates but always succeeds, emitting a `WARNING` annotation on a mismatch. Warning mode applies to string formats only; for a numeric format it falls back to `assert`. |
 | `CorvusTextJsonUseImplicitOperatorString` | `true` | When `true`, conversion operators to `string` are implicit. When `false`, explicit casting is required. Explicit casts make string allocations more visible. |
 | `CorvusTextJsonAddExplicitUsings` | `true` | When `true`, generated files include `using` statements for standard implicit usings. Disable if your project already uses implicit usings and you want cleaner output. |
 | `CorvusTextJsonUseOptionalNameHeuristics` | `true` | When `true`, applies naming heuristics to infer idiomatic C# names from JSON Schema property names and definitions. |

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -758,16 +758,16 @@ main-docs:
       - {index: 1, language: bash, lines: [19, 22]}
       - {index: 2, language: bash, lines: [30, 34]}
       - {index: 3, language: bash, lines: [44, 46]}
-      - {index: 4, language: bash, lines: [75, 94]}
-      - {index: 5, language: bash, lines: [100, 102]}
-      - {index: 6, language: json, lines: [106, 141]}
-      - {index: 7, language: bash, lines: [203, 205]}
-      - {index: 8, language: bash, lines: [213, 215]}
-      - {index: 9, language: bash, lines: [221, 223]}
-      - {index: 10, language: json, lines: [255, 265]}
-      - {index: 11, language: bash, lines: [293, 298]}
-      - {index: 12, language: json, lines: [318, 327]}
-      - {index: 13, language: bash, lines: [356, 368]}
+      - {index: 4, language: bash, lines: [76, 95]}
+      - {index: 5, language: bash, lines: [101, 103]}
+      - {index: 6, language: json, lines: [107, 143]}
+      - {index: 7, language: bash, lines: [206, 208]}
+      - {index: 8, language: bash, lines: [216, 218]}
+      - {index: 9, language: bash, lines: [224, 226]}
+      - {index: 10, language: json, lines: [258, 268]}
+      - {index: 11, language: bash, lines: [296, 301]}
+      - {index: 12, language: json, lines: [321, 330]}
+      - {index: 13, language: bash, lines: [359, 371]}
   - path: "docs/CodeSampleCatalog.md"
     blocks:
       - {index: 0, language: powershell, lines: [13, 26]}
@@ -1367,9 +1367,9 @@ main-docs:
       - {index: 6, language: csharp, lines: [95, 101], category: compilable, verified: false}
       - {index: 7, language: xml, lines: [114, 123]}
       - {index: 8, language: xml, lines: [127, 131]}
-      - {index: 9, language: xml, lines: [139, 145]}
-      - {index: 10, language: xml, lines: [178, 182]}
-      - {index: 11, language: , lines: [186, 191]}
+      - {index: 9, language: xml, lines: [139, 146]}
+      - {index: 10, language: xml, lines: [180, 184]}
+      - {index: 11, language: , lines: [188, 193]}
   - path: "docs/StandaloneEvaluatorInternals.md"
     blocks:
       - {index: 0, language: csharp, lines: [19, 26], category: compilable, verified: false}
@@ -1710,8 +1710,8 @@ skills:
       - {index: 0, language: csharp, lines: [22, 25], category: compilable, verified: false}
       - {index: 1, language: xml, lines: [34, 38]}
       - {index: 2, language: powershell, lines: [42, 52]}
-      - {index: 3, language: json, lines: [103, 121]}
-      - {index: 4, language: powershell, lines: [125, 133]}
+      - {index: 3, language: json, lines: [105, 123]}
+      - {index: 4, language: powershell, lines: [127, 135]}
   - path: ".github/skills/corvus-ctj-handler-implementation/SKILL.md"
     blocks:
       - {index: 0, language: csharp, lines: [29, 34], category: compilable, verified: false}

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CSharpLanguageProvider.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CSharpLanguageProvider.cs
@@ -657,6 +657,7 @@ public class CSharpLanguageProvider(CSharpLanguageProvider.Options? options = nu
     /// <param name="addExplicitUsings">If true, then the generated files will include using statements for the standard implicit usings. You should use this when your project does not use implicit usings.</param>
     /// <param name="defaultAccessibility">Defines the accessibility of the generated types. Defaults to <see cref="GeneratedTypeAccessibility.Public"/>.</param>
     /// <param name="excludeNonNullDefaulted">If true (and <paramref name="optionalAsNullable"/> is true), then optional properties that declare a non-null <c>default</c> are generated as non-nullable types.</param>
+    /// <param name="formatModeOverrides">Per-format assertion mode overrides, keyed by format name (e.g. <c>date-time</c>). An override takes precedence over both the vocabulary's format-assertion behaviour and <paramref name="alwaysAssertFormat"/>.</param>
     public class Options(
         string defaultNamespace,
         NamedType[]? namedTypes = null,
@@ -670,7 +671,8 @@ public class CSharpLanguageProvider(CSharpLanguageProvider.Options? options = nu
         string lineEndSequence = "\r\n",
         bool addExplicitUsings = false,
         GeneratedTypeAccessibility defaultAccessibility = GeneratedTypeAccessibility.Public,
-        bool excludeNonNullDefaulted = false)
+        bool excludeNonNullDefaulted = false,
+        IReadOnlyDictionary<string, FormatAssertionMode>? formatModeOverrides = null)
     {
         private readonly FrozenDictionary<string, NamedType> namedTypeMap = namedTypes?.ToFrozenDictionary(kvp => kvp.Reference, kvp => kvp) ?? FrozenDictionary<string, NamedType>.Empty;
         private readonly FrozenDictionary<string, string> namespaceMap = namespaces?.ToFrozenDictionary(kvp => kvp.BaseUri, kvp => kvp.DotnetNamespace) ?? FrozenDictionary<string, string>.Empty;
@@ -694,6 +696,18 @@ public class CSharpLanguageProvider(CSharpLanguageProvider.Options? options = nu
         /// Gets a value indicating whether to always assert the format validation, regardless of the vocabulary.
         /// </summary>
         internal bool AlwaysAssertFormat { get; } = alwaysAssertFormat;
+
+        /// <summary>
+        /// Gets the per-format assertion mode overrides, keyed by format name (e.g. <c>date-time</c>).
+        /// </summary>
+        /// <remarks>
+        /// An override takes precedence over both the vocabulary's format-assertion behaviour
+        /// and <see cref="AlwaysAssertFormat"/>.
+        /// </remarks>
+        internal FrozenDictionary<string, FormatAssertionMode> FormatModeOverrides { get; } =
+            formatModeOverrides is { Count: > 0 }
+                ? formatModeOverrides.ToFrozenDictionary(StringComparer.Ordinal)
+                : FrozenDictionary<string, FormatAssertionMode>.Empty;
 
         /// <summary>
         /// Gets a value indicating whether to generate nullable types for optional parameters.

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/FormatHandlers/FormatHandlerExtensions.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/FormatHandlers/FormatHandlerExtensions.cs
@@ -421,6 +421,7 @@ public static class FormatHandlerExtensions
     /// <param name="formatKeyword">The format keyword.</param>
     /// <param name="returnFromMethod"><see langword="true"/> if you should return from the method, otherwise it updates the <paramref name="validationContextIdentifier"/>.</param>
     /// <param name="includeType"><see langword="true"/> if you should also include type assertion.</param>
+    /// <param name="warn">If <see langword="true"/>, emit the warning-mode variant that records a <c>WARNING</c> annotation on mismatch instead of failing validation.</param>
     /// <returns><see langword="true"/> if the assertion was appended successfully.</returns>
     public static bool AppendFormatAssertion<T>(
         this IEnumerable<T> handlers,
@@ -431,7 +432,8 @@ public static class FormatHandlerExtensions
         IKeyword? typeKeyword,
         IKeyword? formatKeyword,
         bool returnFromMethod,
-        bool includeType = false)
+        bool includeType = false,
+        bool warn = false)
         where T : notnull, IFormatHandler
     {
         foreach (T handler in handlers)
@@ -441,7 +443,7 @@ public static class FormatHandlerExtensions
                 return false;
             }
 
-            if (handler.AppendFormatAssertion(generator, format, valueIdentifier, validationContextIdentifier, includeType, typeKeyword, formatKeyword, returnFromMethod))
+            if (handler.AppendFormatAssertion(generator, format, valueIdentifier, validationContextIdentifier, includeType, typeKeyword, formatKeyword, returnFromMethod, warn))
             {
                 return true;
             }

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/FormatHandlers/IFormatHandler.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/FormatHandlers/IFormatHandler.cs
@@ -55,8 +55,9 @@ public interface IFormatHandler
     /// <param name="typeKeyword">The type keyword, or <see langword="null"/> if no type keyword is applied.</param>
     /// <param name="formatKeyword">The format keyword, or <see langword="null"/> if no format keyword is applied.</param>
     /// <param name="returnFromMethod">If <see langword="true"/>, then the method will return. Otherwise it will set the <paramref name="validationContextIdentifier"/>.</param>
+    /// <param name="warn">If <see langword="true"/>, emit the warning-mode variant that records a <c>WARNING</c> annotation on mismatch instead of failing validation.</param>
     /// <returns><see langword="true"/> if the instance handled this format.</returns>
-    bool AppendFormatAssertion(CodeGenerator generator, string format, string valueIdentifier, string validationContextIdentifier, bool includeType, IKeyword? typeKeyword, IKeyword? formatKeyword, bool returnFromMethod);
+    bool AppendFormatAssertion(CodeGenerator generator, string format, string valueIdentifier, string validationContextIdentifier, bool includeType, IKeyword? typeKeyword, IKeyword? formatKeyword, bool returnFromMethod, bool warn = false);
 
     /// <summary>
     /// Append format-specific constructors to the generator.

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/FormatHandlers/WellKnownNumericFormatHandler.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/FormatHandlers/WellKnownNumericFormatHandler.cs
@@ -21,8 +21,10 @@ public class WellKnownNumericFormatHandler : INumberFormatHandler
     public uint Priority => 100_000;
 
     /// <inheritdoc/>
-    public bool AppendFormatAssertion(CodeGenerator generator, string format, string valueIdentifier, string validationContextIdentifier, bool includeType, IKeyword? typeKeyword, IKeyword? formatKeyword, bool returnFromMethod)
+    public bool AppendFormatAssertion(CodeGenerator generator, string format, string valueIdentifier, string validationContextIdentifier, bool includeType, IKeyword? typeKeyword, IKeyword? formatKeyword, bool returnFromMethod, bool warn = false)
     {
+        // Warning mode is not supported for numeric formats; the caller emits a diagnostic and
+        // this falls back to assertion. The 'warn' parameter is intentionally ignored here.
         string validator = includeType ? "Validate" : "ValidateWithoutCoreType";
 
         string typeKeywordDisplay = typeKeyword is IKeyword t ? SymbolDisplay.FormatLiteral(t.Keyword, true) : "null";

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/FormatHandlers/WellKnownStringFormatHandler.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/FormatHandlers/WellKnownStringFormatHandler.cs
@@ -141,7 +141,7 @@ public class WellKnownStringFormatHandler : IStringFormatHandler
     }
 
     /// <inheritdoc/>
-    public bool AppendFormatAssertion(CodeGenerator generator, string format, string valueIdentifier, string validationContextIdentifier, bool includeType, IKeyword? typeKeyword, IKeyword? formatKeyword, bool returnFromMethod)
+    public bool AppendFormatAssertion(CodeGenerator generator, string format, string valueIdentifier, string validationContextIdentifier, bool includeType, IKeyword? typeKeyword, IKeyword? formatKeyword, bool returnFromMethod, bool warn = false)
     {
         string validator = includeType ? "Validate" : "ValidateWithoutCoreType";
 
@@ -153,274 +153,55 @@ public class WellKnownStringFormatHandler : IStringFormatHandler
                 ? $"{typeKeywordDisplay}, {formatKeywordDisplay}"
                 : formatKeywordDisplay;
 
+        string? methodSuffix = format switch
+        {
+            "date" => "Date",
+            "date-time" => "DateTime",
+            "time" => "Time",
+            "duration" => "Duration",
+            "email" => "Email",
+            "idn-email" => "IdnEmail",
+            "hostname" => "Hostname",
+            "idn-hostname" => "IdnHostName",
+            "ipv4" => "IpV4",
+            "ipv6" => "IpV6",
+            "uuid" => "Uuid",
+            "uri" => "Uri",
+            "uri-template" => "UriTemplate",
+            "uri-reference" => "UriReference",
+            "iri" => "Iri",
+            "iri-reference" => "IriReference",
+            "json-pointer" => "Pointer",
+            "relative-json-pointer" => "RelativePointer",
+            "regex" => "Regex",
+            _ => null,
+        };
+
+        if (methodSuffix is not null)
+        {
+            // In warning mode emit the TypeXxxWarning sibling, which records a WARNING annotation
+            // on mismatch instead of failing validation.
+            string methodName = warn ? methodSuffix + "Warning" : methodSuffix;
+            generator.AppendLineIndent(
+                returnFromMethod ? "return" : validationContextIdentifier,
+                returnFromMethod ? string.Empty : " = ",
+                " Corvus.Json.",
+                validator,
+                ".Type",
+                methodName,
+                "(",
+                valueIdentifier,
+                ", ",
+                validationContextIdentifier,
+                ", level, ",
+                keywordParameters,
+                ");");
+            return true;
+        }
+
+        // Content formats already pass and annotate failures, so warning mode is a no-op for them.
         switch (format)
         {
-            case "date":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeDate(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "date-time":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeDateTime(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "time":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeTime(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "duration":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeDuration(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "email":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeEmail(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "idn-email":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeIdnEmail(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "hostname":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeHostname(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "idn-hostname":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeIdnHostName(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "ipv4":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeIpV4(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "ipv6":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeIpV6(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "uuid":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeUuid(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "uri":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeUri(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "uri-template":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeUriTemplate(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "uri-reference":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeUriReference(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "iri":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeIri(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "iri-reference":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeIriReference(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "json-pointer":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypePointer(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "relative-json-pointer":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeRelativePointer(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
-            case "regex":
-                generator.AppendLineIndent(
-                    returnFromMethod ? "return" : validationContextIdentifier,
-                    returnFromMethod ? string.Empty : " = ",
-                    " Corvus.Json.",
-                    validator,
-                    ".TypeRegex(",
-                    valueIdentifier,
-                    ", ",
-                    validationContextIdentifier,
-                    ", level, ",
-                    keywordParameters,
-                    ");");
-                return true;
             case "corvus-base64-content":
                 generator.AppendLineIndent(
                     returnFromMethod ? "return" : validationContextIdentifier,

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/TypeDeclarationExtensions.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/TypeDeclarationExtensions.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
+using System.Collections.Frozen;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Corvus.Json.CodeGeneration.CSharp;
@@ -20,6 +21,7 @@ public static class TypeDeclarationExtensions
     private const string FullyQualifiedDotnetTypeNameKey = "CSharp_LanguageProvider_FullyQualifiedDotnetTypeName";
     private const string PreferredDotnetNumericTypeNameKey = "CSharp_LanguageProvider_PreferredDotnetNumericTypeName";
     private const string AlwaysAssertFormatKey = "CSharp_LanguageProvider_AlwaysAssertFormat";
+    private const string FormatModeOverridesKey = "CSharp_LanguageProvider_FormatModeOverrides";
     private const string OptionalAsNullableKey = "CSharp_LanguageProvider_OptionalAsNullable";
     private const string ExcludeNonNullDefaultedKey = "CSharp_LanguageProvider_ExcludeNonNullDefaulted";
     private const string PreferredBinaryJsonNumberKindKey = "CSharp_LanguageProvider_PreferredBinaryJsonNumberKind";
@@ -36,6 +38,7 @@ public static class TypeDeclarationExtensions
     public static void SetCSharpOptions(this TypeDeclaration typeDeclaration, CSharpLanguageProvider.Options options)
     {
         typeDeclaration.SetMetadata(AlwaysAssertFormatKey, options.AlwaysAssertFormat);
+        typeDeclaration.SetMetadata(FormatModeOverridesKey, options.FormatModeOverrides);
         typeDeclaration.SetMetadata(OptionalAsNullableKey, options.OptionalAsNullable);
         typeDeclaration.SetMetadata(ExcludeNonNullDefaultedKey, options.ExcludeNonNullDefaulted);
         typeDeclaration.SetMetadata(UseImplicitOperatorStringKey, options.UseImplicitOperatorString);
@@ -128,6 +131,56 @@ public static class TypeDeclarationExtensions
             return value;
         }
 
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the effective <see cref="FormatAssertionMode"/> for the given format on this
+    /// type declaration.
+    /// </summary>
+    /// <param name="typeDeclaration">The type declaration to test.</param>
+    /// <param name="format">The format name (e.g. <c>date-time</c>).</param>
+    /// <returns>The effective <see cref="FormatAssertionMode"/>.</returns>
+    /// <remarks>
+    /// Resolution order: a per-format override (if present) takes precedence, then the
+    /// vocabulary's format-assertion behaviour or the global
+    /// <see cref="AlwaysAssertFormat(TypeDeclaration)"/> setting (either of which yields
+    /// <see cref="FormatAssertionMode.Assert"/>), otherwise <see cref="FormatAssertionMode.Disable"/>.
+    /// </remarks>
+    public static FormatAssertionMode GetEffectiveFormatMode(this TypeDeclaration typeDeclaration, string format)
+    {
+        if (typeDeclaration.TryGetMetadata(FormatModeOverridesKey, out FrozenDictionary<string, FormatAssertionMode>? overrides) &&
+            overrides is not null &&
+            overrides.TryGetValue(format, out FormatAssertionMode mode))
+        {
+            return mode;
+        }
+
+        if (typeDeclaration.IsFormatAssertion() || typeDeclaration.AlwaysAssertFormat())
+        {
+            return FormatAssertionMode.Assert;
+        }
+
+        return FormatAssertionMode.Disable;
+    }
+
+    /// <summary>
+    /// Tries to get an explicit per-format assertion mode override for the given format.
+    /// </summary>
+    /// <param name="typeDeclaration">The type declaration to test.</param>
+    /// <param name="format">The format name (e.g. <c>date-time</c>).</param>
+    /// <param name="mode">When this method returns <see langword="true"/>, contains the override mode.</param>
+    /// <returns><see langword="true"/> if an explicit override was configured for the format.</returns>
+    public static bool GetFormatModeOverride(this TypeDeclaration typeDeclaration, string format, out FormatAssertionMode mode)
+    {
+        if (typeDeclaration.TryGetMetadata(FormatModeOverridesKey, out FrozenDictionary<string, FormatAssertionMode>? overrides) &&
+            overrides is not null &&
+            overrides.TryGetValue(format, out mode))
+        {
+            return true;
+        }
+
+        mode = FormatAssertionMode.Disable;
         return false;
     }
 

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Format.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.Format.cs
@@ -101,9 +101,22 @@ public static partial class ValidationCodeGeneratorExtensions
             child.AppendValidationCode(generator, typeDeclaration);
         }
 
-        if (typeDeclaration.IsFormatAssertion() || typeDeclaration.AlwaysAssertFormat())
+        FormatAssertionMode formatMode = typeDeclaration.GetEffectiveFormatMode(explicitFormat);
+
+        if (formatMode is FormatAssertionMode.Assert or FormatAssertionMode.Warning)
         {
-            FormatHandlerRegistry.Instance.FormatHandlers.AppendFormatAssertion(generator, explicitFormat, "value", "validationContext", null, keywords.FirstOrDefault(), returnFromMethod: true);
+            bool warn = formatMode == FormatAssertionMode.Warning;
+
+            if (warn && expectedValueKind != JsonValueKind.String)
+            {
+                // Warning mode is only supported for string formats. Numeric formats fall back to
+                // assertion; emit a visible note in the generated code.
+                generator
+                    .AppendLineIndent("// NOTE: 'warning' format mode is not supported for the numeric format '", explicitFormat, "'; asserting instead.");
+                warn = false;
+            }
+
+            FormatHandlerRegistry.Instance.FormatHandlers.AppendFormatAssertion(generator, explicitFormat, "value", "validationContext", null, keywords.FirstOrDefault(), returnFromMethod: true, warn: warn);
         }
         else
         {

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/ValidationCodeGeneratorExtensions.cs
@@ -603,15 +603,37 @@ public static partial class ValidationCodeGeneratorExtensions
                         .AppendLineIndent("result = validationContext;");
                     break;
                 default:
+                    string extendedFormat = typeDeclaration.ExplicitFormat() ?? throw new InvalidOperationException("There should be an explicit format for a JSON extended type that is not one of the Core types.");
+
+                    // An explicit per-format override can disable the assertion or downgrade it to a
+                    // warning. Without an override, the extended type asserts its format as before.
+                    if (typeDeclaration.GetFormatModeOverride(extendedFormat, out FormatAssertionMode extendedFormatMode) &&
+                        extendedFormatMode == FormatAssertionMode.Disable)
+                    {
+                        generator
+                            .AppendLineIndent("result = validationContext;");
+                        break;
+                    }
+
+                    bool extendedWarn = extendedFormatMode == FormatAssertionMode.Warning;
+                    if (extendedWarn && FormatHandlerRegistry.Instance.FormatHandlers.GetExpectedValueKind(extendedFormat) != System.Text.Json.JsonValueKind.String)
+                    {
+                        // Warning mode is only supported for string formats; assert numeric formats.
+                        generator
+                            .AppendLineIndent("// NOTE: 'warning' format mode is not supported for the numeric format '", extendedFormat, "'; asserting instead.");
+                        extendedWarn = false;
+                    }
+
                     FormatHandlerRegistry.Instance.FormatHandlers.AppendFormatAssertion(
                         generator,
-                        typeDeclaration.ExplicitFormat() ?? throw new InvalidOperationException("There should be an explicit format for a JSON extended type that is not one of the Core types."),
+                        extendedFormat,
                         "this",
                         "result",
                         typeKeyword,
                         formatKeyword,
                         returnFromMethod: false,
-                        includeType: true);
+                        includeType: true,
+                        warn: extendedWarn);
                     break;
             }
 

--- a/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Format/FormatAssertionMode.cs
+++ b/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Format/FormatAssertionMode.cs
@@ -1,0 +1,34 @@
+// <copyright file="FormatAssertionMode.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Json.CodeGeneration;
+
+/// <summary>
+/// Determines how a JSON Schema <c>format</c> assertion is emitted by the code
+/// generation pipeline for a particular format.
+/// </summary>
+/// <remarks>
+/// The mode is resolved at code-generation time, not at runtime. Each mode emits
+/// different static code, so the default <see cref="Assert"/> path carries no
+/// additional runtime branches.
+/// </remarks>
+public enum FormatAssertionMode
+{
+    /// <summary>
+    /// The format is validated and a non-conformant value fails validation. This is
+    /// the standard behaviour.
+    /// </summary>
+    Assert,
+
+    /// <summary>
+    /// The format keyword becomes annotation-only: no validation is performed.
+    /// </summary>
+    Disable,
+
+    /// <summary>
+    /// The format is validated, but validation always succeeds. A non-conformant
+    /// value produces a <c>WARNING</c> annotation rather than a failure.
+    /// </summary>
+    Warning,
+}

--- a/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Format/FormatAssertionModeParser.cs
+++ b/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Format/FormatAssertionModeParser.cs
@@ -1,0 +1,95 @@
+// <copyright file="FormatAssertionModeParser.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System;
+using System.Collections.Generic;
+
+namespace Corvus.Json.CodeGeneration;
+
+/// <summary>
+/// Helpers for parsing per-format <see cref="FormatAssertionMode"/> configuration from the
+/// textual forms used by the CLI (<c>date-time=disable,time=warning</c>) and the MSBuild
+/// source-generator property (<c>date-time=disable;time=warning</c>).
+/// </summary>
+public static class FormatAssertionModeParser
+{
+    /// <summary>
+    /// Tries to parse a single mode token (<c>assert</c>, <c>disable</c> or <c>warning</c>,
+    /// case-insensitive).
+    /// </summary>
+    /// <param name="value">The value to parse.</param>
+    /// <param name="mode">The parsed mode.</param>
+    /// <returns><see langword="true"/> if the value was a recognized mode.</returns>
+    public static bool TryParseMode(string? value, out FormatAssertionMode mode)
+    {
+        if (value is not null)
+        {
+            if (string.Equals(value, "assert", StringComparison.OrdinalIgnoreCase))
+            {
+                mode = FormatAssertionMode.Assert;
+                return true;
+            }
+
+            if (string.Equals(value, "disable", StringComparison.OrdinalIgnoreCase))
+            {
+                mode = FormatAssertionMode.Disable;
+                return true;
+            }
+
+            if (string.Equals(value, "warning", StringComparison.OrdinalIgnoreCase))
+            {
+                mode = FormatAssertionMode.Warning;
+                return true;
+            }
+        }
+
+        mode = FormatAssertionMode.Assert;
+        return false;
+    }
+
+    /// <summary>
+    /// Parses a per-format mode specification consisting of <c>format=mode</c> pairs separated
+    /// by any of the given <paramref name="separators"/> (e.g. <c>date-time=disable,time=warning</c>).
+    /// </summary>
+    /// <param name="specification">The specification to parse. May be <see langword="null"/> or empty.</param>
+    /// <param name="separators">The pair separators (e.g. <c>,</c> for the CLI, <c>;</c> for MSBuild).</param>
+    /// <returns>A dictionary of format name to <see cref="FormatAssertionMode"/>. Empty if there were no pairs.</returns>
+    /// <exception cref="FormatException">A pair was malformed or specified an unrecognized mode.</exception>
+    public static IReadOnlyDictionary<string, FormatAssertionMode> ParseSpecification(string? specification, params char[] separators)
+    {
+        Dictionary<string, FormatAssertionMode> result = new(StringComparer.Ordinal);
+
+        if (string.IsNullOrWhiteSpace(specification))
+        {
+            return result;
+        }
+
+        foreach (string rawPair in specification!.Split(separators, StringSplitOptions.RemoveEmptyEntries))
+        {
+            string pair = rawPair.Trim();
+            if (pair.Length == 0)
+            {
+                continue;
+            }
+
+            int equalsIndex = pair.IndexOf('=');
+            if (equalsIndex <= 0 || equalsIndex == pair.Length - 1)
+            {
+                throw new FormatException($"Invalid format mode entry '{pair}'. Expected '<format>=<assert|disable|warning>'.");
+            }
+
+            string format = pair.Substring(0, equalsIndex).Trim();
+            string modeText = pair.Substring(equalsIndex + 1).Trim();
+
+            if (format.Length == 0 || !TryParseMode(modeText, out FormatAssertionMode mode))
+            {
+                throw new FormatException($"Invalid format mode entry '{pair}'. Expected '<format>=<assert|disable|warning>'.");
+            }
+
+            result[format] = mode;
+        }
+
+        return result;
+    }
+}

--- a/src-v4/Corvus.Json.ExtendedTypes/Corvus.Json/Validate.Warning.cs
+++ b/src-v4/Corvus.Json.ExtendedTypes/Corvus.Json/Validate.Warning.cs
@@ -1,0 +1,760 @@
+// <copyright file="Validate.Warning.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.Text.Json;
+
+namespace Corvus.Json;
+
+/// <summary>
+/// Warning-mode format validation helpers.
+/// </summary>
+/// <remarks>
+/// Each method mirrors its <c>Type&lt;Format&gt;</c> sibling but, for a value of the correct
+/// JSON type that does not satisfy the format, records a <c>WARNING</c> annotation and reports
+/// the value as valid rather than failing. A value of the wrong JSON type still fails, because
+/// warning mode only downgrades the <c>format</c> assertion.
+/// </remarks>
+public static partial class Validate
+{
+    /// <summary>
+    /// Validates the format <c>uri-template</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeUriTemplateWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeUriTemplate(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeUriTemplate(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'uri-template'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'uri-template'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>idn-email</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIdnEmailWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeIdnEmail(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeIdnEmail(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'idn-email'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'idn-email'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>idn-hostname</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIdnHostNameWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeIdnHostName(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeIdnHostName(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'idn-hostname'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'idn-hostname'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>hostname</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeHostnameWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeHostname(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeHostname(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'hostname'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'hostname'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>uuid</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeUuidWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeUuid(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeUuid(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'uuid'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'uuid'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>duration</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeDurationWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeDuration(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeDuration(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'duration'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'duration'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>email</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeEmailWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeEmail(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeEmail(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'email'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'email'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>relative-json-pointer</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeRelativePointerWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeRelativePointer(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeRelativePointer(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'relative-json-pointer'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'relative-json-pointer'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>json-pointer</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypePointerWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypePointer(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypePointer(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'json-pointer'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'json-pointer'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>regex</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeRegexWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeRegex(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeRegex(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'regex'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'regex'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>iri-reference</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIriReferenceWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeIriReference(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeIriReference(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'iri-reference'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'iri-reference'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>iri</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIriWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeIri(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeIri(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'iri'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'iri'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>uri</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeUriWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeUri(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeUri(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'uri'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'uri'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>uri-reference</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeUriReferenceWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeUriReference(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeUriReference(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'uri-reference'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'uri-reference'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>time</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeTimeWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeTime(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeTime(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'time'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'time'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>date</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeDateWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeDate(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeDate(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'date'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'date'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>ipv6</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIpV6Warning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeIpV6(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeIpV6(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'ipv6'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'ipv6'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>ipv4</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIpV4Warning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeIpV4(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeIpV4(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'ipv4'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'ipv4'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>date-time</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="typeKeyword">The type keyword.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeDateTimeWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? typeKeyword = null, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (instance.ValueKind != JsonValueKind.String)
+        {
+            // The type itself is incorrect; warning mode only downgrades the format assertion.
+            return Validate.TypeDateTime(instance, validationContext, level, typeKeyword, formatKeyword);
+        }
+
+        if (Validate.TypeDateTime(instance, ValidationContext.ValidContext, ValidationLevel.Flag, typeKeyword, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {typeKeyword ?? "type"} - was 'string'.", typeKeyword ?? "type")
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'date-time'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'date-time'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+}

--- a/src-v4/Corvus.Json.ExtendedTypes/Corvus.Json/ValidateWithoutCoreType.Warning.cs
+++ b/src-v4/Corvus.Json.ExtendedTypes/Corvus.Json/ValidateWithoutCoreType.Warning.cs
@@ -1,0 +1,607 @@
+// <copyright file="ValidateWithoutCoreType.Warning.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.Text.Json;
+
+namespace Corvus.Json;
+
+/// <summary>
+/// Warning-mode format validation helpers that do not assert the core type.
+/// </summary>
+/// <remarks>
+/// Each method mirrors its <c>Type&lt;Format&gt;</c> sibling but, for a value that does not
+/// satisfy the format, records a <c>WARNING</c> annotation and reports the value as valid
+/// rather than failing.
+/// </remarks>
+public static partial class ValidateWithoutCoreType
+{
+    /// <summary>
+    /// Validates the format <c>uri-template</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeUriTemplateWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeUriTemplate(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'uri-template'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'uri-template'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>idn-email</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIdnEmailWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeIdnEmail(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'idn-email'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'idn-email'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>idn-hostname</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIdnHostNameWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeIdnHostName(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'idn-hostname'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'idn-hostname'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>hostname</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeHostnameWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeHostname(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'hostname'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'hostname'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>uuid</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeUuidWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeUuid(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'uuid'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'uuid'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>duration</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeDurationWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeDuration(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'duration'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'duration'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>email</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeEmailWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeEmail(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'email'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'email'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>relative-json-pointer</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeRelativePointerWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeRelativePointer(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'relative-json-pointer'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'relative-json-pointer'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>json-pointer</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypePointerWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypePointer(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'json-pointer'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'json-pointer'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>regex</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeRegexWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeRegex(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'regex'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'regex'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>iri-reference</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIriReferenceWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeIriReference(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'iri-reference'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'iri-reference'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>iri</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIriWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeIri(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'iri'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'iri'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>uri</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeUriWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeUri(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'uri'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'uri'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>uri-reference</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeUriReferenceWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeUriReference(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'uri-reference'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'uri-reference'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>time</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeTimeWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeTime(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'time'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'time'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>date</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeDateWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeDate(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'date'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'date'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>ipv6</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIpV6Warning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeIpV6(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'ipv6'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'ipv6'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>ipv4</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeIpV4Warning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeIpV4(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'ipv4'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'ipv4'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+
+    /// <summary>
+    /// Validates the format <c>date-time</c> in warning mode.
+    /// </summary>
+    /// <typeparam name="T">The type of <see cref="IJsonValue"/> to validate.</typeparam>
+    /// <param name="instance">The instance to validate.</param>
+    /// <param name="validationContext">The validation context.</param>
+    /// <param name="level">The validation level.</param>
+    /// <param name="formatKeyword">The format keyword.</param>
+    /// <returns>The updated validation context. A non-conformant value is reported as valid with a warning.</returns>
+    public static ValidationContext TypeDateTimeWarning<T>(in T instance, in ValidationContext validationContext, ValidationLevel level, string? formatKeyword = null)
+        where T : struct, IJsonValue<T>
+    {
+        if (ValidateWithoutCoreType.TypeDateTime(instance, ValidationContext.ValidContext, ValidationLevel.Flag, formatKeyword).IsValid)
+        {
+            if (level == ValidationLevel.Verbose)
+            {
+                return validationContext
+                    .WithResult(isValid: true, $"Validation {formatKeyword ?? "format"} - was 'date-time'.", formatKeyword ?? "format");
+            }
+
+            return validationContext;
+        }
+
+        if (level >= ValidationLevel.Basic)
+        {
+            return validationContext.WithResult(isValid: true, $"WARNING: Validation {formatKeyword ?? "format"} - should have been 'date-time'.", formatKeyword ?? "format");
+        }
+
+        return validationContext;
+    }
+}

--- a/src-v4/Corvus.Json.SourceGenerator/Corvus.Json.SourceGenerator.props
+++ b/src-v4/Corvus.Json.SourceGenerator/Corvus.Json.SourceGenerator.props
@@ -4,6 +4,7 @@
         <CompilerVisibleProperty Include="CorvusJsonSchemaOptionalAsNullable" />
         <CompilerVisibleProperty Include="CorvusJsonSchemaUseOptionalNameHeuristics" />
         <CompilerVisibleProperty Include="CorvusJsonSchemaAlwaysAssertFormat" />
+        <CompilerVisibleProperty Include="CorvusJsonSchemaFormatMode" />
         <CompilerVisibleProperty Include="CorvusJsonSchemaDisabledNamingHeuristics" />
       <CompilerVisibleProperty Include="CorvusJsonSchemaDefaultAccessibility" />
       <CompilerVisibleProperty Include="CorvusJsonSchemaAddExplicitUsings" />

--- a/src-v4/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
+++ b/src-v4/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
@@ -130,7 +130,10 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
             defaultAccessibility: generationSource.DefaultAccessibility,
             addExplicitUsings: generationSource.AddExplicitUsings,
             useImplicitOperatorString: generationSource.UseImplicitOperatorString,
-            excludeNonNullDefaulted: generationSource.ExcludeNonNullDefaulted);
+            excludeNonNullDefaulted: generationSource.ExcludeNonNullDefaulted,
+            formatModeOverrides: string.IsNullOrWhiteSpace(generationSource.FormatModeSpecification)
+                ? null
+                : FormatAssertionModeParser.ParseSpecification(generationSource.FormatModeSpecification, ';', ','));
 
         var languageProvider = CSharpLanguageProvider.DefaultWithOptions(options);
 
@@ -255,6 +258,16 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
             }
         }
 
+        string? formatModeSpecification = null;
+
+        if (source.GlobalOptions.TryGetValue("build_property.CorvusJsonSchemaFormatMode", out string? formatModeSpec) &&
+            !string.IsNullOrWhiteSpace(formatModeSpec))
+        {
+            // Validate eagerly so a malformed value fails the build with a clear message.
+            FormatAssertionModeParser.ParseSpecification(formatModeSpec, ';', ',');
+            formatModeSpecification = formatModeSpec;
+        }
+
         GeneratedTypeAccessibility defaultAccessibility = GeneratedTypeAccessibility.Public;
 
         if (source.GlobalOptions.TryGetValue("build_property.CorvusJsonSchemaDefaultAccessibility", out string? defaultAccessibilityName))
@@ -288,7 +301,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
             disabledNamingHeuristics ?? DefaultDisabledNamingHeuristics,
             defaultAccessibility,
             addExplicitUsings,
-            useImplicitOperatorString);
+            useImplicitOperatorString,
+            formatModeSpecification);
     }
 
     private static CompoundDocumentResolver BuildDocumentResolver(ImmutableArray<AdditionalText> source, CancellationToken token)
@@ -435,6 +449,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         public bool AddExplicitUsings { get; } = right.AddExplicitUsings;
 
         public bool UseImplicitOperatorString { get; } = right.UseImplicitOperatorString;
+
+        public string? FormatModeSpecification { get; } = right.FormatModeSpecification;
     }
 
     private readonly struct TypesToGenerate(ImmutableArray<GenerationSpecification> left, GenerationContext right)
@@ -460,6 +476,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         public bool AddExplicitUsings { get; } = right.AddExplicitUsings;
 
         public bool UseImplicitOperatorString { get; } = right.UseImplicitOperatorString;
+
+        public string? FormatModeSpecification { get; } = right.FormatModeSpecification;
     }
 
     private readonly struct GlobalOptions(
@@ -471,7 +489,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         ImmutableArray<string> disabledNamingHeuristics,
         GeneratedTypeAccessibility defaultAccessibility,
         bool addExplicitUsings,
-        bool useImplicitOperatorString)
+        bool useImplicitOperatorString,
+        string? formatModeSpecification)
     {
         public IVocabulary FallbackVocabulary { get; } = fallbackVocabulary;
 
@@ -490,5 +509,7 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         public bool AddExplicitUsings { get; } = addExplicitUsings;
 
         public bool UseImplicitOperatorString { get; } = useImplicitOperatorString;
+
+        public string? FormatModeSpecification { get; } = formatModeSpecification;
     }
 }

--- a/src/Corvus.Json.Cli.Core/GenerateCommand.cs
+++ b/src/Corvus.Json.Cli.Core/GenerateCommand.cs
@@ -9,7 +9,9 @@
 
 using System.ComponentModel;
 using System.Diagnostics.CodeAnalysis;
+using System.Linq;
 using Corvus.Json;
+using Corvus.Json.CodeGeneration;
 using Corvus.Json.CodeGenerator;
 using Corvus.Text.Json.CodeGeneration;
 using Spectre.Console.Cli;
@@ -70,6 +72,10 @@ internal class GenerateCommand : AsyncCommand<GenerateCommand.Settings>
         [Description("If --assertFormat is specified, assert format specifications.")]
         [DefaultValue(true)]
         public bool AssertFormat { get; init; }
+
+        [CommandOption("--formatMode")]
+        [Description("Per-format assertion mode overrides as comma-separated '<format>=<assert|disable|warning>' pairs (e.g. 'date-time=disable,time=warning'). May be specified more than once. An override takes precedence over --assertFormat.")]
+        public string[]? FormatMode { get; init; }
 
         [Description("The path to the schema file to process.")]
         [CommandArgument(0, "<schemaFile>")]
@@ -166,6 +172,26 @@ internal class GenerateCommand : AsyncCommand<GenerateCommand.Settings>
             config = config.SetProperty("defaultAccessibility", new JsonString(defaultAccessibility.ToString()));
         }
 
+        if (settings.FormatMode is string[] formatModeSpecs && formatModeSpecs.Length > 0)
+        {
+            IReadOnlyDictionary<string, FormatAssertionMode> overrides =
+                FormatAssertionModeParser.ParseSpecification(string.Join(",", formatModeSpecs), ',');
+
+            if (overrides.Count > 0)
+            {
+                config = config.SetProperty(
+                    "formatMode",
+                    JsonObject.FromProperties(overrides.Select(kvp => ((JsonPropertyName)kvp.Key, new JsonString(FormatModeToString(kvp.Value)).AsAny)).ToArray()));
+            }
+        }
+
         return GenerationDriver.GenerateTypes(config, engine, settings.CodeGenerationMode, cancellationToken);
     }
+
+    private static string FormatModeToString(FormatAssertionMode mode) => mode switch
+    {
+        FormatAssertionMode.Disable => "disable",
+        FormatAssertionMode.Warning => "warning",
+        _ => "assert",
+    };
 }

--- a/src/Corvus.Json.Cli.Core/GenerationDriverV4.cs
+++ b/src/Corvus.Json.Cli.Core/GenerationDriverV4.cs
@@ -247,7 +247,31 @@ public static class GenerationDriverV4
             lineEndSequence: (generatorConfig.UseUnixLineEndings ?? false) ? "\n" : "\r\n",
             addExplicitUsings: generatorConfig.AddExplicitUsings ?? false,
             defaultAccessibility: defaultAccessibility,
-            excludeNonNullDefaulted: excludeNonNullDefaulted);
+            excludeNonNullDefaulted: excludeNonNullDefaulted,
+            formatModeOverrides: GetFormatModeOverrides(generatorConfig));
+    }
+
+    private static IReadOnlyDictionary<string, FormatAssertionMode>? GetFormatModeOverrides(in GeneratorConfig generatorConfig)
+    {
+        if (!generatorConfig.TryGetProperty("formatMode", out JsonAny propertyValue) || propertyValue.IsNullOrUndefined())
+        {
+            return null;
+        }
+
+        Dictionary<string, FormatAssertionMode> overrides = new(StringComparer.Ordinal);
+        foreach (JsonObjectProperty property in propertyValue.As<JsonObject>().EnumerateObject())
+        {
+            string format = property.Name.GetString();
+            string modeText = (string)property.Value.As<JsonString>();
+            if (!FormatAssertionModeParser.TryParseMode(modeText, out FormatAssertionMode mode))
+            {
+                throw new FormatException($"Invalid format mode '{modeText}' for format '{format}' in 'formatMode'. Expected 'assert', 'disable' or 'warning'.");
+            }
+
+            overrides[format] = mode;
+        }
+
+        return overrides.Count > 0 ? overrides : null;
     }
 
     private static GeneratedTypeAccessibility GetDefaultAccessibility(in GeneratorConfig generatorConfig)

--- a/src/Corvus.Json.Cli.Core/GenerationDriverV5.cs
+++ b/src/Corvus.Json.Cli.Core/GenerationDriverV5.cs
@@ -251,7 +251,31 @@ public static class GenerationDriverV5
             excludeNonNullDefaulted: excludeNonNullDefaulted,
             buildParametersThreshold: generatorConfig.BuildParametersThreshold is Corvus.Json.JsonInteger buildParametersThreshold && !buildParametersThreshold.IsUndefined()
                 ? (int)buildParametersThreshold
-                : CodeGeneration.CSharpLanguageProvider.Options.DefaultBuildParametersThreshold);
+                : CodeGeneration.CSharpLanguageProvider.Options.DefaultBuildParametersThreshold,
+            formatModeOverrides: GetFormatModeOverrides(generatorConfig));
+    }
+
+    private static IReadOnlyDictionary<string, FormatAssertionMode>? GetFormatModeOverrides(in GeneratorConfig generatorConfig)
+    {
+        if (!generatorConfig.TryGetProperty("formatMode", out JsonAny propertyValue) || propertyValue.IsNullOrUndefined())
+        {
+            return null;
+        }
+
+        Dictionary<string, FormatAssertionMode> overrides = new(StringComparer.Ordinal);
+        foreach (JsonObjectProperty property in propertyValue.As<JsonObject>().EnumerateObject())
+        {
+            string format = property.Name.GetString();
+            string modeText = (string)property.Value.As<JsonString>();
+            if (!FormatAssertionModeParser.TryParseMode(modeText, out FormatAssertionMode mode))
+            {
+                throw new FormatException($"Invalid format mode '{modeText}' for format '{format}' in 'formatMode'. Expected 'assert', 'disable' or 'warning'.");
+            }
+
+            overrides[format] = mode;
+        }
+
+        return overrides.Count > 0 ? overrides : null;
     }
 
     private static CodeGeneration.GeneratedTypeAccessibility GetDefaultAccessibility(in GeneratorConfig generatorConfig)

--- a/src/Corvus.Json.Cli.Core/generator-config.json
+++ b/src/Corvus.Json.Cli.Core/generator-config.json
@@ -13,6 +13,14 @@
             "type": "boolean",
             "description": "If true, assert format specifications."
         },
+        "formatMode": {
+            "type": "object",
+            "description": "Per-format assertion mode overrides. Keys are format names (e.g. 'date-time'); values are the assertion mode. An override takes precedence over assertFormat and the vocabulary's format-assertion behaviour.",
+            "additionalProperties": {
+                "type": "string",
+                "enum": [ "assert", "disable", "warning" ]
+            }
+        },
         "outputMapFile": {
             "type": "string",
             "description": "The name to use for a map file which includes details of the files that were written."

--- a/src/Corvus.Text.Json.CodeGeneration/CSharpLanguageProvider.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CSharpLanguageProvider.cs
@@ -857,6 +857,7 @@ public class CSharpLanguageProvider : IHierarchicalLanguageProvider
     /// <param name="codeGenerationMode">The code generation mode to use.</param>
     /// <param name="excludeNonNullDefaulted">If true (and <paramref name="optionalAsNullable"/> is true), then optional properties that declare a non-null <c>default</c> are generated as non-nullable types.</param>
     /// <param name="buildParametersThreshold">The maximum estimated number of captured value slots an object type's <c>Build(...)</c> property-parameter overload may hold before it is omitted (and callers fall back to the delegate/context <c>Build</c> form). See <see cref="DefaultBuildParametersThreshold"/>.</param>
+    /// <param name="formatModeOverrides">Per-format assertion mode overrides, keyed by format name (e.g. <c>date-time</c>). An override takes precedence over both the vocabulary's format-assertion behaviour and <paramref name="alwaysAssertFormat"/>.</param>
     public class Options(
         string defaultNamespace,
         NamedType[]? namedTypes = null,
@@ -872,7 +873,8 @@ public class CSharpLanguageProvider : IHierarchicalLanguageProvider
         GeneratedTypeAccessibility defaultAccessibility = GeneratedTypeAccessibility.Public,
         CodeGenerationMode codeGenerationMode = CodeGenerationMode.TypeGeneration,
         bool excludeNonNullDefaulted = false,
-        int buildParametersThreshold = 32)
+        int buildParametersThreshold = 32,
+        IReadOnlyDictionary<string, FormatAssertionMode>? formatModeOverrides = null)
     {
         /// <summary>
         /// The default value for <see cref="BuildParametersThreshold"/>.
@@ -912,6 +914,18 @@ public class CSharpLanguageProvider : IHierarchicalLanguageProvider
         /// Gets a value indicating whether to always assert the format validation, regardless of the vocabulary.
         /// </summary>
         internal bool AlwaysAssertFormat { get; } = alwaysAssertFormat;
+
+        /// <summary>
+        /// Gets the per-format assertion mode overrides, keyed by format name (e.g. <c>date-time</c>).
+        /// </summary>
+        /// <remarks>
+        /// An override takes precedence over both the vocabulary's format-assertion behaviour
+        /// and <see cref="AlwaysAssertFormat"/>.
+        /// </remarks>
+        internal FrozenDictionary<string, FormatAssertionMode> FormatModeOverrides { get; } =
+            formatModeOverrides is { Count: > 0 }
+                ? formatModeOverrides.ToFrozenDictionary(StringComparer.Ordinal)
+                : FrozenDictionary<string, FormatAssertionMode>.Empty;
 
         /// <summary>
         /// Gets a value indicating whether to generate nullable types for optional parameters.

--- a/src/Corvus.Text.Json.CodeGeneration/FormatHandlers/FormatHandlerExtensions.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/FormatHandlers/FormatHandlerExtensions.cs
@@ -220,6 +220,8 @@ internal static class FormatHandlerExtensions
     /// <param name="formatKeywordProviderExpression">The expression that provides the format keyword.</param>
     /// <param name="valueIdentifier">The identifier for the string value to validate.</param>
     /// <param name="validationContextIdentifier">The identifier for the validation context.</param>
+    /// <param name="warn">If <see langword="true"/>, emit the warning-mode variant that records a
+    /// <c>WARNING</c> annotation on mismatch instead of failing validation.</param>
     /// <returns><see langword="true"/> if a handler was found and emitted code; otherwise, <see langword="false"/>.</returns>
     public static bool AppendFormatAssertion<T>(
         this IEnumerable<T> handlers,
@@ -227,12 +229,13 @@ internal static class FormatHandlerExtensions
         string format,
         string formatKeywordProviderExpression,
         string valueIdentifier,
-        string validationContextIdentifier)
+        string validationContextIdentifier,
+        bool warn = false)
         where T : notnull, IStringFormatHandler
     {
         foreach (T handler in handlers)
         {
-            if (handler.AppendFormatAssertion(generator, format, formatKeywordProviderExpression, valueIdentifier, validationContextIdentifier))
+            if (handler.AppendFormatAssertion(generator, format, formatKeywordProviderExpression, valueIdentifier, validationContextIdentifier, warn))
             {
                 return true;
             }

--- a/src/Corvus.Text.Json.CodeGeneration/FormatHandlers/IStringFormatHandler.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/FormatHandlers/IStringFormatHandler.cs
@@ -24,13 +24,16 @@ public interface IStringFormatHandler : IFormatHandler
     /// <param name="formatKeywordProviderExpression">The expression that produces the JsonSchemaPathProvider for the keyword.</param>
     /// <param name="valueIdentifier">The identifier for the value to test.</param>
     /// <param name="validationContextIdentifier">The identifier for the validation context to update.</param>
+    /// <param name="warn">If <see langword="true"/>, emit the warning-mode variant that records a
+    /// <c>WARNING</c> annotation on mismatch instead of failing validation.</param>
     /// <returns><see langword="true"/> if the instance handled this format.</returns>
     bool AppendFormatAssertion(
         CodeGenerator generator,
         string format,
         string formatKeywordProviderExpression,
         string valueIdentifier,
-        string validationContextIdentifier);
+        string validationContextIdentifier,
+        bool warn = false);
 
     /// <summary>
     /// Indicates whether the string format requires the simple types backing.

--- a/src/Corvus.Text.Json.CodeGeneration/FormatHandlers/WellKnownStringFormatHandler.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/FormatHandlers/WellKnownStringFormatHandler.cs
@@ -28,198 +28,50 @@ public class WellKnownStringFormatHandler : IStringFormatHandler
     public uint Priority => 100_000;
 
     /// <inheritdoc/>
-    public bool AppendFormatAssertion(CodeGenerator generator, string format, string formatKeywordProviderExpression, string valueIdentifier, string validationContextIdentifier)
+    public bool AppendFormatAssertion(CodeGenerator generator, string format, string formatKeywordProviderExpression, string valueIdentifier, string validationContextIdentifier, bool warn = false)
     {
-        switch (format)
+        string? methodSuffix = format switch
         {
-            case "date":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchDate(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
+            "date" => "Date",
+            "date-time" => "DateTime",
+            "time" => "Time",
+            "duration" => "Duration",
+            "email" => "Email",
+            "idn-email" => "IdnEmail",
+            "hostname" => "Hostname",
+            "idn-hostname" => "IdnHostname",
+            "ipv4" => "IPV4",
+            "ipv6" => "IPV6",
+            "uuid" => "Uuid",
+            "uri" => "Uri",
+            "uri-template" => "UriTemplate",
+            "uri-reference" => "UriReference",
+            "iri" => "Iri",
+            "iri-reference" => "IriReference",
+            "json-pointer" => "JsonPointer",
+            "relative-json-pointer" => "RelativeJsonPointer",
+            "regex" => "Regex",
+            "corvus-base64-content-pre201909" => "Base64Content",
+            "corvus-base64-string-pre201909" => "Base64String",
+            "corvus-json-content-pre201909" => "JsonContent",
+            _ => null,
+        };
 
-            case "date-time":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchDateTime(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "time":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchTime(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "duration":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchDuration(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "email":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchEmail(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "idn-email":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchIdnEmail(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "hostname":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchHostname(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "idn-hostname":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchIdnHostname(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "ipv4":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchIPV4(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "ipv6":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchIPV6(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "uuid":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchUuid(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "uri":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchUri(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "uri-template":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchUriTemplate(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "uri-reference":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchUriReference(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "iri":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchIri(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "iri-reference":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchIriReference(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "json-pointer":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchJsonPointer(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "relative-json-pointer":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchRelativeJsonPointer(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "regex":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchRegex(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "corvus-base64-content":
-                return false;
-
-            case "corvus-base64-content-pre201909":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchBase64Content(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "corvus-base64-string":
-                return false;
-
-            case "corvus-base64-string-pre201909":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchBase64String(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            case "corvus-json-content":
-                return false;
-
-            case "corvus-json-content-pre201909":
-                generator.AppendIndent(
-                   "JsonSchemaEvaluation.MatchJsonContent(",
-                   valueIdentifier, ", ",
-                   formatKeywordProviderExpression, ", ",
-                   "ref ", validationContextIdentifier, ")");
-                return true;
-
-            default:
-                return false;
+        if (methodSuffix is null)
+        {
+            // Includes the Draft 2019-09+ content formats (corvus-base64-content,
+            // corvus-base64-string, corvus-json-content), which are handled elsewhere.
+            return false;
         }
+
+        generator.AppendIndent(
+           warn ? "JsonSchemaEvaluation.Warn" : "JsonSchemaEvaluation.Match",
+           methodSuffix,
+           "(",
+           valueIdentifier, ", ",
+           formatKeywordProviderExpression, ", ",
+           "ref ", validationContextIdentifier, ")");
+        return true;
     }
 
     /// <inheritdoc/>

--- a/src/Corvus.Text.Json.CodeGeneration/StandaloneEvaluatorGenerator.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/StandaloneEvaluatorGenerator.cs
@@ -1854,7 +1854,18 @@ internal static partial class StandaloneEvaluatorGenerator
             (formatKw is IContentMediaTypeValidationKeyword &&
              (format.EndsWith("-pre201909", System.StringComparison.Ordinal) ||
               typeDeclaration.Keywords().OfType<IContentSemanticsKeyword>().Any(k => k.ContentSemantics == ContentEncodingSemantics.PreDraft201909)));
-        if (!isContentFormat && !typeDeclaration.AlwaysAssertFormat())
+        bool warn = false;
+        if (typeDeclaration.GetFormatModeOverride(format, out FormatAssertionMode overrideMode))
+        {
+            if (overrideMode == FormatAssertionMode.Disable)
+            {
+                // Format is not asserted — the annotation value is emitted by EmitAnnotations.
+                return;
+            }
+
+            warn = overrideMode == FormatAssertionMode.Warning;
+        }
+        else if (!isContentFormat && !typeDeclaration.AlwaysAssertFormat())
         {
             // Format is not asserted — the annotation value is emitted by EmitAnnotations.
             return;
@@ -1873,11 +1884,17 @@ internal static partial class StandaloneEvaluatorGenerator
 
         if (expectedTokenType == JsonTokenType.String)
         {
+            // Warning mode emits the WarnXxx sibling, which records a WARNING annotation on
+            // mismatch instead of failing validation.
+            string stringMethodName = warn && matchMethodName.StartsWith("Match", System.StringComparison.Ordinal)
+                ? "Warn" + matchMethodName.Substring("Match".Length)
+                : matchMethodName;
+
             ctx.AppendLine("if (tokenType == JsonTokenType.String)");
             ctx.AppendLine("{");
             ctx.PushIndent();
             ctx.AppendLine("using UnescapedUtf8JsonString unescapedFormatString = parentDocument.GetUtf8JsonString(parentIndex, JsonTokenType.String);");
-            ctx.AppendLine($"JsonSchemaEvaluation.{matchMethodName}(unescapedFormatString.Span, {formatKeywordLiteral}, ref context);");
+            ctx.AppendLine($"JsonSchemaEvaluation.{stringMethodName}(unescapedFormatString.Span, {formatKeywordLiteral}, ref context);");
             ctx.AppendLine();
             ctx.AppendLine("if (!context.HasCollector && !context.IsMatch)");
             ctx.AppendLine("{");
@@ -1903,6 +1920,13 @@ internal static partial class StandaloneEvaluatorGenerator
         }
         else if (expectedTokenType == JsonTokenType.Number)
         {
+            if (warn)
+            {
+                // Warning mode is only supported for string formats. Numeric formats fall back
+                // to assertion; emit a visible note in the generated code.
+                ctx.AppendLine($"// NOTE: 'warning' format mode is not supported for the numeric format '{format}'; asserting instead.");
+            }
+
             ctx.AppendLine("if (tokenType == JsonTokenType.Number)");
             ctx.AppendLine("{");
             ctx.PushIndent();

--- a/src/Corvus.Text.Json.CodeGeneration/TypeDeclarationExtensions.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/TypeDeclarationExtensions.cs
@@ -7,6 +7,7 @@
 // https://github.com/dotnet/runtime/blob/388a7c4814cb0d6e344621d017507b357902043a/LICENSE.TXT
 // </licensing>
 
+using System.Collections.Frozen;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
@@ -57,6 +58,7 @@ public static class TypeDeclarationExtensions
     private const string AccessibilityKey = "CSharp_LanguageProvider_AccessibilityKey";
     private const string AddExplicitUsingsKey = "CSharp_LanguageProvider_AddExplicitUsings";
     private const string AlwaysAssertFormatKey = "CSharp_LanguageProvider_AlwaysAssertFormat";
+    private const string FormatModeOverridesKey = "CSharp_LanguageProvider_FormatModeOverrides";
     private const string BuilderSourcesKey = "CSharp_LanguageProvider_BuilderSources";
     private const string ChildrenKey = "CSharp_LanguageProvider_Children";
     private const string DefaultAccessibilityKey = "CSharp_LanguageProvider_DefaultAccessibilityKey";
@@ -105,6 +107,56 @@ public static class TypeDeclarationExtensions
             return value;
         }
 
+        return false;
+    }
+
+    /// <summary>
+    /// Gets the effective <see cref="FormatAssertionMode"/> for the given format on this
+    /// type declaration.
+    /// </summary>
+    /// <param name="typeDeclaration">The type declaration to test.</param>
+    /// <param name="format">The format name (e.g. <c>date-time</c>).</param>
+    /// <returns>The effective <see cref="FormatAssertionMode"/>.</returns>
+    /// <remarks>
+    /// Resolution order: a per-format override (if present) takes precedence, then the
+    /// vocabulary's format-assertion behaviour or the global
+    /// <see cref="AlwaysAssertFormat(TypeDeclaration)"/> setting (either of which yields
+    /// <see cref="FormatAssertionMode.Assert"/>), otherwise <see cref="FormatAssertionMode.Disable"/>.
+    /// </remarks>
+    public static FormatAssertionMode GetEffectiveFormatMode(this TypeDeclaration typeDeclaration, string format)
+    {
+        if (typeDeclaration.TryGetMetadata(FormatModeOverridesKey, out FrozenDictionary<string, FormatAssertionMode>? overrides) &&
+            overrides is not null &&
+            overrides.TryGetValue(format, out FormatAssertionMode mode))
+        {
+            return mode;
+        }
+
+        if (typeDeclaration.IsFormatAssertion() || typeDeclaration.AlwaysAssertFormat())
+        {
+            return FormatAssertionMode.Assert;
+        }
+
+        return FormatAssertionMode.Disable;
+    }
+
+    /// <summary>
+    /// Tries to get an explicit per-format assertion mode override for the given format.
+    /// </summary>
+    /// <param name="typeDeclaration">The type declaration to test.</param>
+    /// <param name="format">The format name (e.g. <c>date-time</c>).</param>
+    /// <param name="mode">When this method returns <see langword="true"/>, contains the override mode.</param>
+    /// <returns><see langword="true"/> if an explicit override was configured for the format.</returns>
+    public static bool GetFormatModeOverride(this TypeDeclaration typeDeclaration, string format, out FormatAssertionMode mode)
+    {
+        if (typeDeclaration.TryGetMetadata(FormatModeOverridesKey, out FrozenDictionary<string, FormatAssertionMode>? overrides) &&
+            overrides is not null &&
+            overrides.TryGetValue(format, out mode))
+        {
+            return true;
+        }
+
+        mode = FormatAssertionMode.Disable;
         return false;
     }
 
@@ -630,6 +682,7 @@ public static class TypeDeclarationExtensions
     public static void SetCSharpOptions(this TypeDeclaration typeDeclaration, CSharpLanguageProvider.Options options)
     {
         typeDeclaration.SetMetadata(AlwaysAssertFormatKey, options.AlwaysAssertFormat);
+        typeDeclaration.SetMetadata(FormatModeOverridesKey, options.FormatModeOverrides);
         typeDeclaration.SetMetadata(OptionalAsNullableKey, options.OptionalAsNullable);
         typeDeclaration.SetMetadata(ExcludeNonNullDefaultedKey, options.ExcludeNonNullDefaulted);
         typeDeclaration.SetMetadata(BuildParametersThresholdKey, options.BuildParametersThreshold);

--- a/src/Corvus.Text.Json.CodeGeneration/ValidationHandlers/FormatValidationHandler.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/ValidationHandlers/FormatValidationHandler.cs
@@ -135,18 +135,31 @@ file static class FormatValidationHandlerExtensions
         generator
             .PrependChildValidationCode(typeDeclaration, childHandlers, validationPriority);
 
-        if (typeDeclaration.IsFormatAssertion() || typeDeclaration.AlwaysAssertFormat())
+        FormatAssertionMode formatMode = typeDeclaration.GetEffectiveFormatMode(explicitFormat);
+
+        if (formatMode is FormatAssertionMode.Assert or FormatAssertionMode.Warning)
         {
+            bool warn = formatMode == FormatAssertionMode.Warning;
+
             if (expectedTokenType is JsonTokenType.String)
             {
                 generator
                     .AppendSeparatorLine()
                     .AppendUnescapedUtf8JsonStringIfNotAppended(typeDeclaration, includeTokenTypeCheck: false);
-                FormatHandlerRegistry.Instance.StringFormatHandlers.AppendFormatAssertion(generator, explicitFormat, $"{SymbolDisplay.FormatLiteral(keyword.Keyword, true)}u8", "unescapedUtf8JsonString.Span", "context");
+                FormatHandlerRegistry.Instance.StringFormatHandlers.AppendFormatAssertion(generator, explicitFormat, $"{SymbolDisplay.FormatLiteral(keyword.Keyword, true)}u8", "unescapedUtf8JsonString.Span", "context", warn);
                 generator.AppendLine(";");
             }
             else
             {
+                if (warn)
+                {
+                    // Warning mode is only supported for string formats. Numeric formats fall back
+                    // to assertion; emit a visible note in the generated code.
+                    generator
+                        .AppendSeparatorLine()
+                        .AppendLineIndent("// NOTE: 'warning' format mode is not supported for the numeric format '", explicitFormat, "'; asserting instead.");
+                }
+
                 generator
                     .AppendSeparatorLine()
                     .AppendNormalizedJsonNumberIfNotAppended(typeDeclaration, includeTokenTypeCheck: false);

--- a/src/Corvus.Text.Json.SourceGenerator/Corvus.Text.Json.SourceGenerator.props
+++ b/src/Corvus.Text.Json.SourceGenerator/Corvus.Text.Json.SourceGenerator.props
@@ -4,6 +4,7 @@
     <CompilerVisibleProperty Include="CorvusTextJsonOptionalAsNullable" />
     <CompilerVisibleProperty Include="CorvusTextJsonUseOptionalNameHeuristics" />
     <CompilerVisibleProperty Include="CorvusTextJsonAlwaysAssertFormat" />
+    <CompilerVisibleProperty Include="CorvusTextJsonFormatMode" />
     <CompilerVisibleProperty Include="CorvusTextJsonDisabledNamingHeuristics" />
     <CompilerVisibleProperty Include="CorvusTextJsonDefaultAccessibility" />
     <CompilerVisibleProperty Include="CorvusTextJsonAddExplicitUsings" />

--- a/src/Corvus.Text.Json.SourceGenerator/IncrementalSourceGenerator.cs
+++ b/src/Corvus.Text.Json.SourceGenerator/IncrementalSourceGenerator.cs
@@ -171,6 +171,14 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
             }
         }
 
+        IReadOnlyDictionary<string, FormatAssertionMode>? formatModeOverrides = null;
+
+        if (source.GlobalOptions.TryGetValue("build_property.CorvusTextJsonFormatMode", out string? formatModeSpec) &&
+            !string.IsNullOrWhiteSpace(formatModeSpec))
+        {
+            formatModeOverrides = FormatAssertionModeParser.ParseSpecification(formatModeSpec, ';', ',');
+        }
+
         Text.Json.CodeGeneration.GeneratedTypeAccessibility defaultAccessibility = Text.Json.CodeGeneration.GeneratedTypeAccessibility.Public;
 
         if (source.GlobalOptions.TryGetValue("build_property.CorvusTextJsonDefaultAccessibility", out string? defaultAccessibilityName))
@@ -218,7 +226,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
             defaultAccessibility,
             addExplicitUsings,
             useImplicitOperatorString,
-            buildParametersThreshold);
+            buildParametersThreshold,
+            formatModeOverrides);
     }
 
     private static void EmitGeneratorAttribute(IncrementalGeneratorInitializationContext initializationContext)
@@ -283,7 +292,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         Text.Json.CodeGeneration.GeneratedTypeAccessibility defaultAccessibility,
         bool addExplicitUsings,
         bool useImplicitOperatorString,
-        int buildParametersThreshold) : IGlobalOptions
+        int buildParametersThreshold,
+        IReadOnlyDictionary<string, FormatAssertionMode>? formatModeOverrides) : IGlobalOptions
     {
         private readonly List<CSharpLanguageProvider.NamedType> _namedTypes = [];
 
@@ -306,6 +316,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
         public bool UseImplicitOperatorString { get; } = useImplicitOperatorString;
 
         public int BuildParametersThreshold { get; } = buildParametersThreshold;
+
+        public IReadOnlyDictionary<string, FormatAssertionMode>? FormatModeOverrides { get; } = formatModeOverrides;
 
         public bool EmitEvaluator { get; set; }
 
@@ -348,7 +360,8 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
                 defaultAccessibility: DefaultAccessibility,
                 codeGenerationMode: EmitEvaluator ? CodeGenerationMode.Both : CodeGenerationMode.TypeGeneration,
                 excludeNonNullDefaulted: ExcludeNonNullDefaulted,
-                buildParametersThreshold: BuildParametersThreshold);
+                buildParametersThreshold: BuildParametersThreshold,
+                formatModeOverrides: FormatModeOverrides);
 
             return options;
         }

--- a/src/Corvus.Text.Json/Corvus/Text/Json/JsonSchema/Internal/JsonSchemaEvaluation.String.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/JsonSchema/Internal/JsonSchemaEvaluation.String.cs
@@ -92,6 +92,50 @@ public static partial class JsonSchemaEvaluation
 
     private static readonly JsonSchemaMessageProvider<int> ExpectedStringLengthGreaterThanOrEquals = static (length, buffer, out written) => ExpectedLengthGreaterThanOrEquals(length, buffer, out written);
 
+    private static readonly JsonSchemaMessageProvider WarningDate = static (buffer, out written) => WriteWarning(ExpectedDate, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningDateTime = static (buffer, out written) => WriteWarning(ExpectedDateTime, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningDuration = static (buffer, out written) => WriteWarning(ExpectedDuration, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningEmail = static (buffer, out written) => WriteWarning(ExpectedEmail, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningHostname = static (buffer, out written) => WriteWarning(ExpectedHostname, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningIdnEmail = static (buffer, out written) => WriteWarning(ExpectedIdnEmail, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningIdnHostname = static (buffer, out written) => WriteWarning(ExpectedIdnHostname, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningIPV4 = static (buffer, out written) => WriteWarning(ExpectedIPV4, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningIPV6 = static (buffer, out written) => WriteWarning(ExpectedIPV6, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningIri = static (buffer, out written) => WriteWarning(ExpectedIri, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningIriReference = static (buffer, out written) => WriteWarning(ExpectedIriReference, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningJsonPointer = static (buffer, out written) => WriteWarning(ExpectedJsonPointer, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningRegex = static (buffer, out written) => WriteWarning(ExpectedRegex, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningRelativeJsonPointer = static (buffer, out written) => WriteWarning(ExpectedRelativeJsonPointer, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningTime = static (buffer, out written) => WriteWarning(ExpectedTime, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningUri = static (buffer, out written) => WriteWarning(ExpectedUri, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningUriReference = static (buffer, out written) => WriteWarning(ExpectedUriReference, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningUriTemplate = static (buffer, out written) => WriteWarning(ExpectedUriTemplate, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningUuid = static (buffer, out written) => WriteWarning(ExpectedUuid, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningBase64String = static (buffer, out written) => WriteWarning(ExpectedBase64String, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningJsonContent = static (buffer, out written) => WriteWarning(ExpectedJsonContent, buffer, out written);
+
+    private static readonly JsonSchemaMessageProvider WarningBase64Content = static (buffer, out written) => WriteWarning(ExpectedBase64Content, buffer, out written);
+
     /// <summary>
     /// Gets the allowed characters for the local part of an email address.
     /// </summary>
@@ -905,6 +949,474 @@ public static partial class JsonSchemaEvaluation
         {
             context.EvaluatedKeyword(false, messageProvider: ExpectedBase64Content, keyword);
             return false;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedBase64Content, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Writes a <c>WARNING: </c> prefix followed by the message produced by the
+    /// supplied inner message provider. Used by the warning-mode format methods.
+    /// </summary>
+    /// <param name="inner">The inner message provider supplying the format-specific message.</param>
+    /// <param name="buffer">The buffer into which to write the message.</param>
+    /// <param name="bytesWritten">The number of bytes written.</param>
+    /// <returns><see langword="true"/> if the message was written; otherwise, <see langword="false"/>.</returns>
+    private static bool WriteWarning(JsonSchemaMessageProvider inner, Span<byte> buffer, out int bytesWritten)
+    {
+        ReadOnlySpan<byte> prefix = "WARNING: "u8;
+        if (buffer.Length < prefix.Length)
+        {
+            bytesWritten = 0;
+            return false;
+        }
+
+        prefix.CopyTo(buffer);
+        if (!inner(buffer.Slice(prefix.Length), out int innerWritten))
+        {
+            bytesWritten = 0;
+            return false;
+        }
+
+        bytesWritten = prefix.Length + innerWritten;
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an ISO 8601 date.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnDate(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!JsonElementHelpers.TryParseLocalDate(value, out _))
+        {
+            context.EvaluatedKeyword(true, WarningDate, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedDate, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an ISO 8601 offset date-time.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnDateTime(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!JsonElementHelpers.TryParseOffsetDateTime(value, out _))
+        {
+            context.EvaluatedKeyword(true, WarningDateTime, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedDateTime, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an ISO 8601 duration.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnDuration(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!JsonElementHelpers.TryParsePeriod(value, out _))
+        {
+            context.EvaluatedKeyword(true, WarningDuration, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedDuration, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an email address.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnEmail(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchEmail(value))
+        {
+            context.EvaluatedKeyword(true, WarningEmail, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedEmail, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is a hostname.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnHostname(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchHostname(value))
+        {
+            context.EvaluatedKeyword(true, WarningHostname, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedHostname, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an internationalized (IDN) email address.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnIdnEmail(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchIdnEmail(value))
+        {
+            context.EvaluatedKeyword(true, WarningIdnEmail, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedIdnEmail, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an internationalized (IDN) hostname.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnIdnHostname(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchIdnHostname(value))
+        {
+            context.EvaluatedKeyword(true, WarningIdnHostname, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedIdnHostname, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an IPv4 address.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnIPV4(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchIPV4(value))
+        {
+            context.EvaluatedKeyword(true, WarningIPV4, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedIPV4, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an IPv6 address.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnIPV6(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchIPV6(value))
+        {
+            context.EvaluatedKeyword(true, WarningIPV6, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedIPV6, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an IRI.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnIri(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchIri(value))
+        {
+            context.EvaluatedKeyword(true, WarningIri, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedIri, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an IRI reference.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnIriReference(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchIriReference(value))
+        {
+            context.EvaluatedKeyword(true, WarningIriReference, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedIriReference, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is a JSON Pointer.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnJsonPointer(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchJsonPointer(value))
+        {
+            context.EvaluatedKeyword(true, WarningJsonPointer, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedJsonPointer, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an ECMAScript regular expression.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnRegex(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchRegex(value))
+        {
+            context.EvaluatedKeyword(true, WarningRegex, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedRegex, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is a relative JSON Pointer.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnRelativeJsonPointer(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchRelativeJsonPointer(value))
+        {
+            context.EvaluatedKeyword(true, WarningRelativeJsonPointer, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedRelativeJsonPointer, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is an ISO 8601 offset time.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnTime(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!JsonElementHelpers.TryParseOffsetTime(value, out _))
+        {
+            context.EvaluatedKeyword(true, WarningTime, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedTime, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is a URI.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnUri(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchUri(value))
+        {
+            context.EvaluatedKeyword(true, WarningUri, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedUri, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is a URI reference.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnUriReference(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchUriReference(value))
+        {
+            context.EvaluatedKeyword(true, WarningUriReference, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedUriReference, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is a URI template.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnUriTemplate(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchUriTemplate(value))
+        {
+            context.EvaluatedKeyword(true, WarningUriTemplate, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedUriTemplate, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is a UUID.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnUuid(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchUuid(value))
+        {
+            context.EvaluatedKeyword(true, WarningUuid, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedUuid, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is a Base64-encoded string.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnBase64String(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchBase64String(value))
+        {
+            context.EvaluatedKeyword(true, WarningBase64String, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedBase64String, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is valid JSON content.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnJsonContent(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchJsonContent(value))
+        {
+            context.EvaluatedKeyword(true, WarningJsonContent, keyword);
+            return true;
+        }
+
+        context.EvaluatedKeyword(true, ExpectedJsonContent, keyword);
+        return true;
+    }
+
+    /// <summary>
+    /// Validates, in warning mode, that a string value is a Base64-encoded JSON document.
+    /// </summary>
+    /// <param name="value">The UTF-8 encoded string value to validate.</param>
+    /// <param name="keyword">The keyword being evaluated.</param>
+    /// <param name="context">The JSON schema validation context.</param>
+    /// <returns>Always <see langword="true"/>; a non-conformant value records a <c>WARNING</c> annotation rather than failing validation.</returns>
+    [CLSCompliant(false)]
+    public static bool WarnBase64Content(ReadOnlySpan<byte> value, ReadOnlySpan<byte> keyword, ref JsonSchemaContext context)
+    {
+        if (!MatchBase64Content(value))
+        {
+            context.EvaluatedKeyword(true, WarningBase64Content, keyword);
+            return true;
         }
 
         context.EvaluatedKeyword(true, ExpectedBase64Content, keyword);

--- a/tests-v4/Corvus.Json.Specs.Tests/CoverageGap/FormatWarningValidationTests.cs
+++ b/tests-v4/Corvus.Json.Specs.Tests/CoverageGap/FormatWarningValidationTests.cs
@@ -1,0 +1,70 @@
+// <copyright file="FormatWarningValidationTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+#pragma warning disable SA1600
+
+using Corvus.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Json.Specs.Tests.CoverageGap;
+
+/// <summary>
+/// Tests for the warning-mode format validation helpers (<c>TypeXxxWarning</c>) added for
+/// per-format assertion modes. A value of the correct JSON type that does not satisfy the
+/// format is reported as valid with a warning; a value of the wrong type still fails.
+/// </summary>
+[TestClass]
+public class FormatWarningValidationTests
+{
+    [TestMethod]
+    public void TypeDateTimeWarning_ValidValue_IsValid()
+    {
+        JsonString value = new("2024-01-02T03:04:05Z");
+        ValidationContext result = Validate.TypeDateTimeWarning(value, ValidationContext.ValidContext, ValidationLevel.Flag);
+        Assert.IsTrue(result.IsValid);
+    }
+
+    [TestMethod]
+    public void TypeDateTimeWarning_InvalidFormat_IsValidWithWarning()
+    {
+        JsonString value = new("not-a-date-time");
+        ValidationContext result = Validate.TypeDateTimeWarning(value, ValidationContext.ValidContext, ValidationLevel.Detailed);
+
+        // Warning mode passes validation despite the non-conformant value.
+        Assert.IsTrue(result.IsValid);
+    }
+
+    [TestMethod]
+    public void TypeDateTimeWarning_WrongType_StillFails()
+    {
+        // Warning mode only downgrades the format assertion; a non-string still fails the type check.
+        JsonNumber value = new(42);
+        ValidationContext result = Validate.TypeDateTimeWarning(value, ValidationContext.ValidContext, ValidationLevel.Flag);
+        Assert.IsFalse(result.IsValid);
+    }
+
+    [TestMethod]
+    public void WithoutCoreType_TypeDateTimeWarning_ValidValue_IsValid()
+    {
+        JsonString value = new("2024-01-02T03:04:05Z");
+        ValidationContext result = ValidateWithoutCoreType.TypeDateTimeWarning(value, ValidationContext.ValidContext, ValidationLevel.Flag);
+        Assert.IsTrue(result.IsValid);
+    }
+
+    [TestMethod]
+    public void WithoutCoreType_TypeDateTimeWarning_InvalidFormat_IsValidWithWarning()
+    {
+        JsonString value = new("not-a-date-time");
+        ValidationContext result = ValidateWithoutCoreType.TypeDateTimeWarning(value, ValidationContext.ValidContext, ValidationLevel.Detailed);
+        Assert.IsTrue(result.IsValid);
+    }
+
+    [TestMethod]
+    public void TypeUuidWarning_InvalidFormat_IsValidWithWarning()
+    {
+        JsonString value = new("not-a-uuid");
+        ValidationContext result = Validate.TypeUuidWarning(value, ValidationContext.ValidContext, ValidationLevel.Detailed);
+        Assert.IsTrue(result.IsValid);
+    }
+}

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/FormatAssertionModeEvaluatorTests.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/FormatAssertionModeEvaluatorTests.cs
@@ -1,0 +1,91 @@
+// Derived from code licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licensed this code under the MIT license.
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Corvus.Json.CodeGeneration;
+using Corvus.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace Corvus.Text.Json.EvaluatorTestSuite.Tests;
+
+/// <summary>
+/// Covers per-format assertion modes (assert/disable/warning) in the standalone schema
+/// evaluator generation path (<see cref="Corvus.Text.Json.CodeGeneration.CodeGenerationMode.SchemaEvaluationOnly"/>).
+/// </summary>
+[TestClass]
+public class FormatAssertionModeEvaluatorTests
+{
+    private const string DateTimeSchema =
+        """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "string",
+            "format": "date-time"
+        }
+        """;
+
+    private const string Invalid = "\"not-a-date-time\"";
+    private const string Valid = "\"2024-01-02T03:04:05Z\"";
+
+    [TestMethod]
+    public async Task Assert_InvalidValue_Fails()
+    {
+        CompiledEvaluator evaluator = await GenerateAsync(validateFormat: true, overrides: null);
+
+        StringAssert.Contains(evaluator.GeneratedCode!, "MatchDateTime");
+
+        using var invalid = ParsedJsonDocument<JsonElement>.Parse(Invalid);
+        Assert.IsFalse(evaluator.Evaluate(invalid.RootElement), "Default assert mode must reject a non-conformant value.");
+
+        using var valid = ParsedJsonDocument<JsonElement>.Parse(Valid);
+        Assert.IsTrue(evaluator.Evaluate(valid.RootElement));
+    }
+
+    [TestMethod]
+    public async Task Warning_InvalidValue_Passes()
+    {
+        CompiledEvaluator evaluator = await GenerateAsync(
+            validateFormat: true,
+            overrides: new Dictionary<string, FormatAssertionMode> { ["date-time"] = FormatAssertionMode.Warning });
+
+        // The standalone evaluator emits the warning-mode sibling.
+        StringAssert.Contains(evaluator.GeneratedCode!, "WarnDateTime");
+        Assert.IsFalse(evaluator.GeneratedCode!.Contains("MatchDateTime"), "Warning mode must replace the assertion.");
+
+        using var invalid = ParsedJsonDocument<JsonElement>.Parse(Invalid);
+        Assert.IsTrue(evaluator.Evaluate(invalid.RootElement), "Warning mode must accept a non-conformant value.");
+
+        using var valid = ParsedJsonDocument<JsonElement>.Parse(Valid);
+        Assert.IsTrue(evaluator.Evaluate(valid.RootElement));
+    }
+
+    [TestMethod]
+    public async Task Disable_InvalidValue_Passes()
+    {
+        CompiledEvaluator evaluator = await GenerateAsync(
+            validateFormat: true,
+            overrides: new Dictionary<string, FormatAssertionMode> { ["date-time"] = FormatAssertionMode.Disable });
+
+        Assert.IsFalse(evaluator.GeneratedCode!.Contains("MatchDateTime"), "Disabled format must not assert.");
+        Assert.IsFalse(evaluator.GeneratedCode!.Contains("WarnDateTime"), "Disabled format must not warn.");
+
+        using var invalid = ParsedJsonDocument<JsonElement>.Parse(Invalid);
+        Assert.IsTrue(evaluator.Evaluate(invalid.RootElement), "Disabled format must accept a non-conformant value.");
+    }
+
+    private static ValueTask<CompiledEvaluator> GenerateAsync(bool validateFormat, IReadOnlyDictionary<string, FormatAssertionMode>? overrides)
+    {
+        return TestEvaluatorHelper.GenerateEvaluatorForVirtualFileAsync(
+            "formatModeEvaluator.json",
+            DateTimeSchema,
+            "Corvus.Text.Json.EvaluatorTestSuite.Tests.FormatModeEvaluator",
+            "./someFakePath",
+            Corvus.Json.CodeGeneration.Draft202012.VocabularyAnalyser.DefaultVocabulary,
+            validateFormat,
+            overrides,
+            Assembly.GetExecutingAssembly());
+    }
+}

--- a/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
+++ b/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
@@ -200,6 +200,7 @@
     <Compile Include="JsonSchemaAdditionalTests\draft2020-12\benchmarkRepro.cs" />
     <Compile Include="JsonSchemaAdditionalTests\draft2020-12\largeNumbersOfRequiredProperties.cs" />
     <Compile Include="JsonSchemaAdditionalTests\draft2020-12\typeAndFormat.cs" />
+    <Compile Include="FormatAssertionModeTests.cs" />
     <Compile Include="JsonSchemaCodeGeneratorTests.cs" />
     <Compile Include="JsonRegexValidatorTests.cs" />
     <Compile Include="JsonSchemaContextTests.cs" />

--- a/tests/Corvus.Text.Json.Tests/FormatAssertionModeTests.cs
+++ b/tests/Corvus.Text.Json.Tests/FormatAssertionModeTests.cs
@@ -1,0 +1,168 @@
+// Derived from code licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licensed this code under the MIT license.
+
+using System.Collections.Generic;
+using System.Reflection;
+using System.Threading.Tasks;
+using Corvus.Json.CodeGeneration;
+using Corvus.Text.Json.Validator;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace Corvus.Text.Json.Tests;
+
+/// <summary>
+/// Tests for per-format assertion modes (assert/disable/warning) in V5 code generation,
+/// and for the shared <see cref="FormatAssertionModeParser"/>.
+/// </summary>
+[TestClass]
+public class FormatAssertionModeTests
+{
+    private const string DateTimeObject =
+        """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "created": { "type": "string", "format": "date-time" }
+            }
+        }
+        """;
+
+    private const string DateTimeAndUuidObject =
+        """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "created": { "type": "string", "format": "date-time" },
+                "id": { "type": "string", "format": "uuid" }
+            }
+        }
+        """;
+
+    [TestMethod]
+    public async Task DefaultMode_EmitsFormatAssertion()
+    {
+        string code = await GenerateAsync(DateTimeObject, validateFormat: true, overrides: null);
+
+        StringAssert.Contains(code, "MatchDateTime");
+        Assert.IsFalse(code.Contains("WarnDateTime"), "Default mode must not emit the warning variant.");
+    }
+
+    [TestMethod]
+    public async Task DisableOverride_EmitsIgnoredAnnotation()
+    {
+        string code = await GenerateAsync(
+            DateTimeObject,
+            validateFormat: true,
+            overrides: new Dictionary<string, FormatAssertionMode> { ["date-time"] = FormatAssertionMode.Disable });
+
+        StringAssert.Contains(code, "IgnoredFormatNotAsserted");
+        Assert.IsFalse(code.Contains("MatchDateTime"), "Disabled format must not emit an assertion.");
+        Assert.IsFalse(code.Contains("WarnDateTime"), "Disabled format must not emit the warning variant.");
+    }
+
+    [TestMethod]
+    public async Task WarningOverride_EmitsWarningVariant()
+    {
+        string code = await GenerateAsync(
+            DateTimeObject,
+            validateFormat: true,
+            overrides: new Dictionary<string, FormatAssertionMode> { ["date-time"] = FormatAssertionMode.Warning });
+
+        StringAssert.Contains(code, "WarnDateTime");
+        Assert.IsFalse(code.Contains("MatchDateTime"), "Warning mode must replace the assertion with the warning variant.");
+    }
+
+    [TestMethod]
+    public async Task WarningOverride_IsPerFormat()
+    {
+        // Only date-time is downgraded to a warning; uuid still asserts.
+        string code = await GenerateAsync(
+            DateTimeAndUuidObject,
+            validateFormat: true,
+            overrides: new Dictionary<string, FormatAssertionMode> { ["date-time"] = FormatAssertionMode.Warning });
+
+        StringAssert.Contains(code, "WarnDateTime");
+        StringAssert.Contains(code, "MatchUuid");
+        Assert.IsFalse(code.Contains("MatchDateTime"), "date-time should use the warning variant.");
+        Assert.IsFalse(code.Contains("WarnUuid"), "uuid should still assert.");
+    }
+
+    [TestMethod]
+    public async Task WarningOverride_GeneratedCodeCompiles()
+    {
+        DynamicJsonType type = await TestJsonSchemaCodeGenerator.GenerateTypeForVirtualFile(
+            "formatMode_warning_compiles.json",
+            DateTimeObject,
+            $"{MethodBase.GetCurrentMethod().DeclaringType.FullName}.{MethodBase.GetCurrentMethod().Name}",
+            "./someFakePath",
+            Corvus.Json.CodeGeneration.Draft202012.VocabularyAnalyser.DefaultVocabulary,
+            validateFormat: true,
+            formatModeOverrides: new Dictionary<string, FormatAssertionMode> { ["date-time"] = FormatAssertionMode.Warning },
+            hostAssembly: Assembly.GetExecutingAssembly());
+
+        Assert.IsNotNull(type);
+    }
+
+    [TestMethod]
+    [DataRow("assert", FormatAssertionMode.Assert)]
+    [DataRow("ASSERT", FormatAssertionMode.Assert)]
+    [DataRow("disable", FormatAssertionMode.Disable)]
+    [DataRow("Warning", FormatAssertionMode.Warning)]
+    public void Parser_TryParseMode_RecognizesModes(string text, FormatAssertionMode expected)
+    {
+        Assert.IsTrue(FormatAssertionModeParser.TryParseMode(text, out FormatAssertionMode mode));
+        Assert.AreEqual(expected, mode);
+    }
+
+    [TestMethod]
+    [DataRow("bogus")]
+    [DataRow("")]
+    [DataRow(null)]
+    public void Parser_TryParseMode_RejectsUnknown(string? text)
+    {
+        Assert.IsFalse(FormatAssertionModeParser.TryParseMode(text, out _));
+    }
+
+    [TestMethod]
+    public void Parser_ParseSpecification_ParsesCommaAndSemicolonPairs()
+    {
+        IReadOnlyDictionary<string, FormatAssertionMode> result =
+            FormatAssertionModeParser.ParseSpecification("date-time=disable,time=warning;uuid=assert", ';', ',');
+
+        Assert.AreEqual(3, result.Count);
+        Assert.AreEqual(FormatAssertionMode.Disable, result["date-time"]);
+        Assert.AreEqual(FormatAssertionMode.Warning, result["time"]);
+        Assert.AreEqual(FormatAssertionMode.Assert, result["uuid"]);
+    }
+
+    [TestMethod]
+    public void Parser_ParseSpecification_EmptyIsEmpty()
+    {
+        Assert.AreEqual(0, FormatAssertionModeParser.ParseSpecification(null, ',').Count);
+        Assert.AreEqual(0, FormatAssertionModeParser.ParseSpecification("  ", ',').Count);
+    }
+
+    [TestMethod]
+    [DataRow("date-time")]
+    [DataRow("date-time=bogus")]
+    [DataRow("=disable")]
+    public void Parser_ParseSpecification_ThrowsOnMalformed(string spec)
+    {
+        Assert.ThrowsExactly<System.FormatException>(() => FormatAssertionModeParser.ParseSpecification(spec, ','));
+    }
+
+    private static ValueTask<string> GenerateAsync(string schema, bool validateFormat, IReadOnlyDictionary<string, FormatAssertionMode>? overrides)
+    {
+        return TestJsonSchemaCodeGenerator.GenerateCodeTextForVirtualFile(
+            "formatMode_test.json",
+            schema,
+            "Corvus.Text.Json.Tests.FormatModeGenerated",
+            "./someFakePath",
+            Corvus.Json.CodeGeneration.Draft202012.VocabularyAnalyser.DefaultVocabulary,
+            validateFormat,
+            overrides);
+    }
+}


### PR DESCRIPTION
Closes #749.

## Summary

Adds per-format `format` assertion mode configuration to the code generation pipeline (both **V4** and **V5** engines), allowing consumers to selectively **disable** or **downgrade to warning** specific format assertions (e.g. `date-time`, `time`) without weakening all format validation globally. Motivated by #667 — consumers with non-conformant `date-time` data (e.g. missing timezone offset from quicktype-generated schemas) need an escape hatch.

Three modes per format:

| Mode | Behaviour |
|------|-----------|
| **assert** (default) | Current behaviour — validation fails on a non-conformant value |
| **disable** | Format keyword becomes annotation-only — no validation |
| **warning** | Validation runs but always succeeds; a mismatch records a `WARNING` annotation |

Mode selection happens at **code-generation time**, not runtime — each mode emits different static code, so the default `assert` path carries zero additional branches.

## What changed

- **Shared model** (`Corvus.Json.CodeGeneration`): `FormatAssertionMode` enum + `FormatAssertionModeParser`; per-format override map on `CSharpLanguageProvider.Options` (both engines) with `GetEffectiveFormatMode` / `GetFormatModeOverride` resolution — *per-format override > vocabulary (`IsFormatAssertion`) > global `assertFormat` > disable*.
- **V5 codegen**: three-way branch in `FormatValidationHandler` and `StandaloneEvaluatorGenerator`; 22 `WarnXxx` sibling methods in `JsonSchemaEvaluation.String.cs` (each mirrors its `MatchXxx` sibling but records a `WARNING` annotation on mismatch and returns `true`).
- **V4 codegen**: three-way at both decision points (`ValidationCodeGeneratorExtensions.Format.cs` and the extended-type path); `TypeXxxWarning` siblings in `Validate` / `ValidateWithoutCoreType`. Content formats reuse their existing leniency.
- **Numeric formats**: warning isn't meaningful for type-narrowing formats, so it falls back to `assert` with a visible generated diagnostic comment.
- **Config surfaces**:
  - CLI: `corvusjson jsonschema ... --formatMode date-time=disable,time=warning`
  - Driver JSON: `"formatMode": { "date-time": "disable", "time": "warning" }`
  - Source generator (MSBuild): `<CorvusTextJsonFormatMode>date-time=disable;time=warning</CorvusTextJsonFormatMode>` (V5) / `CorvusJsonSchemaFormatMode` (V4)
  - The existing `--assertFormat` / `CorvusTextJsonAlwaysAssertFormat` global default is unchanged; per-format overrides take precedence.

## Backwards compatibility

`--assertFormat` and `assertFormat` continue to work unchanged as the global default. `--formatMode` / `formatMode` are additive per-format overrides.

## Tests & verification

- New tests for both engines: V5 codegen-text + compile (`FormatAssertionModeTests`, 17), V5 standalone evaluator emission + runtime (`FormatAssertionModeEvaluatorTests`, 3), V4 runtime (`FormatWarningValidationTests`, 6), plus the shared parser.
- Regression suites green: V5 schema-suite `format*` 2663/2663, V5 evaluator-suite `format*` 2671/2671, V4 `Format*` 2997/2997.
- `dotnet build Corvus.Text.Json.slnx` — 0 warnings, 0 errors.
- Docs (`CodeGenerator.md`, `SourceGenerator.md`), the `corvus-codegen` skill, and the code-sample catalog updated; catalog `-Check` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)