### PR TITLE
fix: Period invalid duration strings (#805) and Freeze on parsed JsonDocumentBuilder (#808)

### DIFF
--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,8 +1,41 @@
 # Version History
 
-## V5.2.0
+## V5.1.12
 
-V5.2.0 adds an opt-in `NullOrUndefinedExceptNonNullDefaulted` value for the `OptionalAsNullable` generation option — generating optional properties that declare a non-null `default` as non-nullable `T` — and fixes a V5 bug where an explicit JSON `null` was not mapped to C# `null` under `OptionalAsNullable=NullOrUndefined`.
+V5.1.12 fixes a V5 bug where `Corvus.Text.Json.Period` could emit `duration` strings that are invalid under the JSON Schema `duration` format.
+
+### Bug fixes
+
+- **`Period` no longer emits invalid `duration` strings** — The V5 `Corvus.Text.Json.Period` formatter (used by `Period.ToString()` and when writing a period to a JSON document, including the OpenAPI server `Build` methods) could emit a fractional seconds value, for example `P0Y0M0DT0H0M6.220724100S` for a period built from a sub-second `System.TimeSpan`. The JSON Schema `duration` format (RFC 3339 Appendix A) does not permit fractional seconds, so such values failed to round-trip through `Period.TryParse`. The formatter now rounds any sub-second component (milliseconds, ticks, nanoseconds) to the nearest whole second — rounding halves away from zero — producing a valid, round-trippable duration. As part of the fix the formatter also omits unnecessary zero-valued units where the RFC 3339 grammar allows, so output is now compact (for example `PT6S` and `P7D` rather than `P0Y0M0DT0H0M6S` and `P0Y0M7D`). Consumers that compared the exact formatted string should note the more compact output. See [#805](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/805).
+
+## V5.1.11
+
+V5.1.11 adds per-format assertion mode configuration to the V4 and V5 code generation pipelines, so consumers can selectively disable a single `format` assertion or downgrade it to a warning without weakening all format validation.
+
+### New features
+
+- **Per-format assertion modes** — A new `FormatAssertionMode` (`Assert` / `Disable` / `Warning`) can be configured per format, letting you keep strict format validation while relaxing an individual format that real-world data violates (for example a `date-time` missing its timezone offset). The effective mode is resolved per format as override > vocabulary > the global `assertFormat` default > disable. Configurable via the `corvusjson` CLI `--formatMode` flag, a `formatMode` object in `generator-config.json`, the `CorvusTextJsonFormatMode` / `CorvusJsonSchemaFormatMode` MSBuild properties, and the `CSharpLanguageProvider.Options` API. `Warning` applies to string formats (a non-conformant value is reported rather than rejected); numeric formats fall back to `Assert`. Mode selection happens at generation time, so the default assert path carries no extra runtime branches. Supported by both engines. See [#749](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/749).
+
+## V5.1.10
+
+V5.1.10 extends OpenAPI server generation to extract an operation's declared `security` for OpenAPI 3.0 and 3.1 (not just 3.2), models it with correct OR/AND semantics, and adds a one-line authorization helper.
+
+### New features
+
+- **Declared security extraction and authorization helper** — Generated servers now populate each endpoint's security requirements for OpenAPI 3.0 and 3.1 (previously only 3.2 did so; 3.0/3.1 always emitted an empty array despite the spec supporting `security`). `EndpointSecurityRequirement` carries the resolved `SchemeType` (oauth2/apiKey/http/openIdConnect) and a canonical `PolicyName`, and a generated `EndpointSecurityConventions.RequireDeclaredAuthorization` extension implements the default mapping (`AllowAnonymous` when there is no security, `RequireAuthorization(PolicyName)` per requirement) so the common case is a one-line hook. The generated registration takes no dependency on `Microsoft.AspNetCore.Authorization`, and the custom `configureEndpoint` escape hatch is unchanged. See [#791](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/791).
+- **OR/AND security semantics** — `EndpointDescriptor.SecurityRequirements` is now an `IReadOnlyList<EndpointSecurityRequirementSet>`, one element per OR alternative, each exposing its AND-group of requirements, an `IsOptional` marker for the anonymous (`{}`) requirement, and a canonical `PolicyName`. `RequireDeclaredAuthorization` honours the structure (AND within an alternative; a single combined policy for multiple OR alternatives), correcting the previous behaviour that flattened the array and enforced the alternatives as if all were required. See [#791](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/791).
+
+## V5.1.9
+
+V5.1.9 emits `Build(...)` overloads on V5 object types that take the `Create(...)` property parameters directly, removing the nested builder lambda at call sites.
+
+### New features
+
+- **Property-parameter `Build(...)` overloads** — V5 object types now emit `Build(...)` / `Build<TContext>(...)` factories that capture the `Create(...)` arguments directly, so `quaternion: Quaternion.Build(w: r.W, x: r.X, y: r.Y, z: r.Z)` replaces the previous `(ref b) => b.Create(...)` lambda form. The captured arguments materialise through the existing static `Create` with no closure allocation. A type emits the overload only when it has at least one `Create` parameter, is not part of a reference cycle (keeping a `Source` from ever transitively containing itself), and its captured-slot weight is within the configured threshold (default 32); recursive or over-threshold types keep the delegate/context `Build` form with a `<remarks>` explaining the omission. The threshold is configurable via the `CSharpLanguageProvider.Options` API, the `CorvusTextJsonBuildParametersThreshold` MSBuild property, and the `corvusjson` CLI `--buildParametersThreshold` flag. See [#789](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/789).
+
+## V5.1.8
+
+V5.1.8 adds an opt-in `NullOrUndefinedExceptNonNullDefaulted` value for the `OptionalAsNullable` generation option — generating optional properties that declare a non-null `default` as non-nullable `T` — and fixes a V5 bug where an explicit JSON `null` was not mapped to C# `null` under `OptionalAsNullable=NullOrUndefined`.
 
 ### New features
 
@@ -20,13 +53,20 @@ V5.1.7 adds an optional per-endpoint configuration callback to the generated Ope
 
 - **Per-endpoint configuration callback for generated servers** — The generated `MapApiEndpoints` extension gains an additive overload that accepts a `ConfigureEndpoint` callback. It is invoked once per generated endpoint (including webhook/callback endpoints) with an `EndpointDescriptor` (operation id, generated method name, HTTP verb, route template, tags, callback origin, and the operation's security requirements) and the route's `IEndpointConventionBuilder`. This lets consumers apply per-endpoint conventions — authorization, naming, tags, output caching, rate limiting — and wire the OpenAPI security specification onto endpoints without editing generated code. The original overload is preserved, so the change is source- and binary-compatible. Implemented for OpenAPI 3.0/3.1/3.2 across both the regular and callback/webhook server paths, with no new package dependency on the generated server. See [#783](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/783).
 
-## V5.1.2
+## V5.1.5
 
-V5.1.2 is a breaking change that moves generated JSON Schema model types into a `.Models` sub-namespace for OpenAPI and AsyncAPI code generation, preventing name collisions with request/response infrastructure types.
+V5.1.5 adds context-flowing source overloads to generated V5 mutable builders.
+
+### New features
+
+- **Context source builder overloads** — Generated V5 mutable object and array builders now expose `AddProperty<TContext>(propertyName, in PropertyType.Source<TContext> value)` and `AddItem<TContext>(in ItemType.Source<TContext> value)` overloads (for the `ReadOnlySpan<byte>`, `ReadOnlySpan<char>`, and `string` property-name forms, with `where TContext : allows ref struct` on .NET 9 and later). This lets a context-bearing `.Source<TContext>` value be added directly to a builder without first materialising it. See [#780](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/780).
+
+## V5.1.4
+
+V5.1.4 changes generated OpenAPI server result factories to take `.Source` types for response headers, deprecates `ParseValue()`, adds `JsonWorkspace.TakeOwnership()`, and fixes webhook schema pointer resolution.
 
 ### Breaking changes
 
-- **OpenAPI/AsyncAPI model types now in `.Models` sub-namespace** — JSON Schema model types generated by `corvusjson openapi-client`, `openapi-server`, `openapi-callback-client`, `openapi-callback-server`, and `asyncapi-generate` are now placed in a `.Models` sub-namespace (e.g., `Petstore.Client.Models` instead of `Petstore.Client`). Consumer code must add a `using` directive for the new namespace (e.g., `using Petstore.Client.Models;`). Request/response infrastructure types (producers, consumers, handler interfaces, request/response classes) remain in the root namespace.
 - **Server result factory methods use `.Source` for response headers** — Generated server result factory methods (e.g., `ListPetsResult.Ok(...)`) now accept `.Source` types for response header parameters instead of realized types. For example, a header parameter changes from `JsonString xNext = default` to `JsonString.Source xNext = default`. Existing code that passes realized types (e.g., `JsonString.ParseValue(...)`) continues to compile via implicit conversion. Factories with headers but no body now also require a `JsonWorkspace workspace` parameter.
 - **`ParseValue()` deprecated** — All `ParseValue()` overloads on `JsonElement` and generated types are now marked `[Obsolete]`. Use `ParsedJsonDocument<T>.Parse()` for pooled-memory parsing (returns a disposable document that recycles memory), or `Clone()` when you genuinely need a standalone copy. `ParseValue()` allocates backing memory that becomes GC garbage — the deprecation makes the performance tradeoff explicit. See [#772](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/772).
 
@@ -37,6 +77,14 @@ V5.1.2 is a breaking change that moves generated JSON Schema model types into a 
 ### Bug fixes
 
 - **Webhook schema pointer resolution** — `openapi-callback-server` previously constructed JSON pointers using `#/paths/{name}` instead of `#/webhooks/{name}` when processing webhook schemas, causing resolution failures. `SchemaPointerBuilder` full-pointer methods now accept a `rootSegmentUtf8` parameter to correctly distinguish between paths and webhooks. See [#773](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/773).
+
+## V5.1.2
+
+V5.1.2 is a breaking change that moves generated JSON Schema model types into a `.Models` sub-namespace for OpenAPI and AsyncAPI code generation, preventing name collisions with request/response infrastructure types.
+
+### Breaking changes
+
+- **OpenAPI/AsyncAPI model types now in `.Models` sub-namespace** — JSON Schema model types generated by `corvusjson openapi-client`, `openapi-server`, `openapi-callback-client`, `openapi-callback-server`, and `asyncapi-generate` are now placed in a `.Models` sub-namespace (e.g., `Petstore.Client.Models` instead of `Petstore.Client`). Consumer code must add a `using` directive for the new namespace (e.g., `using Petstore.Client.Models;`). Request/response infrastructure types (producers, consumers, handler interfaces, request/response classes) remain in the root namespace.
 
 ## V5.1.1
 

--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -2,11 +2,12 @@
 
 ## V5.1.12
 
-V5.1.12 fixes a V5 bug where `Corvus.Text.Json.Period` could emit `duration` strings that are invalid under the JSON Schema `duration` format.
+V5.1.12 fixes two V5 bugs: `Corvus.Text.Json.Period` could emit `duration` strings that are invalid under the JSON Schema `duration` format, and calling `Freeze()` on a `JsonDocumentBuilder` created via `Parse` threw an exception.
 
 ### Bug fixes
 
 - **`Period` no longer emits invalid `duration` strings** — The V5 `Corvus.Text.Json.Period` formatter (used by `Period.ToString()` and when writing a period to a JSON document, including the OpenAPI server `Build` methods) could emit a fractional seconds value, for example `P0Y0M0DT0H0M6.220724100S` for a period built from a sub-second `System.TimeSpan`. The JSON Schema `duration` format (RFC 3339 Appendix A) does not permit fractional seconds, so such values failed to round-trip through `Period.TryParse`. The formatter now rounds any sub-second component (milliseconds, ticks, nanoseconds) to the nearest whole second — rounding halves away from zero — producing a valid, round-trippable duration. As part of the fix the formatter also omits unnecessary zero-valued units where the RFC 3339 grammar allows, so output is now compact (for example `PT6S` and `P7D` rather than `P0Y0M0DT0H0M6S` and `P0Y0M7D`). Consumers that compared the exact formatted string should note the more compact output. See [#805](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/805).
+- **`Freeze()` on a parsed `JsonDocumentBuilder` no longer throws** — Calling `Freeze()` on a document produced by `JsonDocumentBuilder<T>.Parse(...)` threw `ArgumentException` (`Offset and length were out of bounds`) from `Buffer.BlockCopy`. The freeze copy assumed every value was stored as a length-prefixed *DynamicValue* blob, but values from a parsed document point directly into the original UTF-8 JSON backing region with no such header, so the copy read a bogus length. Freezing now compacts the value backing into a raw-JSON region and a DynamicValue region and propagates the raw-region length to the frozen document, so parsed, mutated, and from-scratch documents all freeze correctly. See [#808](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/808).
 
 ## V5.1.11
 

--- a/src/Corvus.Text.Json/Corvus/NodaTimeExtensions/Period.cs
+++ b/src/Corvus.Text.Json/Corvus/NodaTimeExtensions/Period.cs
@@ -683,12 +683,93 @@ public readonly struct Period : IEquatable<Period>
     }
 
     /// <summary>
+    /// Returns a normalized copy of this period with any sub-second component (milliseconds,
+    /// ticks and nanoseconds) rounded to the nearest whole second.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The RFC 3339 Appendix A <c>duration</c> grammar used by the JSON Schema <c>duration</c>
+    /// format only permits integer values for each unit, and seconds is the smallest unit it
+    /// defines - fractional seconds are not allowed. A <see cref="Period"/>, however, can carry
+    /// sub-second precision (for example when it is built from a .NET <see cref="System.TimeSpan"/>
+    /// via <see cref="FromTicks"/>). Such precision cannot be represented in a valid duration
+    /// string, so the formatting performed by <see cref="ToString"/> rounds the sub-second portion
+    /// to the nearest second, with halves rounded away from zero.
+    /// </para>
+    /// <para>
+    /// For example, a period of 6.2207241 seconds is rounded to 6 seconds, and a period of
+    /// 6.6 seconds is rounded to 7 seconds. The rounding is applied to the normalized value, so a
+    /// carry (such as 59.6 seconds rounding up to a full minute) is propagated through the higher
+    /// units.
+    /// </para>
+    /// </remarks>
+    /// <returns>The period rounded to whole seconds.</returns>
+    [Pure]
+    internal Period RoundedToWholeSeconds()
+    {
+        Period normalized = this.Normalize();
+
+        // After normalization "ticks" is always zero, but include it for completeness.
+        long subSecondNanoseconds =
+            (normalized.Milliseconds * NanosecondsPerMillisecond) +
+            (normalized.Ticks * NanosecondsPerTick) +
+            normalized.Nanoseconds;
+
+        if (subSecondNanoseconds == 0)
+        {
+            return normalized;
+        }
+
+        // Round halves away from zero. Normalization guarantees every "standard" property shares the
+        // same sign, so a positive period has a positive remainder and a negative period a negative one.
+        long roundingSeconds =
+            subSecondNanoseconds >= NanosecondsPerSecond / 2 ? 1 :
+            subSecondNanoseconds <= -(NanosecondsPerSecond / 2) ? -1 :
+            0;
+
+        // Rebuild without the sub-second component and re-normalize so that any carry produced by the
+        // rounding (e.g. 59 seconds + 1 -> +1 minute) is propagated through the higher units.
+        return new Period(
+            normalized.Years,
+            normalized.Months,
+            0 /* weeks */,
+            normalized.Days,
+            normalized.Hours,
+            normalized.Minutes,
+            normalized.Seconds + roundingSeconds,
+            0 /* milliseconds */,
+            0 /* ticks */,
+            0 /* nanoseconds */).Normalize();
+    }
+
+    /// <summary>
     /// Returns this string formatted according to the ISO8601 duration specification used by JSON schema.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The result is a valid RFC 3339 Appendix A <c>duration</c> (the grammar used by the JSON Schema
+    /// <c>duration</c> format), and is produced by the same formatter used when writing a period to a
+    /// JSON document, so it always round-trips back through <see cref="TryParse"/>.
+    /// </para>
+    /// <para>
+    /// That grammar does not permit fractional seconds, so any sub-second component is rounded to the
+    /// nearest whole second before formatting (rounding halves away from zero). Zero-valued
+    /// units are omitted where the grammar allows, so for example a one-day, two-hour period is
+    /// formatted as <c>P1DT2H</c> rather than <c>P0Y0M1DT2H0M0S</c>.
+    /// </para>
+    /// </remarks>
     /// <returns>A formatted representation of this period.</returns>
     public override string ToString()
     {
-        return NodaTime.Text.PeriodPattern.NormalizingIso.Format(this);
+        Span<byte> buffer = stackalloc byte[JsonConstants.MaximumFormatPeriodLength];
+        if (Internal.JsonElementHelpers.TryFormatPeriod(this, buffer, out int bytesWritten))
+        {
+            return JsonHelpers.Utf8GetString(buffer[..bytesWritten]);
+        }
+
+        // The buffer is sized to the maximum possible formatted length, so this is unreachable for any
+        // representable period; fall back to the NodaTime formatter (which also rounds sub-seconds away).
+        return NodaTime.Text.PeriodPattern.NormalizingIso.Format(this.RoundedToWholeSeconds());
     }
 
     /// <summary>

--- a/src/Corvus.Text.Json/Corvus/Text/Json/Document/Internal/JsonDocument.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/Document/Internal/JsonDocument.cs
@@ -1962,52 +1962,108 @@ public abstract partial class JsonDocument
 
     /// <summary>
     /// Copies the metadb segment and only the referenced value backing from this document
-    /// into a target document for a freeze operation. Uses a single forward pass to copy
-    /// each local value row's backing data and adjust its offset.
+    /// into a target document for a freeze operation, compacting the value backing into a
+    /// raw-JSON region followed by a DynamicValue region.
     /// </summary>
     /// <param name="target">The target document to initialize.</param>
     /// <param name="index">The starting metadb byte index of the element to freeze.</param>
     /// <param name="byteSize">The byte size of the metadb segment.</param>
-    internal void CopyFreezeState(JsonDocument target, int index, int byteSize)
+    /// <param name="rawJsonLength">The length of this document's raw-JSON backing region;
+    /// value rows whose location is below this point into the original parsed JSON and carry
+    /// no DynamicValue header (the same <c>location &lt; rawJsonLength</c> convention used by
+    /// the value readers).</param>
+    /// <returns>The length of the raw-JSON region written to the target's value backing. The
+    /// caller must assign this to the target's raw-JSON length so the frozen document reads
+    /// raw and dynamic values back with the same discriminator.</returns>
+    internal int CopyFreezeState(JsonDocument target, int index, int byteSize, int rawJsonLength)
     {
         target._parsedData = _parsedData.CopySegmentRaw(index, index + byteSize);
 
         if (_valueBacking == null || _valueOffset <= 0)
         {
-            return;
+            return 0;
         }
 
-        // Single forward pass: for each local String/Number/PropertyName row,
-        // copy its backing bytes and rewrite its offset.
-        byte[]? targetBacking = null;
-        int writeOffset = 0;
+        // The value backing is compacted into two regions, each holding only the referenced
+        // values for this segment:
+        //  - Raw-JSON values (location < rawJsonLength) carry no header. Strings and property
+        //    names are copied with their surrounding quotes (location points one past the
+        //    opening quote); numbers are copied verbatim. These occupy [0..rawRegionLength).
+        //  - DynamicValue blobs ([4-byte header: length << 4 | type][data]) keep their layout
+        //    and follow the raw region.
+        // The caller sets the target's raw-JSON length to rawRegionLength, so the frozen
+        // document resolves each row to the correct region via the same location comparison.
 
+        // Pass 1: size each region so they can be laid out contiguously in one buffer.
+        int rawRegionLength = 0;
+        int dynamicRegionLength = 0;
         for (int i = 0; i < byteSize; i += DbRow.Size)
         {
             DbRow row = target._parsedData.Get(i);
-            if (!row.FromExternalDocument && row.TokenType is JsonTokenType.String or JsonTokenType.Number or JsonTokenType.PropertyName)
+            if (row.FromExternalDocument || row.TokenType is not (JsonTokenType.String or JsonTokenType.Number or JsonTokenType.PropertyName))
             {
-                int loc = row.LocationOrIndex;
+                continue;
+            }
 
-                // Read the stored size from the 4-byte header in _valueBacking.
-                // Format: [4-byte header: length<<4 | type][value data of 'length' bytes]
+            int loc = row.LocationOrIndex;
+            if (loc < rawJsonLength)
+            {
+                bool quoted = row.TokenType is JsonTokenType.String or JsonTokenType.PropertyName;
+                rawRegionLength += row.SizeOrLengthOrPropertyMapIndex + (quoted ? 2 : 0);
+            }
+            else
+            {
                 uint header = BitConverter.ToUInt32(_valueBacking, loc);
-                int storedSize = 4 + (int)(header >> 4);
-
-                targetBacking ??= ArrayPool<byte>.Shared.Rent(_valueOffset);
-
-                Buffer.BlockCopy(_valueBacking, loc, targetBacking, writeOffset, storedSize);
-                target._parsedData.SetRowLocation(i, writeOffset);
-
-                writeOffset += storedSize;
+                dynamicRegionLength += 4 + (int)(header >> 4);
             }
         }
 
-        if (targetBacking != null)
+        if (rawRegionLength == 0 && dynamicRegionLength == 0)
         {
-            target._valueBacking = targetBacking;
-            target._valueOffset = writeOffset;
+            return 0;
         }
+
+        byte[] targetBacking = ArrayPool<byte>.Shared.Rent(rawRegionLength + dynamicRegionLength);
+        int rawWrite = 0;
+        int dynamicWrite = rawRegionLength;
+
+        // Pass 2: copy each value into its region and rewrite the row's location.
+        for (int i = 0; i < byteSize; i += DbRow.Size)
+        {
+            DbRow row = target._parsedData.Get(i);
+            if (row.FromExternalDocument || row.TokenType is not (JsonTokenType.String or JsonTokenType.Number or JsonTokenType.PropertyName))
+            {
+                continue;
+            }
+
+            int loc = row.LocationOrIndex;
+            if (loc < rawJsonLength)
+            {
+                bool quoted = row.TokenType is JsonTokenType.String or JsonTokenType.PropertyName;
+                int sourceStart = quoted ? loc - 1 : loc;
+                int copyLength = row.SizeOrLengthOrPropertyMapIndex + (quoted ? 2 : 0);
+
+                Buffer.BlockCopy(_valueBacking, sourceStart, targetBacking, rawWrite, copyLength);
+
+                // Preserve the convention: location points one past the opening quote for
+                // quoted tokens, or at the value start for numbers.
+                target._parsedData.SetRowLocation(i, quoted ? rawWrite + 1 : rawWrite);
+                rawWrite += copyLength;
+            }
+            else
+            {
+                uint header = BitConverter.ToUInt32(_valueBacking, loc);
+                int storedSize = 4 + (int)(header >> 4);
+
+                Buffer.BlockCopy(_valueBacking, loc, targetBacking, dynamicWrite, storedSize);
+                target._parsedData.SetRowLocation(i, dynamicWrite);
+                dynamicWrite += storedSize;
+            }
+        }
+
+        target._valueBacking = targetBacking;
+        target._valueOffset = dynamicWrite;
+        return rawRegionLength;
     }
 
     /// <summary>

--- a/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/JsonDocumentBuilder.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/JsonDocumentBuilder.cs
@@ -2130,7 +2130,13 @@ public sealed partial class JsonDocumentBuilder<T> : JsonDocument, IMutableJsonD
     internal void InitializeFrozen(JsonDocument source, int index, int byteSize, int parentWorkspaceIndex)
     {
         _parentWorkspaceIndex = parentWorkspaceIndex;
-        source.CopyFreezeState(this, index, byteSize);
+
+        // A source created via Parse keeps its values in a raw-JSON backing region; rows there
+        // carry no DynamicValue header. CopyFreezeState compacts those into a raw region and
+        // returns its length, which becomes this frozen builder's raw-JSON length so the same
+        // location-based discriminator keeps resolving them after the freeze.
+        int sourceRawJsonLength = source is JsonDocumentBuilder<T> sourceBuilder ? sourceBuilder._rawJsonLength : 0;
+        _rawJsonLength = source.CopyFreezeState(this, index, byteSize, sourceRawJsonLength);
         _isImmutable = true;
     }
 

--- a/src/Corvus.Text.Json/Corvus/Text/Json/Internal/JsonElementHelpers.DateTime.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/Internal/JsonElementHelpers.DateTime.cs
@@ -78,6 +78,11 @@ public static partial class JsonElementHelpers
     /// <param name="output">The output buffer.</param>
     /// <param name="bytesWritten">The number of bytes written to the output buffer.</param>
     /// <returns><see langword="true"/> if the period was formatted successfully.</returns>
+    /// <remarks>
+    /// The JSON Schema <c>duration</c> format (RFC 3339 Appendix A) does not permit fractional
+    /// seconds, so any sub-second component of <paramref name="value"/> is rounded to the nearest
+    /// whole second before formatting (rounding halves away from zero).
+    /// </remarks>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool TryFormatPeriod(in Period value, Span<byte> output, out int bytesWritten)
     {
@@ -620,13 +625,15 @@ public static partial class JsonElementHelpers
         return true;
     }
 
-    // Roundtrippable format. One of
-    // 012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
-    // ------------------------------------------------------------------------------------------
-    // P2147483647Y2147483647M2147483647W2147483647DT2147483647H2147483647M-2147483647.123456789S
+    // Round-trippable RFC 3339 Appendix A duration. The grammar permits only integer values for each
+    // unit, and seconds is the smallest unit (no fractional seconds), so any sub-second component is
+    // rounded to the nearest whole second by RoundedToWholeSeconds before formatting. One of:
+    // 01234567890123456789012345678901234567890123456789012345678901234567890123456789
+    // --------------------------------------------------------------------------------
+    // P2147483647Y2147483647M2147483647W2147483647DT2147483647H2147483647M-2147483647S
     // P2147483647Y2147483647M2147483647W2147483647D
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static unsafe bool TryFormat(in Period incomingPeriod, Span<byte> destination, out int bytesWritten)
+    private static bool TryFormat(in Period incomingPeriod, Span<byte> destination, out int bytesWritten)
     {
         const int bytesRequired = JsonConstants.MaximumFormatPeriodLength;
 
@@ -636,7 +643,7 @@ public static partial class JsonElementHelpers
             return false;
         }
 
-        Period period = incomingPeriod.Normalize();
+        Period period = incomingPeriod.RoundedToWholeSeconds();
 
         if (period.Equals(Period.Zero))
         {
@@ -646,106 +653,87 @@ public static partial class JsonElementHelpers
         }
 
         int index = 0;
-        int localWritten;
 
         destination[index++] = (byte)'P';
 
-        if (period.Weeks == 0)
-        {
-            if (!Utf8Formatter.TryFormat(period.Years, destination.Slice(index), out localWritten))
-            {
-                bytesWritten = 0;
-                return false;
-            }
+        // After RoundedToWholeSeconds the period is normalized: weeks and ticks are zero and the
+        // sub-second component has been folded into seconds, so the period reduces to Y/M/D and H/M/S.
+        // RFC 3339 Appendix A allows zero-valued units to be omitted, but the grammar is contiguous:
+        //   dur-year = Y [dur-month], dur-month = M [dur-day]      (a Day after a Year needs the Month)
+        //   dur-hour = H [dur-minute], dur-minute = M [dur-second] (a Second after an Hour needs the Minute)
+        // so a zero "bridge" unit is retained when omitting it would create an invalid gap.
+        bool hasYears = period.Years != 0;
+        bool hasDays = period.Days != 0;
 
-            index += localWritten;
-            destination[index++] = (byte)'Y';
-
-            if (!Utf8Formatter.TryFormat(period.Months, destination.Slice(index), out localWritten))
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            index += localWritten;
-            destination[index++] = (byte)'M';
-        }
-
-        if (period.Weeks != 0)
-        {
-            if (!Utf8Formatter.TryFormat(period.Weeks, destination.Slice(index), out localWritten))
-            {
-                bytesWritten = 0;
-                return false;
-            }
-
-            index += localWritten;
-            destination[index++] = (byte)'W';
-        }
-
-        if (!Utf8Formatter.TryFormat(period.Days, destination.Slice(index), out localWritten))
+        if (hasYears && !TryAppendUnit(period.Years, (byte)'Y', destination, ref index))
         {
             bytesWritten = 0;
             return false;
         }
 
-        index += localWritten;
-        destination[index++] = (byte)'D';
+        // Emit months when non-zero, or as the bridge between years and days.
+        if ((period.Months != 0 || (hasYears && hasDays)) && !TryAppendUnit(period.Months, (byte)'M', destination, ref index))
+        {
+            bytesWritten = 0;
+            return false;
+        }
+
+        if (hasDays && !TryAppendUnit(period.Days, (byte)'D', destination, ref index))
+        {
+            bytesWritten = 0;
+            return false;
+        }
 
         if (period.HasTimeComponent)
         {
             destination[index++] = (byte)'T';
-            if (!Utf8Formatter.TryFormat(period.Hours, destination.Slice(index), out localWritten))
+
+            bool hasHours = period.Hours != 0;
+
+            // The sub-second component has been rounded into seconds, so seconds is the smallest unit.
+            bool hasSeconds = period.Seconds != 0;
+
+            if (hasHours && !TryAppendUnit(period.Hours, (byte)'H', destination, ref index))
             {
                 bytesWritten = 0;
                 return false;
             }
 
-            index += localWritten;
-            destination[index++] = (byte)'H';
-            if (!Utf8Formatter.TryFormat(period.Minutes, destination.Slice(index), out localWritten))
+            // Emit minutes when non-zero, or as the bridge between hours and seconds.
+            if ((period.Minutes != 0 || (hasHours && hasSeconds)) && !TryAppendUnit(period.Minutes, (byte)'M', destination, ref index))
             {
                 bytesWritten = 0;
                 return false;
             }
 
-            index += localWritten;
-            destination[index++] = (byte)'M';
-            long fractional = period.Milliseconds * 1000000 + period.Ticks * 100 + period.Nanoseconds;
-            long integral = period.Seconds;
-            if (fractional != 0L || integral != 0L)
+            if (hasSeconds && !TryAppendUnit(period.Seconds, (byte)'S', destination, ref index))
             {
-                if (fractional < 0 || integral < 0)
-                {
-                    destination[index++] = (byte)'-';
-                    fractional = -fractional;
-                    integral = -integral;
-                }
-
-                if (!Utf8Formatter.TryFormat(integral, destination.Slice(index), out localWritten))
-                {
-                    bytesWritten = 0;
-                    return false;
-                }
-
-                index += localWritten;
-
-                if (fractional != 0L)
-                {
-                    destination[index++] = (byte)'.';
-                    fixed (byte* dest = &MemoryMarshal.GetReference(destination))
-                    {
-                        Number.WriteDigits((uint)fractional, dest + index, 9);
-                    }
-
-                    index += 9;
-                }
-
-                destination[index++] = (byte)'S';
+                bytesWritten = 0;
+                return false;
             }
         }
 
         bytesWritten = index;
+        return true;
+    }
+
+    /// <summary>
+    /// Appends a single duration unit (an integer value followed by its designator) to the destination.
+    /// </summary>
+    /// <param name="value">The integer value of the unit. Negative values are formatted with a leading '-'.</param>
+    /// <param name="designator">The RFC 3339 designator byte for the unit (for example <c>(byte)'S'</c>).</param>
+    /// <param name="destination">The output buffer.</param>
+    /// <param name="index">The current write position, advanced past the bytes written.</param>
+    /// <returns><see langword="true"/> if the unit was written successfully.</returns>
+    private static bool TryAppendUnit(long value, byte designator, Span<byte> destination, ref int index)
+    {
+        if (!Utf8Formatter.TryFormat(value, destination.Slice(index), out int localWritten))
+        {
+            return false;
+        }
+
+        index += localWritten;
+        destination[index++] = designator;
         return true;
     }
 }

--- a/src/Corvus.Text.Json/Corvus/Text/Json/JsonConstants.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/JsonConstants.cs
@@ -191,7 +191,7 @@ internal static partial class JsonConstants
     public const int MaximumFormatDateLength = 10;    // StandardFormat 'O', e.g. 2017-06-12
     public const int MaximumFormatOffsetDateLength = 16;    // StandardFormat 'O', e.g. 2017-06-12-07:00
     public const int MaximumFormatOffsetTimeLength = 22;    // StandardFormat 'O', e.g. 05:30:45.7680000-07:00
-    public const int MaximumFormatPeriodLength = ((MaximumFormatUInt32Length + 1) * 7) + 13;    // StandardFormat e.g. P2147483647Y2147483647M2147483647W2147483647DT2147483647H2147483647M-2147483647.123456789S
+    public const int MaximumFormatPeriodLength = ((MaximumFormatUInt32Length + 1) * 7) + 13;    // StandardFormat e.g. P2147483647Y2147483647M2147483647W2147483647DT2147483647H2147483647M-2147483647S (RFC 3339 durations have no fractional seconds)
     public const int MaximumFormatDateTimeOffsetLength = 33;  // StandardFormat 'O', e.g. 2017-06-12T05:30:45.7680000-07:00
     public const int MaxDateTimeUtcOffsetHours = 14; // The UTC offset portion of a TimeSpan or DateTime can be no more than 14 hours and no less than -14 hours.
     public const int DateTimeNumFractionDigits = 7;  // TimeSpan and DateTime formats allow exactly up to many digits for specifying the fraction after the seconds.

--- a/tests/Corvus.Text.Json.Tests/ComplexValueBuilderCoverageTests.cs
+++ b/tests/Corvus.Text.Json.Tests/ComplexValueBuilderCoverageTests.cs
@@ -610,7 +610,7 @@ public class ComplexValueBuilderCoverageTests
         ((IMutableJsonDocument)documentBuilder).SetAndDispose(ref cvb);
         string json = documentBuilder.RootElement.ToString();
 
-        Assert.AreEqual("""{"p":"P0Y0M7D"}""", json);
+        Assert.AreEqual("""{"p":"P7D"}""", json);
     }
 
     [TestMethod]

--- a/tests/Corvus.Text.Json.Tests/DateTimeCoverageTests.cs
+++ b/tests/Corvus.Text.Json.Tests/DateTimeCoverageTests.cs
@@ -123,7 +123,7 @@ public class DateTimeCoverageTests
 
     #endregion
 
-    #region Period with time components (seconds and fractional)
+    #region Period with time components (seconds and sub-second rounding)
 
     [TestMethod]
     public void TryFormatPeriod_WithSeconds_RoundTrips()
@@ -149,15 +149,16 @@ public class DateTimeCoverageTests
     }
 
     [TestMethod]
-    public void TryFormatPeriod_WithMilliseconds_FormatsSuccessfully()
+    public void TryFormatPeriod_WithMilliseconds_RoundsToWholeSeconds()
     {
-        // Exercises the fractional != 0 path in TryFormat(Period, ...)
+        // RFC 3339 durations have no sub-second precision, so the milliseconds are rounded to the
+        // nearest second (123ms rounds down). The output must be a valid, fraction-free duration.
         Period period = Period.FromSeconds(5) + Period.FromMilliseconds(123);
         Span<byte> buffer = stackalloc byte[90];
         Assert.IsTrue(JsonElementHelpers.TryFormatPeriod(period, buffer, out int bytesWritten));
         string result = JsonReaderHelper.TranscodeHelper(buffer.Slice(0, bytesWritten));
-        StringAssert.Contains(result, ".");
-        StringAssert.Contains(result, "S");
+        Assert.AreEqual("PT5S", result);
+        Assert.IsFalse(result.Contains("."), $"Formatted duration '{result}' must not contain a fraction.");
     }
 
     #endregion

--- a/tests/Corvus.Text.Json.Tests/JsonElement.MutableFreezeTests.cs
+++ b/tests/Corvus.Text.Json.Tests/JsonElement.MutableFreezeTests.cs
@@ -437,6 +437,79 @@ public class JsonElementMutableFreezeTests
         Assert.AreEqual(cloned.GetRawText(), frozen.GetRawText());
     }
 
+    [TestMethod]
+    public void FreezeRootOfParsedBuilder_RoundTrips()
+    {
+        // Regression for #808: freezing a JsonDocumentBuilder created via Parse threw
+        // ArgumentException from Buffer.BlockCopy in CopyFreezeState, because parsed values
+        // live in the raw-JSON backing region and carry no DynamicValue header.
+        const string json = """{ "test": "test" }""";
+
+        using JsonWorkspace ws = JsonWorkspace.Create();
+        using JsonDocumentBuilder<JsonElement.Mutable> builder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(ws, json.AsMemory());
+
+        JsonElement frozen = builder.RootElement.Freeze();
+
+        Assert.AreEqual(JsonValueKind.Object, frozen.ValueKind);
+        Assert.AreEqual("test", frozen.GetProperty("test").GetString());
+        Assert.AreEqual("""{"test":"test"}""", frozen.GetRawText());
+    }
+
+    [TestMethod]
+    [DataRow("""{"a":1,"b":[true,null,"x",2.5],"c":{"d":-3}}""")]
+    [DataRow("""{"unicode":"héllo","escaped":"a\"b\nc"}""")]
+    [DataRow("""[1,"two",3.0,{"k":"v"},[]]""")]
+    [DataRow("\"just a string\"")]
+    [DataRow("12345")]
+    public void FreezeRootOfParsedBuilder_PreservesAllValueKinds(string json)
+    {
+        using JsonWorkspace ws = JsonWorkspace.Create();
+        using JsonDocumentBuilder<JsonElement.Mutable> builder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(ws, json.AsMemory());
+
+        JsonElement cloned = builder.RootElement.Clone();
+        JsonElement frozen = builder.RootElement.Freeze();
+
+        Assert.AreEqual(cloned.GetRawText(), frozen.GetRawText());
+    }
+
+    [TestMethod]
+    public void FreezeParsedBuilderAfterMutation_PreservesRawAndDynamicValues()
+    {
+        // Exercises the two-region (raw + DynamicValue) compaction: "a" is a raw-JSON value,
+        // "b" is added through the builder and stored as a DynamicValue.
+        using JsonWorkspace ws = JsonWorkspace.Create();
+        using JsonDocumentBuilder<JsonElement.Mutable> builder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(ws, """{"a":"raw"}""".AsMemory());
+
+        builder.RootElement.SetProperty("b"u8, "dynamic");
+
+        JsonElement cloned = builder.RootElement.Clone();
+        JsonElement frozen = builder.RootElement.Freeze();
+
+        Assert.AreEqual(cloned.GetRawText(), frozen.GetRawText());
+        Assert.AreEqual("raw", frozen.GetProperty("a").GetString());
+        Assert.AreEqual("dynamic", frozen.GetProperty("b").GetString());
+    }
+
+    [TestMethod]
+    public void FreezeInnerElementOfParsedBuilder_RoundTrips()
+    {
+        // Freezing a sub-element compacts only that segment's referenced values.
+        using JsonWorkspace ws = JsonWorkspace.Create();
+        using JsonDocumentBuilder<JsonElement.Mutable> builder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(ws, """{"keep":{"n":42,"s":"deep"},"other":[1,2,3]}""".AsMemory());
+
+        JsonElement.Mutable target = builder.RootElement.GetProperty("keep");
+        JsonElement cloned = target.Clone();
+        JsonElement frozen = target.Freeze();
+
+        Assert.AreEqual(cloned.GetRawText(), frozen.GetRawText());
+        Assert.AreEqual(42, frozen.GetProperty("n").GetInt32());
+        Assert.AreEqual("deep", frozen.GetProperty("s").GetString());
+    }
+
     private static IJsonDocument SniffParentDocument<TElement>(TElement element)
         where TElement : struct, IJsonElement<TElement>
     {

--- a/tests/Corvus.Text.Json.Tests/JsonElementSourceCoverageTests.cs
+++ b/tests/Corvus.Text.Json.Tests/JsonElementSourceCoverageTests.cs
@@ -556,7 +556,7 @@ public class JsonElementSourceCoverageTests
         Assert.AreEqual(Offset.FromHours(2), parsedOffsetDateTime.Offset);
         
         Assert.IsTrue(doc.RootElement.TryGetProperty("period"u8, out JsonElement.Mutable periodProp));
-        Assert.AreEqual("P1Y2M0D", periodProp.GetString());
+        Assert.AreEqual("P1Y2M", periodProp.GetString());
     }
 
     [TestMethod]
@@ -701,7 +701,7 @@ public class JsonElementSourceCoverageTests
         Assert.AreEqual(Offset.FromHours(2), parsedOffsetDateTime.Offset);
         
         Assert.IsTrue(doc.RootElement.TryGetProperty("period", out JsonElement.Mutable periodProp));
-        Assert.AreEqual("P1Y2M0D", periodProp.GetString());
+        Assert.AreEqual("P1Y2M", periodProp.GetString());
     }
 
     [TestMethod]
@@ -845,6 +845,6 @@ public class JsonElementSourceCoverageTests
         Assert.AreEqual(Offset.FromHours(2), parsedOffsetDateTime.Offset);
         
         Assert.IsTrue(doc.RootElement.TryGetProperty("period", out JsonElement.Mutable periodProp));
-        Assert.AreEqual("P1Y2M0D", periodProp.GetString());
+        Assert.AreEqual("P1Y2M", periodProp.GetString());
     }
 }

--- a/tests/Corvus.Text.Json.Tests/PeriodTests.cs
+++ b/tests/Corvus.Text.Json.Tests/PeriodTests.cs
@@ -290,6 +290,104 @@ public class PeriodTest
     }
 
     [TestMethod]
+    public void ToString_SubSecondRoundsDown()
+    {
+        // 6.2207241 seconds (the value from issue #805). RFC 3339 durations have no fractional
+        // seconds, so the sub-second component rounds down to 6 whole seconds.
+        Json.Period period = new Corvus.Text.Json.PeriodBuilder { Seconds = 6, Milliseconds = 220, Nanoseconds = 724100 }.BuildPeriod();
+        Assert.AreEqual("PT6S", period.ToString());
+    }
+
+    [TestMethod]
+    public void ToString_SubSecondRoundsUp()
+    {
+        // 6.6 seconds rounds up to 7 whole seconds.
+        Json.Period period = new Corvus.Text.Json.PeriodBuilder { Seconds = 6, Milliseconds = 600 }.BuildPeriod();
+        Assert.AreEqual("PT7S", period.ToString());
+    }
+
+    [TestMethod]
+    public void ToString_SubSecondRoundsHalfAwayFromZero()
+    {
+        // Exactly half a second rounds away from zero (up to 1 second).
+        Json.Period period = new Corvus.Text.Json.PeriodBuilder { Milliseconds = 500 }.BuildPeriod();
+        Assert.AreEqual("PT1S", period.ToString());
+    }
+
+    [TestMethod]
+    public void ToString_SubSecondRoundUpCarriesIntoMinutes()
+    {
+        // 59.6 seconds rounds up to 60, which carries into a full minute.
+        Json.Period period = new Corvus.Text.Json.PeriodBuilder { Seconds = 59, Milliseconds = 600 }.BuildPeriod();
+        Assert.AreEqual("PT1M", period.ToString());
+    }
+
+    [TestMethod]
+    public void ToString_NegativeSubSecondRoundsAwayFromZero()
+    {
+        // -6.6 seconds rounds away from zero to -7 whole seconds.
+        Json.Period period = new Corvus.Text.Json.PeriodBuilder { Seconds = -6, Milliseconds = -600 }.BuildPeriod();
+        Assert.AreEqual("PT-7S", period.ToString());
+    }
+
+    [TestMethod]
+    public void TryFormatPeriod_SubSecondRoundsAndRoundTripsThroughParser()
+    {
+        // The backing-store formatter (used by the OpenAPI source generator's Build methods, via the
+        // implicit Period -> Source conversion) must emit a valid RFC 3339 duration with no fraction.
+        Json.Period period = new Corvus.Text.Json.PeriodBuilder { Seconds = 6, Milliseconds = 220, Nanoseconds = 724100 }.BuildPeriod();
+
+        byte[] buffer = new byte[128];
+        Assert.IsTrue(Corvus.Text.Json.Internal.JsonElementHelpers.TryFormatPeriod(period, buffer, out int written));
+        string formatted = System.Text.Encoding.UTF8.GetString(buffer, 0, written);
+
+        // No fraction, and unnecessary leading zero units are omitted.
+        Assert.AreEqual("PT6S", formatted);
+
+        // It round-trips through the (strict RFC 3339) parser, which rejects fractions.
+        Assert.IsTrue(Corvus.Text.Json.Period.TryParse(System.Text.Encoding.UTF8.GetBytes(formatted), out Json.Period roundTripped));
+        Assert.AreEqual(6, roundTripped.Seconds);
+        Assert.AreEqual(0, roundTripped.Milliseconds);
+        Assert.AreEqual(0, roundTripped.Nanoseconds);
+    }
+
+    [TestMethod]
+    [DataRow(1, 0, 3, "P1Y0M3D")] // A day after a year requires the bridging zero month (contiguity).
+    [DataRow(0, 0, 5, "P5D")] // Lone day omits years and months.
+    [DataRow(5, 0, 0, "P5Y")] // Lone year omits months and days.
+    [DataRow(0, 2, 3, "P2M3D")] // Month + day, no year.
+    [DataRow(1, 2, 3, "P1Y2M3D")] // All three date units.
+    public void TryFormatPeriod_DateUnits_OmitsZerosWithContiguity(int years, int months, int days, string expected)
+    {
+        Json.Period period = new Corvus.Text.Json.PeriodBuilder { Years = years, Months = months, Days = days }.BuildPeriod();
+
+        byte[] buffer = new byte[128];
+        Assert.IsTrue(Corvus.Text.Json.Internal.JsonElementHelpers.TryFormatPeriod(period, buffer, out int written));
+        string formatted = System.Text.Encoding.UTF8.GetString(buffer, 0, written);
+
+        Assert.AreEqual(expected, formatted);
+        Assert.IsTrue(Corvus.Text.Json.Period.TryParse(System.Text.Encoding.UTF8.GetBytes(formatted), out _), $"'{formatted}' must round-trip through the parser.");
+    }
+
+    [TestMethod]
+    [DataRow(1, 0, 5, "PT1H0M5S")] // A second after an hour requires the bridging zero minute (contiguity).
+    [DataRow(5, 0, 0, "PT5H")] // Lone hour omits minutes and seconds.
+    [DataRow(0, 0, 6, "PT6S")] // Lone second omits hours and minutes.
+    [DataRow(0, 30, 0, "PT30M")] // Lone minute.
+    [DataRow(5, 30, 6, "PT5H30M6S")] // All three time units.
+    public void TryFormatPeriod_TimeUnits_OmitsZerosWithContiguity(int hours, int minutes, int seconds, string expected)
+    {
+        Json.Period period = new Corvus.Text.Json.PeriodBuilder { Hours = hours, Minutes = minutes, Seconds = seconds }.BuildPeriod();
+
+        byte[] buffer = new byte[128];
+        Assert.IsTrue(Corvus.Text.Json.Internal.JsonElementHelpers.TryFormatPeriod(period, buffer, out int written));
+        string formatted = System.Text.Encoding.UTF8.GetString(buffer, 0, written);
+
+        Assert.AreEqual(expected, formatted);
+        Assert.IsTrue(Corvus.Text.Json.Period.TryParse(System.Text.Encoding.UTF8.GetBytes(formatted), out _), $"'{formatted}' must round-trip through the parser.");
+    }
+
+    [TestMethod]
     public void Normalize_Weeks()
     {
         Json.Period original = new Corvus.Text.Json.PeriodBuilder { Weeks = 2, Days = 5 }.BuildPeriod();


### PR DESCRIPTION
Fixes #805.

## Problem

The V5 `Corvus.Text.Json.Period` formatter could emit a fractional seconds value — e.g. `P0Y0M0DT0H0M6.220724100S` — for a period carrying sub-second precision (such as one built from a sub-second `System.TimeSpan` via `Period.FromTicks`). The JSON Schema `duration` format (RFC 3339 Appendix A, `dur-second = 1*DIGIT "S"`) does not permit fractional seconds, so these strings fail to round-trip through the strict `PeriodParser`.

Both formatting paths were affected:
- `JsonElementHelpers.TryFormat(Period)` — the backing-store formatter used when writing a period into a JSON document, including the OpenAPI server `Build` methods (via `implicit operator Source(Period)`). This produced the issue's exact string, including verbose zero-valued units.
- `Period.ToString()` — delegated to NodaTime's `NormalizingIso`, which also emits fractional seconds.

## Fix

- Add `Period.RoundedToWholeSeconds()`: normalize, round any sub-second component (ms/ticks/ns) to the nearest whole second (halves away from zero), then re-normalize so a carry propagates (e.g. `59.6s` → `1 min`).
- Route both formatters through it, emitting integer seconds only (removed the dead fraction/`unsafe`/`fixed` code).
- The backing-store formatter now also **omits unnecessary zero-valued units** where the RFC 3339 grammar allows, retaining a zero "bridge" unit only where contiguity requires it (e.g. `P1Y0M3D`, `PT1H0M5S`).
- `Period.ToString()` delegates to the same formatter, so both paths are byte-identical, compact, and guaranteed round-trippable.
- Documented the behaviour in XML docs and `VERSIONHISTORY.md`.

Output is now compact and valid, e.g. `PT6S` and `P7D`.

## V4 engine

The V4 engine also emits fractional durations, but its `PeriodParser` is deliberately lenient (it accepts `.`/`,` fractions), so V4 does not exhibit the self-round-trip failure and is left unchanged by deliberate decision.

## Behavioural note

Consumers that compared the exact formatted string of a `Period` should note the more compact output (e.g. `P7D` instead of `P0Y0M7D`). Noted under Bug fixes in `VERSIONHISTORY.md`.

## Tests

- New tests for rounding (down/up/half-away/carry/negative), the backing-store round-trip, and date/time zero-omission with contiguity (data-driven).
- Updated three existing tests that had codified the old behaviour, including `TryFormatPeriod_WithMilliseconds` which previously *asserted* the fraction.
- Full solution builds with 0 warnings across all TFMs (incl. net481); the affected test project passes (31,198 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Also fixes #808 — `Freeze()` on a parsed `JsonDocumentBuilder` threw

Added as a follow-up commit on this branch. `JsonDocument.CopyFreezeState` assumed every value row was a length-prefixed DynamicValue blob, but a `JsonDocumentBuilder.Parse`-created document points its `String`/`Number`/`PropertyName` rows directly into the raw-JSON backing region (no header), so the header read produced a bogus length and `Buffer.BlockCopy` threw `ArgumentException`. The freeze copy now compacts referenced values into a raw-JSON region plus a DynamicValue region and propagates the raw-region length to the frozen document, so parsed, mutated, and from-scratch documents all freeze correctly. Regression tests cover the repro, all value kinds, a post-mutation mixed freeze, and a sub-element freeze.

Fixes #808.
