### PR TITLE
Fix #809, #811, #810 and implement #812 (discriminated-union creation)

### DIFF
--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,19 @@
 # Version History
 
+## V5.1.13
+
+V5.1.13 fixes three V5 bugs — `CreatePatch` failing on frozen `JsonDocumentBuilder` elements, schema `default` values being invisible through the mutable view, and circular schemas producing non-terminating generated code — and adds the ability to construct a discriminated union directly from one of its branches.
+
+### New features
+
+- **Construct a discriminated union from a constituent branch** — A well-formed discriminated union (a `oneOf` whose branches carry a required `const` discriminator, with no further required structure on the base) can now be built directly from one of its branches. A branch's mutable view converts to the union in a single implicit hop (`Circle.Mutable` → `Shape`), and the union's builder `Source` accepts a branch by value, so a built branch flows straight into a containing type's `CreateBuilder` for a union-typed property — for example `ShapeHolder.CreateBuilder(ws, ShapeHolder.Circle.Build(...))` — with no intermediate union document. Detection is precise: extra required properties on the base, a missing or non-required `const`, or an `anyOf` (rather than `oneOf`) do not enable the wiring, while additional non-structural keywords (`title`, `description`, and so on) on the base still do. See [#812](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/812).
+
+### Bug fixes
+
+- **Circular same-instance composition now fails generation with a diagnostic** — A `oneOf`/`allOf`/`anyOf`/`$ref` cycle that evaluates against the *same instance* previously produced infinitely-recursive `Match()`/`TryGetAs` code (or silently-omitted code). Code generation now detects the non-terminating composition cycle and fails with a `CircularSchemaReferenceException` naming the referencing and referenced schema locations, surfaced by the V4 and V5 source generators as diagnostic `CRV1002`. Data-driven recursion through properties or items is correctly not flagged. Applies to both the V4 and V5 engines. See [#810](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/810).
+- **Schema `default` values are surfaced through the mutable view** — A non-null `default` declared on a property was invisible through a type's mutable view, and reading it could corrupt the pooled workspace. The mutable getter now returns a zero-copy frozen facade over the immutable default: reads forward to the underlying value, child elements rebase onto the facade, and any attempt to mutate the default throws an `InvalidOperationException` instructing the caller to set the value on its parent first. See [#811](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/811).
+- **`CreatePatch` works with frozen `JsonDocumentBuilder` elements** — Generating a JSON Patch from a frozen `JsonDocumentBuilder` element threw because the read-only metadata copy-out paths performed an unnecessary immutability check. The check has been removed from the copy-out paths (which only read data), so `CreatePatch` round-trips correctly when either side is a frozen builder element. See [#809](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/809).
+
 ## V5.1.12
 
 V5.1.12 fixes two V5 bugs: `Corvus.Text.Json.Period` could emit `duration` strings that are invalid under the JSON Schema `duration` format, and calling `Freeze()` on a `JsonDocumentBuilder` created via `Parse` threw an exception.

--- a/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/Models.cs
+++ b/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/Models.cs
@@ -4,3 +4,6 @@ namespace PolymorphismWithDiscriminators.Models;
 
 [JsonSchemaTypeGenerator("shape.json")]
 public readonly partial struct Shape;
+
+[JsonSchemaTypeGenerator("drawing.json")]
+public readonly partial struct Drawing;

--- a/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/Program.cs
+++ b/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/Program.cs
@@ -28,6 +28,25 @@ Shape rectangle = parsedRectangle.RootElement;
 Console.WriteLine(DescribeShape(circle));
 Console.WriteLine(DescribeShape(rectangle));
 
+// Creating polymorphic shapes from a branch (issue #812)
+//
+// You don't have to hand-write JSON to construct a discriminated union. Each
+// branch exposes a strongly-typed CreateBuilder that sets the `const`
+// discriminator (`type`) for you, and the resulting mutable branch converts
+// implicitly to the union in a single hop. Because the generator recognises the
+// oneOf + const pattern, a branch value can be used wherever the union is
+// expected.
+using var ws = JsonWorkspace.Create();
+
+using var circleBuilder = Shape.RequiredRadiusAndType.CreateBuilder(ws, radius: 5.0);
+Shape builtCircle = circleBuilder.RootElement; // implicit RequiredRadiusAndType.Mutable -> Shape
+
+using var rectangleBuilder = Shape.RequiredHeightAndTypeAndWidth.CreateBuilder(ws, height: 20.0, width: 10.0);
+Shape builtRectangle = rectangleBuilder.RootElement;
+
+Console.WriteLine(DescribeShape(builtCircle));
+Console.WriteLine(DescribeShape(builtRectangle));
+
 // Pattern matching function that handles all shape types
 string DescribeShape(in Shape shape)
 {

--- a/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/Program.cs
+++ b/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/Program.cs
@@ -47,6 +47,23 @@ Shape builtRectangle = rectangleBuilder.RootElement;
 Console.WriteLine(DescribeShape(builtCircle));
 Console.WriteLine(DescribeShape(builtRectangle));
 
+// Building an object whose property *is* a discriminated union (issue #812)
+//
+// 'Drawing' is an object with a required 'shape' property typed as the Shape
+// union. Shape.RequiredRadiusAndType.Build(...) produces the branch's Source,
+// which converts implicitly to the union's Source — exactly what
+// Drawing.CreateBuilder expects for its 'shape' parameter. So a branch built
+// with BranchType.Build() flows straight into the containing object, with no
+// intermediate Shape document materialised.
+using var drawingBuilder = Drawing.CreateBuilder(
+    ws,
+    name: "Sketch #1",
+    shape: Shape.RequiredRadiusAndType.Build(radius: 5.0));
+Drawing drawing = drawingBuilder.RootElement;
+
+Console.WriteLine(drawing); // {"name":"Sketch #1","shape":{"radius":5,"type":"circle"}}
+Console.WriteLine(DescribeShape(drawing.Shape)); // A circle with radius 5
+
 // Pattern matching function that handles all shape types
 string DescribeShape(in Shape shape)
 {

--- a/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/README.md
+++ b/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/README.md
@@ -104,6 +104,26 @@ string DescribeShape(in Shape shape)
 
 Note that the match handlers use named parameters (`matchRequiredRadiusAndType`, `matchRequiredHeightAndTypeAndWidth`) generated from the required properties in each discriminated variant.
 
+### Creating polymorphic types from a branch
+
+You don't have to hand-write JSON to construct a discriminated union. Because the generator recognises the `oneOf` + `const` pattern, each branch exposes a strongly-typed `CreateBuilder` that sets the discriminator (`type`) for you, and the resulting mutable branch converts *implicitly* to the union in a single hop:
+
+```csharp
+using var ws = JsonWorkspace.Create();
+
+// The branch's CreateBuilder sets the `type` const ("circle") automatically.
+using var circleBuilder = Shape.RequiredRadiusAndType.CreateBuilder(ws, radius: 5.0);
+Shape builtCircle = circleBuilder.RootElement; // RequiredRadiusAndType.Mutable -> Shape (implicit)
+
+using var rectangleBuilder = Shape.RequiredHeightAndTypeAndWidth.CreateBuilder(ws, height: 20.0, width: 10.0);
+Shape builtRectangle = rectangleBuilder.RootElement;
+
+Console.WriteLine(DescribeShape(builtCircle));    // A circle with radius 5
+Console.WriteLine(DescribeShape(builtRectangle)); // A rectangle 10x20
+```
+
+This single-hop conversion (branch → union) is what lets a branch value flow wherever the union is expected — for example into a containing type's `CreateBuilder` for a property typed as the union, without first materialising the union document. It applies whenever the union is a well-formed discriminated union (a `oneOf` whose branches carry a required `const` discriminator and whose base adds no further required structure), and continues to apply when the base schema carries additional non-structural keywords such as `title` or `description`.
+
 ## Key Differences from V4
 
 ### V4 (Corvus.Json)
@@ -140,7 +160,7 @@ string desc = shape.Match(
 ```
 
 **Key differences:**
-- V5 parses from JSON rather than providing `Create()` methods for discriminated types
+- V5 constructs discriminated types by building one of their branches (`Branch.CreateBuilder(...)` / `Branch.Build(...)`) and relying on the implicit branch → union conversion, rather than a single `Shape.Create()` factory — see [Creating polymorphic types from a branch](#creating-polymorphic-types-from-a-branch) above
 - V5 names variant types by their required properties (e.g., `RequiredRadiusAndType`, `RequiredHeightAndTypeAndWidth`) instead of using ordinal `OneOfNEntity` names
 - V5 requires explicit `From()` conversion to access variant-specific properties
 - V5 pattern matching uses named parameters based on the variant type names

--- a/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/README.md
+++ b/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/README.md
@@ -124,6 +124,34 @@ Console.WriteLine(DescribeShape(builtRectangle)); // A rectangle 10x20
 
 This single-hop conversion (branch → union) is what lets a branch value flow wherever the union is expected — for example into a containing type's `CreateBuilder` for a property typed as the union, without first materialising the union document. It applies whenever the union is a well-formed discriminated union (a `oneOf` whose branches carry a required `const` discriminator and whose base adds no further required structure), and continues to apply when the base schema carries additional non-structural keywords such as `title` or `description`.
 
+#### Building an object whose property is the union
+
+The same wiring lets you build a containing object directly from a branch. Given `drawing.json`, an object with a required `shape` property typed as the union:
+
+```json
+{
+  "type": "object",
+  "required": ["name", "shape"],
+  "properties": {
+    "name": { "type": "string" },
+    "shape": { "$ref": "shape.json" }
+  }
+}
+```
+
+`BranchType.Build(...)` produces the branch's `Source`, which converts implicitly to the union's `Source` — exactly the type `Drawing.CreateBuilder` expects for its `shape` parameter. So the branch flows straight into the containing object, with no intermediate `Shape` document materialised:
+
+```csharp
+using var drawingBuilder = Drawing.CreateBuilder(
+    ws,
+    name: "Sketch #1",
+    shape: Shape.RequiredRadiusAndType.Build(radius: 5.0));
+Drawing drawing = drawingBuilder.RootElement;
+
+Console.WriteLine(drawing);                       // {"name":"Sketch #1","shape":{"radius":5,"type":"circle"}}
+Console.WriteLine(DescribeShape(drawing.Shape));  // A circle with radius 5
+```
+
 ## Key Differences from V4
 
 ### V4 (Corvus.Json)

--- a/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/drawing.json
+++ b/docs/ExampleRecipes/013-PolymorphismWithDiscriminators/drawing.json
@@ -1,0 +1,8 @@
+{
+  "type": "object",
+  "required": ["name", "shape"],
+  "properties": {
+    "name": { "type": "string" },
+    "shape": { "$ref": "shape.json" }
+  }
+}

--- a/docs/JsonDocumentBuilder.md
+++ b/docs/JsonDocumentBuilder.md
@@ -316,6 +316,25 @@ Console.WriteLine(holder.RootElement.ToString());
 // {"shape":{"kind":"Circle","radius":2.5}}
 ```
 
+You can also *build* the branch inline rather than starting from an existing instance, by passing the
+result of the branch's `Build(...)` straight in — it converts implicitly to the union's `Source`:
+
+```csharp
+using JsonWorkspace workspace = JsonWorkspace.Create();
+
+using JsonDocumentBuilder<ShapeHolder.Mutable> holder = ShapeHolder.CreateBuilder(
+    workspace,
+    ShapeHolder.Circle.Build(static (ref ShapeHolder.Circle.Builder b) =>
+    {
+        b.AddProperty("kind"u8, "Circle"u8);
+        b.AddProperty("radius"u8, 2.5);
+    }));
+```
+
+So a branch flows into a containing type wherever its `Source` is expected, in three forms — a branch
+**instance**, a branch **builder delegate** (`new ShapeHolder.Shape.Source(buildDelegate)`), and the
+**result of `Branch.Build(...)`** (a `Branch.Source`), as shown above.
+
 This works for *pure* `oneOf`/`anyOf` unions (branches discriminated by structure) and for unions whose
 base schema carries a single required `const` discriminator that every branch repeats — the common
 "tagged union" shape used by OpenAPI discriminators and JSON Patch operations. Non-structural keywords

--- a/docs/JsonDocumentBuilder.md
+++ b/docs/JsonDocumentBuilder.md
@@ -264,6 +264,66 @@ using var usersDoc = JsonElement.CreateBuilder(
 Console.WriteLine(usersDoc.RootElement.ToString());
 ```
 
+### Creating Discriminated Unions
+
+A *discriminated union* is a `oneOf` (or `anyOf`) whose branches are distinguished by a constant
+discriminator property — for example a `Shape` that is either a `Circle` or a `Rectangle`, keyed by
+`kind`:
+
+```json
+{
+  "title": "Shape",
+  "type": "object",
+  "required": [ "kind" ],
+  "properties": { "kind": { "type": "string", "enum": [ "Circle", "Rectangle" ] } },
+  "oneOf": [ { "$ref": "#/$defs/circle" }, { "$ref": "#/$defs/rectangle" } ]
+}
+```
+
+You do not have to materialise the union to work with it — you can build a single branch and use it
+wherever the union is expected. Because a valid branch is always a valid union, the generator lets a
+branch flow straight into the union in a **single** implicit conversion (there is no need to spell out
+an intermediate step, which C# would otherwise require because it will not chain two implicit
+conversions):
+
+```csharp
+using JsonWorkspace workspace = JsonWorkspace.Create();
+
+// Build a Circle branch directly...
+using JsonDocumentBuilder<Shape.Circle.Mutable> circleBuilder =
+    JsonDocumentBuilder<Shape.Circle.Mutable>.Parse(workspace, """{"kind":"Circle","radius":2.5}""");
+
+// ...and assign it where a Shape is expected. This is a single hop, even though the value is a
+// Shape.Circle.Mutable — no intermediate Shape.Circle is needed.
+Shape shape = circleBuilder.RootElement;
+```
+
+The same applies when *creating* a larger document: a branch can be passed straight into the
+`Build`/`CreateBuilder` of a type that contains the union. Here a `ShapeHolder` has a required `shape`
+property of the `Shape` union, and we build it from a `Circle`:
+
+```csharp
+using JsonWorkspace workspace = JsonWorkspace.Create();
+
+using ParsedJsonDocument<ShapeHolder.Circle> circleDoc =
+    ParsedJsonDocument<ShapeHolder.Circle>.Parse("""{"kind":"Circle","radius":2.5}""");
+ShapeHolder.Circle circle = circleDoc.RootElement;
+
+// 'circle' converts implicitly to the union's Source for the 'shape' property.
+using JsonDocumentBuilder<ShapeHolder.Mutable> holder = ShapeHolder.CreateBuilder(workspace, circle);
+
+Console.WriteLine(holder.RootElement.ToString());
+// {"shape":{"kind":"Circle","radius":2.5}}
+```
+
+This works for *pure* `oneOf`/`anyOf` unions (branches discriminated by structure) and for unions whose
+base schema carries a single required `const` discriminator that every branch repeats — the common
+"tagged union" shape used by OpenAPI discriminators and JSON Patch operations. Non-structural keywords
+on the base schema (`title`, `description`, `$comment`, `examples`, and so on) do not affect this.
+
+> Note: a branch can always be read back out of the union with the generated `TryGetAs…` / `Match`
+> methods — see [Polymorphism with Discriminators](ExampleRecipes/013-PolymorphismWithDiscriminators/).
+
 ## Working with Existing JSON
 
 In many applications, you receive JSON from an API, file, or database, modify it, and send it on its way. The pattern is straightforward — parse, mutate, serialize.

--- a/docs/JsonDocumentBuilder.md
+++ b/docs/JsonDocumentBuilder.md
@@ -341,7 +341,7 @@ base schema carries a single required `const` discriminator that every branch re
 on the base schema (`title`, `description`, `$comment`, `examples`, and so on) do not affect this.
 
 > Note: a branch can always be read back out of the union with the generated `TryGetAs…` / `Match`
-> methods — see [Polymorphism with Discriminators](ExampleRecipes/013-PolymorphismWithDiscriminators/).
+> methods — see [Polymorphism with Discriminators](../ExampleRecipes/013-PolymorphismWithDiscriminators/).
 
 ## Working with Existing JSON
 

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -173,10 +173,13 @@ example-recipes:
       - {index: 1, language: csharp, lines: [60, 73], category: compilable, verified: false}
       - {index: 2, language: csharp, lines: [79, 84], category: compilable, verified: false}
       - {index: 3, language: csharp, lines: [92, 103], category: compilable, verified: true}
-      - {index: 4, language: csharp, lines: [110, 123], category: compilable, verified: false}
-      - {index: 5, language: csharp, lines: [126, 140], category: compilable, verified: false}
-      - {index: 6, language: bash, lines: [150, 153]}
-      - {index: 7, language: csharp, lines: [169, 172], category: compilable, verified: false}
+      - {index: 4, language: csharp, lines: [111, 123], category: compilable, verified: false}
+      - {index: 5, language: json, lines: [131, 140]}
+      - {index: 6, language: csharp, lines: [144, 153], category: compilable, verified: false}
+      - {index: 7, language: csharp, lines: [158, 171], category: compilable, verified: false}
+      - {index: 8, language: csharp, lines: [174, 188], category: compilable, verified: false}
+      - {index: 9, language: bash, lines: [198, 201]}
+      - {index: 10, language: csharp, lines: [217, 220], category: compilable, verified: false}
   - path: "docs/ExampleRecipes/014-StringEnumerations/README.md"
     companion_project: "docs/ExampleRecipes/014-StringEnumerations/"
     blocks:
@@ -932,39 +935,43 @@ main-docs:
       - {index: 6, language: csharp, lines: [192, 209], category: compilable, verified: false}
       - {index: 7, language: csharp, lines: [213, 231], category: compilable, verified: false}
       - {index: 8, language: csharp, lines: [237, 265], category: compilable, verified: false}
-      - {index: 9, language: csharp, lines: [275, 290], category: compilable, verified: false}
-      - {index: 10, language: csharp, lines: [294, 310], category: compilable, verified: false}
-      - {index: 11, language: csharp, lines: [316, 336], category: compilable, verified: false}
-      - {index: 12, language: csharp, lines: [342, 363], category: compilable, verified: false}
-      - {index: 13, language: csharp, lines: [373, 420], category: compilable, verified: false}
-      - {index: 14, language: csharp, lines: [436, 457], category: compilable, verified: false}
-      - {index: 15, language: csharp, lines: [461, 499], category: compilable, verified: false}
-      - {index: 16, language: csharp, lines: [505, 514], category: compilable, verified: false}
-      - {index: 17, language: csharp, lines: [518, 526], category: compilable, verified: false}
-      - {index: 18, language: csharp, lines: [544, 567], category: compilable, verified: false}
-      - {index: 19, language: csharp, lines: [583, 617], category: compilable, verified: false}
-      - {index: 20, language: csharp, lines: [625, 663], category: compilable, verified: false}
-      - {index: 21, language: csharp, lines: [690, 708], category: compilable, verified: false}
-      - {index: 22, language: csharp, lines: [716, 737], category: compilable, verified: false}
-      - {index: 23, language: csharp, lines: [761, 790], category: compilable, verified: false}
-      - {index: 24, language: csharp, lines: [801, 833], category: fragment, verified: false}
-      - {index: 25, language: csharp, lines: [854, 871], category: compilable, verified: false}
-      - {index: 26, language: csharp, lines: [879, 921], category: compilable, verified: false}
-      - {index: 27, language: csharp, lines: [931, 1024], category: compilable, verified: false}
-      - {index: 28, language: csharp, lines: [1045, 1076], category: compilable, verified: false}
-      - {index: 29, language: csharp, lines: [1091, 1130], category: compilable, verified: false}
-      - {index: 30, language: csharp, lines: [1134, 1160], category: compilable, verified: false}
-      - {index: 31, language: csharp, lines: [1174, 1197], category: compilable, verified: false}
-      - {index: 32, language: csharp, lines: [1201, 1212], category: compilable, verified: false}
-      - {index: 33, language: csharp, lines: [1218, 1239], category: compilable, verified: false}
-      - {index: 34, language: csharp, lines: [1252, 1258], category: compilable, verified: false}
-      - {index: 35, language: csharp, lines: [1261, 1269], category: compilable, verified: false}
-      - {index: 36, language: csharp, lines: [1272, 1279], category: compilable, verified: false}
-      - {index: 37, language: csharp, lines: [1322, 1328], category: compilable, verified: false}
-      - {index: 38, language: csharp, lines: [1331, 1338], category: compilable, verified: false}
-      - {index: 39, language: csharp, lines: [1362, 1366], category: compilable, verified: false}
-      - {index: 40, language: csharp, lines: [1369, 1373], category: compilable, verified: false}
-      - {index: 41, language: csharp, lines: [1376, 1380], category: compilable, verified: false}
+      - {index: 9, language: json, lines: [273, 281]}
+      - {index: 10, language: csharp, lines: [289, 299], category: compilable, verified: false}
+      - {index: 11, language: csharp, lines: [305, 317], category: compilable, verified: false}
+      - {index: 12, language: csharp, lines: [322, 332], category: compilable, verified: false}
+      - {index: 13, language: csharp, lines: [354, 369], category: compilable, verified: false}
+      - {index: 14, language: csharp, lines: [373, 389], category: compilable, verified: false}
+      - {index: 15, language: csharp, lines: [395, 415], category: compilable, verified: false}
+      - {index: 16, language: csharp, lines: [421, 442], category: compilable, verified: false}
+      - {index: 17, language: csharp, lines: [452, 499], category: compilable, verified: false}
+      - {index: 18, language: csharp, lines: [515, 536], category: compilable, verified: false}
+      - {index: 19, language: csharp, lines: [540, 578], category: compilable, verified: false}
+      - {index: 20, language: csharp, lines: [584, 593], category: compilable, verified: false}
+      - {index: 21, language: csharp, lines: [597, 605], category: compilable, verified: false}
+      - {index: 22, language: csharp, lines: [623, 646], category: compilable, verified: false}
+      - {index: 23, language: csharp, lines: [662, 696], category: compilable, verified: false}
+      - {index: 24, language: csharp, lines: [704, 742], category: fragment, verified: false}
+      - {index: 25, language: csharp, lines: [769, 787], category: compilable, verified: false}
+      - {index: 26, language: csharp, lines: [795, 816], category: compilable, verified: false}
+      - {index: 27, language: csharp, lines: [840, 869], category: compilable, verified: false}
+      - {index: 28, language: csharp, lines: [880, 912], category: compilable, verified: false}
+      - {index: 29, language: csharp, lines: [933, 950], category: compilable, verified: false}
+      - {index: 30, language: csharp, lines: [958, 1000], category: compilable, verified: false}
+      - {index: 31, language: csharp, lines: [1010, 1103], category: compilable, verified: false}
+      - {index: 32, language: csharp, lines: [1124, 1155], category: compilable, verified: false}
+      - {index: 33, language: csharp, lines: [1170, 1209], category: compilable, verified: false}
+      - {index: 34, language: csharp, lines: [1213, 1239], category: compilable, verified: false}
+      - {index: 35, language: csharp, lines: [1253, 1276], category: compilable, verified: false}
+      - {index: 36, language: csharp, lines: [1280, 1291], category: compilable, verified: false}
+      - {index: 37, language: csharp, lines: [1297, 1318], category: compilable, verified: false}
+      - {index: 38, language: csharp, lines: [1331, 1337], category: compilable, verified: false}
+      - {index: 39, language: csharp, lines: [1340, 1348], category: compilable, verified: false}
+      - {index: 40, language: csharp, lines: [1351, 1358], category: compilable, verified: false}
+      - {index: 41, language: csharp, lines: [1401, 1407], category: compilable, verified: false}
+      - {index: 42, language: csharp, lines: [1410, 1417], category: compilable, verified: false}
+      - {index: 43, language: csharp, lines: [1441, 1445], category: compilable, verified: false}
+      - {index: 44, language: csharp, lines: [1448, 1452], category: compilable, verified: false}
+      - {index: 45, language: csharp, lines: [1455, 1459], category: compilable, verified: false}
   - path: "docs/JsonLogic.md"
     blocks:
       - {index: 0, language: bash, lines: [29, 32]}

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeGeneratorExtensions.cs
@@ -1898,6 +1898,12 @@ internal static partial class CodeGeneratorExtensions
                 continue;
             }
 
+            // The generated Is accessor validates the target schema; if its schema has a circular
+            // same-instance composition that does not terminate, generation fails with the source
+            // and target schema locations rather than emitting code that would stack-overflow at
+            // runtime (issue #810).
+            t.EnsureTerminatingCompositionEvaluation();
+
             string propertyNameAs = generator.GetPropertyNameInScope("As", suffix: t.DotnetTypeName());
             string currentPropertyName = propertyNameAs;
 
@@ -2010,6 +2016,12 @@ internal static partial class CodeGeneratorExtensions
             {
                 continue;
             }
+
+            // A TryGetAs method validates the target schema; if its schema has a circular
+            // same-instance composition that does not terminate, generation fails with the source
+            // and target schema locations rather than emitting code that would stack-overflow at
+            // runtime (issue #810).
+            t.EnsureTerminatingCompositionEvaluation();
 
             string methodName = generator.GetMethodNameInScope("TryGetAs", suffix: t.DotnetTypeName());
             generator
@@ -5121,7 +5133,7 @@ internal static partial class CodeGeneratorExtensions
                     return generator;
                 }
 
-                var subschema = allOf[keyword].Distinct().ToList();
+                var subschema = EnsureMatchTypesTerminate(allOf[keyword].Distinct().ToList());
                 if (subschema.Count > 1)
                 {
                     AppendMatchCompositionMethod(generator, typeDeclaration, subschema, includeContext: true, matchOverloadIndex++);
@@ -5139,7 +5151,7 @@ internal static partial class CodeGeneratorExtensions
                     return generator;
                 }
 
-                var subschema = anyOf[keyword].Distinct().ToList();
+                var subschema = EnsureMatchTypesTerminate(anyOf[keyword].Distinct().ToList());
                 if (subschema.Count > 1)
                 {
                     AppendMatchCompositionMethod(generator, typeDeclaration, subschema, includeContext: true, matchOverloadIndex++);
@@ -5157,7 +5169,7 @@ internal static partial class CodeGeneratorExtensions
                     return generator;
                 }
 
-                var subschema = oneOf[keyword].Distinct().ToList();
+                var subschema = EnsureMatchTypesTerminate(oneOf[keyword].Distinct().ToList());
                 if (subschema.Count > 1)
                 {
                     AppendMatchCompositionMethod(generator, typeDeclaration, subschema, includeContext: true, matchOverloadIndex++);
@@ -5191,6 +5203,19 @@ internal static partial class CodeGeneratorExtensions
         }
 
         return generator;
+
+        // A Match overload would validate each member; if any member has a circular same-instance
+        // composition that does not terminate, generation fails with the source and target schema
+        // locations rather than emitting code that would stack-overflow at runtime (issue #810).
+        static List<TypeDeclaration> EnsureMatchTypesTerminate(List<TypeDeclaration> subschema)
+        {
+            foreach (TypeDeclaration t in subschema)
+            {
+                t.ReducedTypeDeclaration().ReducedType.EnsureTerminatingCompositionEvaluation();
+            }
+
+            return subschema;
+        }
 
         static void AppendMatchCompositionMethod(CodeGenerator generator, TypeDeclaration typeDeclaration, IReadOnlyCollection<TypeDeclaration> subschema, bool includeContext, int matchOverloadIndex)
         {

--- a/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/CircularSchemaReferenceException.cs
+++ b/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/CircularSchemaReferenceException.cs
@@ -33,13 +33,15 @@ public sealed class CircularSchemaReferenceException : Exception
     /// </summary>
     public string ReferencedLocation { get; }
 
+    private const string MessageFormat =
+        "Circular schema reference: the schema at '{0}' has a same-instance composition " +
+        "reference (allOf/$ref/anyOf/oneOf) to '{1}', which is already being evaluated for " +
+        "the same instance. Validation of this schema would never terminate, so terminating code " +
+        "cannot be generated. Break the cycle before generating types (for example, restructure " +
+        "the discriminated union so its branches do not $ref back to the union).";
+
     private static string BuildMessage(JsonReference referencingLocation, JsonReference referencedLocation)
     {
-        return
-            $"Circular schema reference: the schema at '{referencingLocation}' has a same-instance composition " +
-            $"reference (allOf/$ref/anyOf/oneOf) to '{referencedLocation}', which is already being evaluated for " +
-            "the same instance. Validation of this schema would never terminate, so terminating code cannot be " +
-            "generated. Break the cycle before generating types (for example, restructure the discriminated union " +
-            "so its branches do not $ref back to the union).";
+        return string.Format(MessageFormat, referencingLocation, referencedLocation);
     }
 }

--- a/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/CircularSchemaReferenceException.cs
+++ b/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/CircularSchemaReferenceException.cs
@@ -1,0 +1,45 @@
+// <copyright file="CircularSchemaReferenceException.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Json.CodeGeneration;
+
+/// <summary>
+/// The exception thrown when a schema contains a circular <em>same-instance</em> composition
+/// (an <c>allOf</c>/<c>$ref</c>/<c>anyOf</c>/<c>oneOf</c> cycle) whose validation would never
+/// terminate, and from which terminating code cannot be generated (issue #810).
+/// </summary>
+public sealed class CircularSchemaReferenceException : Exception
+{
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CircularSchemaReferenceException"/> class.
+    /// </summary>
+    /// <param name="referencingLocation">The location of the schema that holds the offending composition reference.</param>
+    /// <param name="referencedLocation">The location of the schema it references, which is already being evaluated for the same instance.</param>
+    public CircularSchemaReferenceException(JsonReference referencingLocation, JsonReference referencedLocation)
+        : base(BuildMessage(referencingLocation, referencedLocation))
+    {
+        this.ReferencingLocation = referencingLocation.ToString();
+        this.ReferencedLocation = referencedLocation.ToString();
+    }
+
+    /// <summary>
+    /// Gets the location of the schema that holds the offending composition reference (the source of the cycle).
+    /// </summary>
+    public string ReferencingLocation { get; }
+
+    /// <summary>
+    /// Gets the location of the schema it references, which is already being evaluated for the same instance (the target of the cycle).
+    /// </summary>
+    public string ReferencedLocation { get; }
+
+    private static string BuildMessage(JsonReference referencingLocation, JsonReference referencedLocation)
+    {
+        return
+            $"Circular schema reference: the schema at '{referencingLocation}' has a same-instance composition " +
+            $"reference (allOf/$ref/anyOf/oneOf) to '{referencedLocation}', which is already being evaluated for " +
+            "the same instance. Validation of this schema would never terminate, so terminating code cannot be " +
+            "generated. Break the cycle before generating types (for example, restructure the discriminated union " +
+            "so its branches do not $ref back to the union).";
+    }
+}

--- a/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/TypeDeclarations/TypeDeclarationExtensions.cs
+++ b/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/TypeDeclarations/TypeDeclarationExtensions.cs
@@ -1540,6 +1540,134 @@ public static class TypeDeclarationExtensions
     }
 
     /// <summary>
+    /// Gets a value indicating whether evaluating this type's schema would recurse forever,
+    /// because its <em>same-instance</em> composition graph (<c>allOf</c>/<c>$ref</c>,
+    /// <c>anyOf</c>, <c>oneOf</c>) contains a cycle.
+    /// </summary>
+    /// <param name="that">The type declaration to test.</param>
+    /// <returns><see langword="true"/> if evaluating the schema would never terminate.</returns>
+    /// <remarks>
+    /// <para>
+    /// Composition keywords evaluate the <em>same</em> instance node, so a cycle in that graph
+    /// re-evaluates the same node forever. This is the case for a discriminated union whose
+    /// branches <c>$ref</c> back to the union (issue #810). Contrast a tree-shaped schema that
+    /// recurses through <c>properties</c>/<c>items</c>: that recursion descends to child instance
+    /// nodes and so terminates with the finite data, and is <em>not</em> flagged here.
+    /// </para>
+    /// <para>
+    /// Generated <c>Match</c>/<c>TryGetAs</c> methods call the target type's <c>Evaluate</c>
+    /// directly, so they would stack-overflow at runtime for such a type. Code generation fails
+    /// instead (see <see cref="EnsureTerminatingCompositionEvaluation"/>).
+    /// </para>
+    /// </remarks>
+    public static bool HasNonTerminatingCompositionEvaluation(this TypeDeclaration that)
+    {
+        if (!that.TryGetMetadata(nameof(HasNonTerminatingCompositionEvaluation), out bool result))
+        {
+            result = that.FindNonTerminatingCompositionCycle() is not null;
+            that.SetMetadata(nameof(HasNonTerminatingCompositionEvaluation), result);
+        }
+
+        return result;
+    }
+
+    /// <summary>
+    /// Throws a <see cref="CircularSchemaReferenceException"/> if evaluating this type's schema
+    /// would not terminate because of a circular same-instance composition (issue #810).
+    /// </summary>
+    /// <param name="that">The type declaration to test.</param>
+    /// <exception cref="CircularSchemaReferenceException">
+    /// The schema has a circular <c>allOf</c>/<c>$ref</c>/<c>anyOf</c>/<c>oneOf</c> composition whose
+    /// validation would never terminate. The exception names the source and target schema locations.
+    /// </exception>
+    public static void EnsureTerminatingCompositionEvaluation(this TypeDeclaration that)
+    {
+        // The cached boolean short-circuits the common (acyclic) case; the cycle edge is only
+        // recomputed for the rare schema that actually fails.
+        if (that.HasNonTerminatingCompositionEvaluation() &&
+            that.FindNonTerminatingCompositionCycle() is (TypeDeclaration referencing, TypeDeclaration referenced))
+        {
+            throw new CircularSchemaReferenceException(
+                referencing.LocatedSchema.Location,
+                referenced.LocatedSchema.Location);
+        }
+    }
+
+    /// <summary>
+    /// Finds a non-terminating same-instance composition cycle reachable from this type, if any.
+    /// </summary>
+    /// <param name="that">The type declaration to test.</param>
+    /// <returns>
+    /// The back-edge of the cycle as a <c>(referencing, referenced)</c> pair — the type that holds the
+    /// offending composition reference and the type it references that is already being evaluated — or
+    /// <see langword="null"/> if evaluation terminates. Data-driven recursion through
+    /// <c>properties</c>/<c>items</c> descends to child instance nodes and so is never reported here.
+    /// </returns>
+    public static (TypeDeclaration Referencing, TypeDeclaration Referenced)? FindNonTerminatingCompositionCycle(this TypeDeclaration that)
+    {
+        return Visit(that, [], []);
+
+        static (TypeDeclaration, TypeDeclaration)? Visit(TypeDeclaration current, HashSet<TypeDeclaration> onPath, HashSet<TypeDeclaration> fullyExplored)
+        {
+            if (fullyExplored.Contains(current))
+            {
+                // We have already proven this subtree contains no cycle.
+                return null;
+            }
+
+            onPath.Add(current);
+
+            foreach (TypeDeclaration next in SameInstanceCompositionTypeDeclarations(current))
+            {
+                if (onPath.Contains(next))
+                {
+                    // 'current' references 'next', which is already on the evaluation path: a cycle.
+                    return (current, next);
+                }
+
+                if (Visit(next, onPath, fullyExplored) is { } cycle)
+                {
+                    return cycle;
+                }
+            }
+
+            onPath.Remove(current);
+            fullyExplored.Add(current);
+            return null;
+        }
+
+        static IEnumerable<TypeDeclaration> SameInstanceCompositionTypeDeclarations(TypeDeclaration that)
+        {
+            // allOf includes $ref (IReferenceKeyword is an IAllOfSubschemaValidationKeyword), so
+            // these three accessors together cover every subschema that is evaluated against the
+            // same instance node.
+            if (that.AllOfCompositionTypes() is IReadOnlyDictionary<IAllOfSubschemaValidationKeyword, IReadOnlyCollection<TypeDeclaration>> allOf)
+            {
+                foreach (TypeDeclaration subschema in allOf.SelectMany(k => k.Value))
+                {
+                    yield return subschema.ReducedTypeDeclaration().ReducedType;
+                }
+            }
+
+            if (that.AnyOfCompositionTypes() is IReadOnlyDictionary<IAnyOfSubschemaValidationKeyword, IReadOnlyCollection<TypeDeclaration>> anyOf)
+            {
+                foreach (TypeDeclaration subschema in anyOf.SelectMany(k => k.Value))
+                {
+                    yield return subschema.ReducedTypeDeclaration().ReducedType;
+                }
+            }
+
+            if (that.OneOfCompositionTypes() is IReadOnlyDictionary<IOneOfSubschemaValidationKeyword, IReadOnlyCollection<TypeDeclaration>> oneOf)
+            {
+                foreach (TypeDeclaration subschema in oneOf.SelectMany(k => k.Value))
+                {
+                    yield return subschema.ReducedTypeDeclaration().ReducedType;
+                }
+            }
+        }
+    }
+
+    /// <summary>
     /// Gets the <see cref="IKeyword" /> keywords for the type declaration.
     /// </summary>
     /// <param name="that">The type declaration.</param>

--- a/src-v4/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
+++ b/src-v4/Corvus.Json.SourceGenerator/IncrementalSourceGenerator.cs
@@ -42,6 +42,15 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
+    private static readonly DiagnosticDescriptor Crv1002CircularSchemaReference =
+        new(
+            id: "CRV1002",
+            title: "Circular JSON Schema reference",
+            messageFormat: "Circular schema reference: the schema at '{0}' references '{1}' for the same instance, so validation would never terminate and terminating code cannot be generated. Break the cycle before generating types.",
+            category: "JsonSchemaCodeGenerator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
     private static readonly IVocabulary Corvus202012Vocab = CodeGeneration.Draft202012.VocabularyAnalyser.DefaultVocabularyWith([CodeGeneration.CorvusVocabulary.SchemaVocabulary.DefaultInstance]);
 
     /// <inheritdoc/>
@@ -146,6 +155,17 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
                     languageProvider,
                     typesToGenerate,
                     context.CancellationToken);
+        }
+        catch (CircularSchemaReferenceException ex)
+        {
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    Crv1002CircularSchemaReference,
+                    Location.None,
+                    ex.ReferencingLocation,
+                    ex.ReferencedLocation));
+
+            return;
         }
         catch (Exception ex)
         {

--- a/src/Corvus.Text.Json.CodeGeneration/CodeFileBuilders/MutableCorePartial.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CodeFileBuilders/MutableCorePartial.cs
@@ -74,6 +74,7 @@ public sealed class MutableCorePartial : ICodeFileBuilder
                             isReadOnly: false)
                             .AppendBackingFields(forMutable: true)
                             .AppendInternalConstructor(typeDeclaration, forMutable: true)
+                            .AppendMutableDefaultInstanceStaticProperty(typeDeclaration)
                             .AppendValueKindProperty()
                             .AppendTokenTypeProperty()
                             .AppendConversionToCompositionTypes(typeDeclaration, forMutable: true)

--- a/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Builder.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Builder.cs
@@ -399,6 +399,17 @@ internal static partial class CodeGeneratorExtensions
                 }
             }
 
+            if (!forContext && composedBuilder.SourceKindName is not null && composedBuilder.SourceInstanceName is not null && seenKinds.Add(composedBuilder.SourceKindName))
+            {
+                // #812: build the value by delegating to the stored constituent Source.
+                generator
+                    .AppendLineIndent("case Kind.", composedBuilder.SourceKindName, ":")
+                    .PushIndent()
+                        .AppendLineIndent("_", composedBuilder.SourceInstanceName, ".AddAsItem(ref valueBuilder);")
+                        .AppendLineIndent("break;")
+                    .PopIndent();
+            }
+
             if (composedBuilder.ArrayInstanceName is not null && composedBuilder.ArrayKindName is not null)
             {
                 if (seenKinds.Add(composedBuilder.ArrayKindName))
@@ -841,6 +852,17 @@ internal static partial class CodeGeneratorExtensions
                 }
             }
 
+            if (!forContext && composedBuilder.SourceKindName is not null && composedBuilder.SourceInstanceName is not null && seenKinds.Add(composedBuilder.SourceKindName))
+            {
+                // #812: build the value by delegating to the stored constituent Source.
+                generator
+                    .AppendLineIndent("case Kind.", composedBuilder.SourceKindName, ":")
+                    .PushIndent()
+                        .AppendLineIndent("_", composedBuilder.SourceInstanceName, ".AddAsPrebakedProperty(prebakedPropertyName, ref valueBuilder);")
+                        .AppendLineIndent("break;")
+                    .PopIndent();
+            }
+
             if (composedBuilder.ArrayInstanceName is not null && composedBuilder.ArrayKindName is not null && composedBuilder.ArrayBuilderName is not null)
             {
                 if (seenKinds.Add(composedBuilder.ArrayKindName))
@@ -1273,6 +1295,17 @@ internal static partial class CodeGeneratorExtensions
                             .PopIndent();
                     }
                 }
+            }
+
+            if (!forContext && composedBuilder.SourceKindName is not null && composedBuilder.SourceInstanceName is not null && seenKinds.Add(composedBuilder.SourceKindName))
+            {
+                // #812: build the value by delegating to the stored constituent Source.
+                generator
+                    .AppendLineIndent("case Kind.", composedBuilder.SourceKindName, ":")
+                    .PushIndent()
+                        .AppendLineIndent("_", composedBuilder.SourceInstanceName, ".AddAsProperty(", nameName, ", ref valueBuilder", includeEscaping ? ", escapeName, nameRequiresUnescaping" : "", ");")
+                        .AppendLineIndent("break;")
+                    .PopIndent();
             }
 
             if (composedBuilder.ArrayInstanceName is not null && composedBuilder.ArrayKindName is not null && composedBuilder.ArrayBuilderName is not null)
@@ -3813,6 +3846,26 @@ internal static partial class CodeGeneratorExtensions
                 }
             }
 
+            if (!forContext && composedBuilder.SourceInstanceName is not null && composedBuilder.SourceKindName is not null)
+            {
+                // #812: construct this union's Source from a constituent's own Source (e.g. the result
+                // of Constituent.Build(...)). The parameter is by value (not 'in'): the implicit
+                // conversion operator passes a by-value local, so a by-value copy keeps it ref-safe.
+                string fqdtn = composedBuilder.TypeDeclaration.FullyQualifiedDotnetTypeName();
+                generator
+                    .AppendSeparatorLine()
+                    .AppendLineIndent(
+                        "public ", generator.SourceClassName(), "(",
+                        fqdtn,
+                        ".",
+                        generator.SourceClassName(fqdtn),
+                        " value) { _",
+                        composedBuilder.SourceInstanceName,
+                        " = value; _kind = Kind.",
+                        composedBuilder.SourceKindName,
+                        "; }");
+            }
+
             if (composedBuilder.ArrayInstanceName is not null && composedBuilder.ArrayKindName is not null)
             {
                 string fqdtn = composedBuilder.TypeDeclaration.FullyQualifiedDotnetTypeName();
@@ -3981,6 +4034,21 @@ internal static partial class CodeGeneratorExtensions
                                 "public static implicit operator ", generator.SourceClassName(), "(",
                                 fqdtn,
                                 " instance) => new(JsonElement.From(instance));");
+                }
+
+                // #812: also convert the constituent's own Source (e.g. the result of
+                // Constituent.Build(...)) so it can be passed wherever this union's Source is expected.
+                if (composedBuilder.SourceKindName is not null && seenConversionOperators.Add($"{fqdtn}.{generator.SourceClassName(fqdtn)}"))
+                {
+                    generator
+                        .AppendSeparatorLine()
+                        .AppendLineIndent("[MethodImpl(MethodImplOptions.AggressiveInlining)]")
+                            .AppendLineIndent(
+                                "public static implicit operator ", generator.SourceClassName(), "(",
+                                fqdtn,
+                                ".",
+                                generator.SourceClassName(fqdtn),
+                                " value) => new(value);");
                 }
             }
         }
@@ -4247,6 +4315,23 @@ internal static partial class CodeGeneratorExtensions
                         oin,
                         ";");
                 }
+            }
+
+            if (!forContext && builder.SourceInstanceName is string sin)
+            {
+                // #812: a by-value backing field for the constituent's own Source, so the result of
+                // Constituent.Build(...) can be stored in (and built through) this union's Source.
+                string fqdtn = builder.TypeDeclaration.FullyQualifiedDotnetTypeName();
+                generator
+                    .ReserveNameIfNotReserved($"_{sin}")
+                    .AppendLineIndent(
+                    "private readonly ",
+                    fqdtn,
+                    ".",
+                    generator.SourceClassName(fqdtn),
+                    " _",
+                    sin,
+                    ";");
             }
 
             if (builder.ArrayInstanceName is string ain)
@@ -4940,6 +5025,9 @@ internal static partial class CodeGeneratorExtensions
             string? stringFormat = null;
             string? numericFormat = null;
 
+            string? sourceKindName = null;
+            string? sourceInstanceName = null;
+
             if (isString)
             {
                 stringFormat = t.Format();
@@ -5013,6 +5101,19 @@ internal static partial class CodeGeneratorExtensions
 
                     generator
                         .AppendLineIndent(objectKindName, ",");
+
+                    // #812: when the constituent object-builder wiring is enabled (a pure oneOf, or a
+                    // discriminated union), also surface the constituent's own Source through the
+                    // union's Source, so the result of Constituent.Build(...) can be passed wherever
+                    // the union's Source is expected.
+                    if (!typeDeclaration.HasPropertyDeclarations || typeDeclaration.ConstituentBuildYieldsValidInstance())
+                    {
+                        sourceKindName = generator.GetUniqueMethodNameInScope(t.DotnetTypeName(), suffix: "Source");
+                        sourceInstanceName = generator.GetUniqueFieldNameInScope(sourceKindName, suffix: "Instance");
+
+                        generator
+                            .AppendLineIndent(sourceKindName, ",");
+                    }
                 }
                 else
                 {
@@ -5022,7 +5123,7 @@ internal static partial class CodeGeneratorExtensions
 
             if (shouldAdd)
             {
-                builders.Add(new(t, arrayKindName, objectKindName, arrayInstanceName, objectInstanceName, objectBuilderName, arrayBuilderName, numericArrayKindName, numericArrayTypeName, stringFormat, numericFormat));
+                builders.Add(new(t, arrayKindName, objectKindName, arrayInstanceName, objectInstanceName, objectBuilderName, arrayBuilderName, numericArrayKindName, numericArrayTypeName, stringFormat, numericFormat, sourceKindName, sourceInstanceName));
             }
         }
 
@@ -5289,7 +5390,9 @@ internal static partial class CodeGeneratorExtensions
             string? numericArrayKindName,
             NumericTypeName? numericArrayTypeName,
             string? stringFormat,
-            string? numericFormat)
+            string? numericFormat,
+            string? sourceKindName = null,
+            string? sourceInstanceName = null)
         {
             TypeDeclaration = typeDeclaration;
             ArrayKindName = arrayKindName;
@@ -5302,6 +5405,8 @@ internal static partial class CodeGeneratorExtensions
             NumericArrayTypeName = numericArrayTypeName;
             StringFormat = stringFormat;
             NumericFormat = numericFormat;
+            SourceKindName = sourceKindName;
+            SourceInstanceName = sourceInstanceName;
         }
 
         public string? ArrayBuilderName { get; }
@@ -5329,5 +5434,17 @@ internal static partial class CodeGeneratorExtensions
         public string? StringFormat { get; }
 
         public TypeDeclaration TypeDeclaration { get; }
+
+        /// <summary>
+        /// Gets the <c>Kind</c> enum value name for surfacing this constituent's own <c>Source</c>
+        /// (e.g. the result of <c>Constituent.Build(...)</c>) through the union's <c>Source</c>.
+        /// Non-null only for a discriminated-union object constituent (issue #812).
+        /// </summary>
+        public string? SourceKindName { get; }
+
+        /// <summary>
+        /// Gets the backing-field name for <see cref="SourceKindName"/>.
+        /// </summary>
+        public string? SourceInstanceName { get; }
     }
 }

--- a/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Builder.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Builder.cs
@@ -373,7 +373,7 @@ internal static partial class CodeGeneratorExtensions
 
             if (composedBuilder.ObjectInstanceName is not null && composedBuilder.ObjectKindName is not null)
             {
-                if (!(composedBuilder.IsObject && typeDeclaration.HasPropertyDeclarations))
+                if (!(composedBuilder.IsObject && typeDeclaration.HasPropertyDeclarations) || typeDeclaration.ConstituentBuildYieldsValidInstance())
                 {
                     if (seenKinds.Add(composedBuilder.ObjectKindName))
                     {
@@ -815,7 +815,7 @@ internal static partial class CodeGeneratorExtensions
 
             if (composedBuilder.ObjectInstanceName is not null && composedBuilder.ObjectKindName is not null && composedBuilder.ObjectBuilderName is not null)
             {
-                if (!(composedBuilder.IsObject && typeDeclaration.HasPropertyDeclarations))
+                if (!(composedBuilder.IsObject && typeDeclaration.HasPropertyDeclarations) || typeDeclaration.ConstituentBuildYieldsValidInstance())
                 {
                     if (seenKinds.Add(composedBuilder.ObjectKindName))
                     {
@@ -1249,7 +1249,7 @@ internal static partial class CodeGeneratorExtensions
 
             if (composedBuilder.ObjectInstanceName is not null && composedBuilder.ObjectKindName is not null && composedBuilder.ObjectBuilderName is not null)
             {
-                if (!(composedBuilder.IsObject && typeDeclaration.HasPropertyDeclarations))
+                if (!(composedBuilder.IsObject && typeDeclaration.HasPropertyDeclarations) || typeDeclaration.ConstituentBuildYieldsValidInstance())
                 {
                     if (seenKinds.Add(composedBuilder.ObjectKindName))
                     {
@@ -1636,6 +1636,61 @@ internal static partial class CodeGeneratorExtensions
         }
 
         return generator;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether building a single composed <c>oneOf</c> constituent always
+    /// yields a valid instance of this type, so the constituent object-builder <c>Source</c> wiring
+    /// may be emitted even though this type has its own properties (issue #812).
+    /// </summary>
+    /// <param name="typeDeclaration">The composing (union) type declaration.</param>
+    /// <returns><see langword="true"/> for a discriminated union whose only required property is a const discriminator carried by every branch.</returns>
+    /// <remarks>
+    /// The constituent object-builder wiring is normally suppressed when the parent has its own
+    /// properties, because building a single constituent might omit a property the parent requires.
+    /// For a discriminated union that cannot happen: the parent requires only a const discriminator
+    /// that every branch also requires, so any valid branch is a valid parent.
+    /// </remarks>
+    internal static bool ConstituentBuildYieldsValidInstance(this TypeDeclaration typeDeclaration)
+    {
+        if (!typeDeclaration.TryGetMetadata(nameof(ConstituentBuildYieldsValidInstance), out bool result))
+        {
+            result = Compute(typeDeclaration);
+            typeDeclaration.SetMetadata(nameof(ConstituentBuildYieldsValidInstance), result);
+        }
+
+        return result;
+
+        static bool Compute(TypeDeclaration typeDeclaration)
+        {
+            if (typeDeclaration.OneOfCompositionTypes() is not IReadOnlyDictionary<IOneOfSubschemaValidationKeyword, IReadOnlyCollection<TypeDeclaration>> oneOf
+                || oneOf.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (IReadOnlyCollection<TypeDeclaration> branches in oneOf.Values)
+            {
+                if (!CodeGenerationExtensions.TryGetOneOfDiscriminator(branches, out string? discriminator, out _, out _, requireRequired: true))
+                {
+                    return false;
+                }
+
+                // Every required local property of the parent must be the discriminator; otherwise a
+                // constituent build could omit a property the parent requires.
+                foreach (PropertyDeclaration property in typeDeclaration.PropertyDeclarations)
+                {
+                    if (property.LocalOrComposed == LocalOrComposed.Local
+                        && property.RequiredOrOptional == RequiredOrOptional.Required
+                        && property.JsonPropertyName != discriminator)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
     }
 
     private static CodeGenerator AppendSourceRefStruct(this CodeGenerator generator, TypeDeclaration typeDeclaration, List<ComposedBuilder> builders)
@@ -3739,7 +3794,7 @@ internal static partial class CodeGeneratorExtensions
 
             if (composedBuilder.ObjectInstanceName is not null && composedBuilder.ObjectKindName is not null)
             {
-                if (!(composedBuilder.IsObject && typeDeclaration.HasPropertyDeclarations))
+                if (!(composedBuilder.IsObject && typeDeclaration.HasPropertyDeclarations) || typeDeclaration.ConstituentBuildYieldsValidInstance())
                 {
                     string fqdtn = composedBuilder.TypeDeclaration.FullyQualifiedDotnetTypeName();
                     generator
@@ -3913,7 +3968,7 @@ internal static partial class CodeGeneratorExtensions
                 }
             }
 
-            if (!(composedBuilder.IsObject && typeDeclaration.HasPropertyDeclarations))
+            if (!(composedBuilder.IsObject && typeDeclaration.HasPropertyDeclarations) || typeDeclaration.ConstituentBuildYieldsValidInstance())
             {
                 string fqdtn = composedBuilder.TypeDeclaration.FullyQualifiedDotnetTypeName();
 
@@ -4178,7 +4233,7 @@ internal static partial class CodeGeneratorExtensions
 
             if (builder.ObjectInstanceName is string oin)
             {
-                if (!(builder.IsObject && typeDeclaration.HasPropertyDeclarations))
+                if (!(builder.IsObject && typeDeclaration.HasPropertyDeclarations) || typeDeclaration.ConstituentBuildYieldsValidInstance())
                 {
                     string fqdtn = builder.TypeDeclaration.FullyQualifiedDotnetTypeName();
                     generator

--- a/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Conversions.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Conversions.cs
@@ -714,6 +714,30 @@ internal static partial class CodeGeneratorExtensions
                 .PopIndent()
                 .AppendLineIndent("}");
 
+            // Also offer the conversion directly from the composed type's mutable view to the
+            // immutable composing type (issue #812 / #806). Without this, converting e.g. a
+            // discriminated-union branch's .Mutable to the union requires two implicit hops
+            // (Branch.Mutable -> Branch -> Union), which C# will not chain, forcing callers to
+            // spell out an intermediate. The general principle: if there is an implicit conversion
+            // from TypeA to TypeB, also offer one from TypeA.Mutable to TypeB.
+            if (!forMutable && isImplicitFrom)
+            {
+                generator
+                    .AppendSeparatorLine()
+                    .AppendLineIndent("/// <summary>")
+                    .AppendLineIndent("/// Conversion from the <see cref=\"", subschema.ReducedTypeDeclaration().ReducedType.FullyQualifiedDotnetTypeName(), "\"/> mutable view.")
+                    .AppendLineIndent("/// </summary>")
+                    .AppendLineIndent("/// <param name=\"value\">The value from which to convert.</param>")
+                    .AppendIndent("public static implicit operator ", rootDeclaration.DotnetTypeName(), "(")
+                    .Append(subschema.ReducedTypeDeclaration().ReducedType.FullyQualifiedDotnetTypeName())
+                    .AppendLine(".Mutable value)")
+                    .AppendLineIndent("{")
+                    .PushIndent()
+                        .AppendLineIndent("return From(value);")
+                    .PopIndent()
+                    .AppendLineIndent("}");
+            }
+
             return true;
         }
     }

--- a/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Conversions.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Conversions.cs
@@ -742,7 +742,7 @@ internal static partial class CodeGeneratorExtensions
                     return generator;
                 }
 
-                var subschema = allOf[keyword].Select(o => o.ReducedTypeDeclaration().ReducedType).Distinct().ToList();
+                var subschema = EnsureMatchTypesTerminate(allOf[keyword].Select(o => o.ReducedTypeDeclaration().ReducedType).Distinct().ToList());
                 if (subschema.Count > 1)
                 {
                     AppendMatchCompositionMethod(generator, typeDeclaration, subschema, includeContext: true, matchOverloadIndex++, forMutable);
@@ -760,7 +760,7 @@ internal static partial class CodeGeneratorExtensions
                     return generator;
                 }
 
-                var subschema = anyOf[keyword].Select(o => o.ReducedTypeDeclaration().ReducedType).Distinct().ToList();
+                var subschema = EnsureMatchTypesTerminate(anyOf[keyword].Select(o => o.ReducedTypeDeclaration().ReducedType).Distinct().ToList());
                 if (subschema.Count > 1)
                 {
                     AppendMatchCompositionMethod(generator, typeDeclaration, subschema, includeContext: true, matchOverloadIndex++, forMutable);
@@ -778,7 +778,7 @@ internal static partial class CodeGeneratorExtensions
                     return generator;
                 }
 
-                var subschema = oneOf[keyword].Select(o => o.ReducedTypeDeclaration().ReducedType).Distinct().ToList();
+                var subschema = EnsureMatchTypesTerminate(oneOf[keyword].Select(o => o.ReducedTypeDeclaration().ReducedType).Distinct().ToList());
                 if (subschema.Count > 1)
                 {
                     AppendMatchCompositionMethod(generator, typeDeclaration, subschema, includeContext: true, matchOverloadIndex++, forMutable);
@@ -812,6 +812,19 @@ internal static partial class CodeGeneratorExtensions
         }
 
         return generator;
+
+        // A Match overload would call each member's Evaluate; if any member has a circular
+        // same-instance composition that does not terminate, generation fails with the source and
+        // target schema locations rather than emitting code that would stack-overflow (issue #810).
+        static List<TypeDeclaration> EnsureMatchTypesTerminate(List<TypeDeclaration> subschema)
+        {
+            foreach (TypeDeclaration t in subschema)
+            {
+                t.EnsureTerminatingCompositionEvaluation();
+            }
+
+            return subschema;
+        }
 
         static void AppendMatchCompositionMethod(CodeGenerator generator, TypeDeclaration typeDeclaration, IReadOnlyCollection<TypeDeclaration> subschema, bool includeContext, int matchOverloadIndex, bool forMutable)
         {
@@ -1487,6 +1500,12 @@ internal static partial class CodeGeneratorExtensions
                 // You can never TryGetAs the not any type - it will always fail
                 continue;
             }
+
+            // A TryGetAs method would call the target's Evaluate; if its schema has a circular
+            // same-instance composition that does not terminate, generation fails with the source
+            // and target schema locations rather than emitting code that would stack-overflow at
+            // runtime (issue #810).
+            t.EnsureTerminatingCompositionEvaluation();
 
             string methodName = generator.GetMethodNameInScope("TryGetAs", suffix: t.DotnetTypeName());
             string typeName = t.FullyQualifiedDotnetTypeName();

--- a/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Object.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Object.cs
@@ -734,7 +734,14 @@ internal static partial class CodeGeneratorExtensions
             string propertyType = $"{property.ReducedPropertyType.FullyQualifiedDotnetTypeName()}{(forMutable ? ".Mutable" : "")}";
 
             string immutableTypeName = property.ReducedPropertyType.FullyQualifiedDotnetTypeName();
-            bool hasDefaultValue = !forMutable && hasDefault && !flipBackNullDefault;
+
+            // A non-null defaulted property returns its (read-only) default instance when absent.
+            // For the immutable view this is the immutable DefaultInstance; for the mutable view it
+            // is the Mutable.DefaultInstance, which is backed by a frozen document so reads return
+            // the default but mutation throws (issue #811). A property whose default is JSON null
+            // (flipBackNullDefault) instead returns C# null/default when absent.
+            bool hasDefaultValue = hasDefault && !flipBackNullDefault;
+            string defaultInstanceTypeName = forMutable ? propertyType : immutableTypeName;
 
             generator
                 .AppendSeparatorLine()
@@ -764,7 +771,7 @@ internal static partial class CodeGeneratorExtensions
                     .PopIndent()
                     .AppendLineIndent("}")
                     .AppendSeparatorLine()
-                    .AppendLineIndent(hasDefaultValue ? $"return {immutableTypeName}.DefaultInstance;" : "return default;")
+                    .AppendLineIndent(hasDefaultValue ? $"return {defaultInstanceTypeName}.DefaultInstance;" : "return default;")
                 .EndReadOnlyPropertyDeclaration();
         }
 

--- a/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.cs
@@ -1385,6 +1385,56 @@ internal static partial class CodeGeneratorExtensions
     }
 
     /// <summary>
+    /// Append the static property which provides a read-only default instance of the mutable
+    /// type declaration, materialised from the schema default value.
+    /// </summary>
+    /// <param name="generator">The code generator.</param>
+    /// <param name="typeDeclaration">The type declaration for which to emit the property.</param>
+    /// <returns>A reference to the generator having completed the operation.</returns>
+    /// <remarks>
+    /// This mirrors <see cref="AppendDefaultInstanceStaticProperty"/> for the nested
+    /// <c>Mutable</c> struct. A mutable value must be backed by an <c>IMutableJsonDocument</c>,
+    /// so the default is materialised into a builder and then frozen: the resulting instance
+    /// reads as the schema default but throws if mutated, matching the immutable read semantics
+    /// for an absent non-nullable defaulted property (issue #811).
+    /// </remarks>
+    public static CodeGenerator AppendMutableDefaultInstanceStaticProperty(this CodeGenerator generator, TypeDeclaration typeDeclaration)
+    {
+        if (generator.IsCancellationRequested)
+        {
+            return generator;
+        }
+
+        // Only emit a default instance when the type actually declares a default value; this is
+        // the same set of types for which the immutable DefaultInstance carries an initializer.
+        if (typeDeclaration.DefaultValue().ValueKind == JsonValueKind.Undefined)
+        {
+            return generator;
+        }
+
+        return generator
+            .ReserveName("DefaultInstance")
+            .AppendSeparatorLine()
+            .AppendBlockIndent(
+            """
+        /// <summary>
+        /// Gets a read-only default instance of the mutable type, surfacing the schema default value.
+        /// </summary>
+        /// <remarks>
+        /// The instance is a zero-copy facade over the immutable default, so it can be read but not
+        /// mutated; attempting to mutate it throws an <see cref="InvalidOperationException"/> directing
+        /// the caller to set the value on its parent first.
+        /// </remarks>
+        """)
+            .AppendLineIndent(
+                "public static Mutable DefaultInstance { get; } = JsonElementHelpers.CreateDefaultValueElement<",
+                typeDeclaration.DotnetTypeName(),
+                ", Mutable>(",
+                typeDeclaration.DotnetTypeName(),
+                ".DefaultInstance);");
+    }
+
+    /// <summary>
     /// Append a property which gets the <see cref="JsonValueKind"/> for the instance.
     /// </summary>
     /// <param name="generator">The code generator.</param>

--- a/src/Corvus.Text.Json.SourceGenerator/SourceGeneratorHelpers.cs
+++ b/src/Corvus.Text.Json.SourceGenerator/SourceGeneratorHelpers.cs
@@ -37,6 +37,15 @@ public static class SourceGeneratorHelpers
             DiagnosticSeverity.Error,
             isEnabledByDefault: true);
 
+    private static readonly DiagnosticDescriptor Crv1002CircularSchemaReference =
+        new(
+            id: "CRV1002",
+            title: "Circular JSON Schema reference",
+            messageFormat: "Circular schema reference: the schema at '{0}' references '{1}' for the same instance, so validation would never terminate and terminating code cannot be generated. Break the cycle before generating types.",
+            category: "JsonSchemaCodeGenerator",
+            DiagnosticSeverity.Error,
+            isEnabledByDefault: true);
+
     /// <summary>
     /// Generate code into a source production context.
     /// </summary>
@@ -131,6 +140,17 @@ public static class SourceGeneratorHelpers
                     languageProvider,
                     typeDeclarationsToGenerate,
                     context.CancellationToken);
+        }
+        catch (CircularSchemaReferenceException ex)
+        {
+            context.ReportDiagnostic(
+                Diagnostic.Create(
+                    Crv1002CircularSchemaReference,
+                    Location.None,
+                    ex.ReferencingLocation,
+                    ex.ReferencedLocation));
+
+            return [];
         }
         catch (Exception ex)
         {

--- a/src/Corvus.Text.Json/Corvus.Text.Json.csproj
+++ b/src/Corvus.Text.Json/Corvus.Text.Json.csproj
@@ -166,6 +166,7 @@
     <Compile Include="Corvus\Text\Json\DocumentBuilder\Internal\IMutableJsonElement{T}.cs" />
     <Compile Include="Corvus\Text\Json\DocumentBuilder\Internal\ComplexValueBuilder.cs" />
     <Compile Include="Corvus\Text\Json\DocumentBuilder\Internal\IMutableJsonDocument.cs" />
+    <Compile Include="Corvus\Text\Json\DocumentBuilder\Internal\DefaultValueJsonDocument.cs" />
     <Compile Include="Corvus\Text\Json\DocumentBuilder\JsonElement.ArrayBuilder.cs" />
     <Compile Include="Corvus\Text\Json\DocumentBuilder\JsonElement.ObjectBuilder.cs" />
     <Compile Include="Corvus\Text\Json\DocumentBuilder\JsonDocumentBuilder.cs" />

--- a/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/Internal/DefaultValueJsonDocument.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/Internal/DefaultValueJsonDocument.cs
@@ -1,0 +1,615 @@
+// <copyright file="DefaultValueJsonDocument.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.Diagnostics.CodeAnalysis;
+using System.Numerics;
+using Corvus.Numerics;
+using NodaTime;
+
+namespace Corvus.Text.Json.Internal;
+
+/// <summary>
+/// A read-only <see cref="IMutableJsonDocument"/> facade over an immutable document, used to back the
+/// mutable view of a schema <c>default</c> value (issue #811).
+/// </summary>
+/// <remarks>
+/// <para>
+/// A mutable element (<c>T.Mutable</c>) must be backed by an <see cref="IMutableJsonDocument"/>, but a
+/// schema default is materialised as an <em>immutable</em> instance. This facade lets an absent,
+/// non-nullable defaulted property be surfaced through the mutable view without copying any data: every
+/// read is forwarded to the wrapped immutable <paramref name="inner"/> document, and every mutating
+/// operation throws an <see cref="InvalidOperationException"/> whose message tells the caller to set the
+/// value on its parent before modifying it.
+/// </para>
+/// <para>
+/// This type owns no resources — it merely wraps <paramref name="inner"/> — so <see cref="Dispose"/> is a
+/// no-op and never disposes the wrapped document.
+/// </para>
+/// </remarks>
+/// <param name="inner">The immutable document that holds the default value.</param>
+[CLSCompliant(false)]
+public sealed class DefaultValueJsonDocument(IJsonDocument inner) : IMutableJsonDocument
+{
+    private readonly IJsonDocument inner = inner;
+
+    /// <inheritdoc />
+    public bool IsImmutable => true;
+
+    /// <inheritdoc />
+    public bool IsDisposable => false;
+
+    /// <inheritdoc />
+    public ulong Version => 0;
+
+    /// <inheritdoc />
+    public JsonWorkspace? CachedWorkspace
+    {
+        get => this.inner.CachedWorkspace;
+        set => this.inner.CachedWorkspace = value;
+    }
+
+    /// <inheritdoc />
+    public int CachedWorkspaceDocumentIndex
+    {
+        get => this.inner.CachedWorkspaceDocumentIndex;
+        set => this.inner.CachedWorkspaceDocumentIndex = value;
+    }
+
+    /// <inheritdoc />
+    public int CachedWorkspaceGeneration
+    {
+        get => this.inner.CachedWorkspaceGeneration;
+        set => this.inner.CachedWorkspaceGeneration = value;
+    }
+
+    /// <inheritdoc />
+    public int ParentWorkspaceIndex => throw Frozen();
+
+    /// <inheritdoc />
+    public JsonWorkspace Workspace => throw Frozen();
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // IMutableJsonDocument reads: forward to the inner document, but surface the
+    // result as a mutable element backed by this facade so nested mutation also
+    // raises the indicative exception.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public TElement FreezeElement<TElement>(int index)
+        where TElement : struct, IJsonElement<TElement>
+#if NET
+        => TElement.CreateInstance(this.inner, index);
+#else
+        => JsonElementHelpers.CreateInstance<TElement>(this.inner, index);
+#endif
+
+    /// <inheritdoc />
+    public JsonElement.Mutable GetArrayIndexElement(int currentIndex, int arrayIndex)
+    {
+        this.inner.GetArrayIndexElement(currentIndex, arrayIndex, out _, out int valueIndex);
+        return new JsonElement.Mutable(this, valueIndex);
+    }
+
+    /// <inheritdoc />
+    public void GetArrayIndexElement(int currentIndex, int arrayIndex, out IMutableJsonDocument parentDocument, out int parentDocumentIndex)
+    {
+        this.inner.GetArrayIndexElement(currentIndex, arrayIndex, out _, out parentDocumentIndex);
+        parentDocument = this;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetNamedPropertyValue(int index, ReadOnlySpan<char> propertyName, out JsonElement.Mutable value)
+    {
+        if (this.inner.TryGetNamedPropertyValue(index, propertyName, out _, out int valueIndex))
+        {
+            value = new JsonElement.Mutable(this, valueIndex);
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetNamedPropertyValue(int index, ReadOnlySpan<byte> propertyName, out JsonElement.Mutable value)
+    {
+        if (this.inner.TryGetNamedPropertyValue(index, propertyName, out _, out int valueIndex))
+        {
+            value = new JsonElement.Mutable(this, valueIndex);
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetNamedPropertyValueIndex(int index, ReadOnlySpan<char> propertyName, out int valueIndex)
+        => this.inner.TryGetNamedPropertyValue(index, propertyName, out _, out valueIndex);
+
+    /// <inheritdoc />
+    public bool TryGetNamedPropertyValueIndex(int index, ReadOnlySpan<byte> propertyName, out int valueIndex)
+        => this.inner.TryGetNamedPropertyValue(index, propertyName, out _, out valueIndex);
+
+    /// <inheritdoc />
+    public bool TryGetNamedPropertyValueIndex(ref MetadataDb parsedData, int startIndex, int endIndex, ReadOnlySpan<byte> propertyName, out int valueIndex)
+        => throw Frozen();
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // IJsonDocument reads: forward verbatim to the inner document.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public void EnsurePropertyMap(int index) => this.inner.EnsurePropertyMap(index);
+
+    /// <inheritdoc />
+    public int GetHashCode(int index) => this.inner.GetHashCode(index);
+
+    /// <inheritdoc />
+    public string ToString(int index) => this.inner.ToString(index);
+
+    /// <inheritdoc />
+    public JsonTokenType GetJsonTokenType(int index) => this.inner.GetJsonTokenType(index);
+
+    /// <inheritdoc />
+    JsonElement IJsonDocument.GetArrayIndexElement(int currentIndex, int arrayIndex) => this.inner.GetArrayIndexElement(currentIndex, arrayIndex);
+
+    /// <inheritdoc />
+    public TElement GetArrayIndexElement<TElement>(int currentIndex, int arrayIndex)
+        where TElement : struct, IJsonElement<TElement>
+    {
+        this.inner.GetArrayIndexElement(currentIndex, arrayIndex, out _, out int valueIndex);
+        return this.Create<TElement>(valueIndex);
+    }
+
+    /// <inheritdoc />
+    void IJsonDocument.GetArrayIndexElement(int currentIndex, int arrayIndex, out IJsonDocument parentDocument, out int parentDocumentIndex)
+        => this.inner.GetArrayIndexElement(currentIndex, arrayIndex, out parentDocument, out parentDocumentIndex);
+
+    /// <inheritdoc />
+    public int GetArrayInsertionIndex(int currentIndex, int arrayIndex) => this.inner.GetArrayInsertionIndex(currentIndex, arrayIndex);
+
+    /// <inheritdoc />
+    public int GetArrayLength(int index) => this.inner.GetArrayLength(index);
+
+    /// <inheritdoc />
+    public int GetPropertyCount(int index) => this.inner.GetPropertyCount(index);
+
+    /// <inheritdoc />
+    public bool TryGetNamedPropertyValue(int index, ReadOnlySpan<char> propertyName, out JsonElement value)
+        => this.inner.TryGetNamedPropertyValue(index, propertyName, out value);
+
+    /// <inheritdoc />
+    public bool TryGetNamedPropertyValue(int index, ReadOnlySpan<byte> propertyName, out JsonElement value)
+        => this.inner.TryGetNamedPropertyValue(index, propertyName, out value);
+
+    /// <inheritdoc />
+    public bool TryGetNamedPropertyValue<TElement>(int index, ReadOnlySpan<byte> propertyName, out TElement value)
+        where TElement : struct, IJsonElement<TElement>
+    {
+        if (this.inner.TryGetNamedPropertyValue(index, propertyName, out _, out int valueIndex))
+        {
+            value = this.Create<TElement>(valueIndex);
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetNamedPropertyValue<TElement>(int index, ReadOnlySpan<char> propertyName, out TElement value)
+        where TElement : struct, IJsonElement<TElement>
+    {
+        if (this.inner.TryGetNamedPropertyValue(index, propertyName, out _, out int valueIndex))
+        {
+            value = this.Create<TElement>(valueIndex);
+            return true;
+        }
+
+        value = default;
+        return false;
+    }
+
+    /// <inheritdoc />
+    public bool TryGetNamedPropertyValue(int index, ReadOnlySpan<char> propertyName, [NotNullWhen(true)] out IJsonDocument? elementParent, out int elementIndex)
+        => this.inner.TryGetNamedPropertyValue(index, propertyName, out elementParent, out elementIndex);
+
+    /// <inheritdoc />
+    public bool TryGetNamedPropertyValue(int index, ReadOnlySpan<byte> propertyName, [NotNullWhen(true)] out IJsonDocument? elementParent, out int elementIndex)
+        => this.inner.TryGetNamedPropertyValue(index, propertyName, out elementParent, out elementIndex);
+
+    /// <inheritdoc />
+    public string? GetString(int index, JsonTokenType expectedType) => this.inner.GetString(index, expectedType);
+
+    /// <inheritdoc />
+    public bool TryGetString(int index, JsonTokenType expectedType, [NotNullWhen(true)] out string? result) => this.inner.TryGetString(index, expectedType, out result);
+
+    /// <inheritdoc />
+    public UnescapedUtf8JsonString GetUtf8JsonString(int index, JsonTokenType expectedType) => this.inner.GetUtf8JsonString(index, expectedType);
+
+    /// <inheritdoc />
+    public UnescapedUtf16JsonString GetUtf16JsonString(int index, JsonTokenType expectedType) => this.inner.GetUtf16JsonString(index, expectedType);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, [NotNullWhen(true)] out byte[]? value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out sbyte value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out byte value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out short value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out ushort value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out int value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out uint value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out long value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out ulong value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out double value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out float value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out decimal value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out BigInteger value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out BigNumber value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out DateTime value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out DateTimeOffset value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out OffsetDateTime value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out OffsetDate value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out OffsetTime value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out LocalDate value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out Period value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out Guid value) => this.inner.TryGetValue(index, out value);
+
+#if NET
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out Int128 value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out UInt128 value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out Half value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out DateOnly value) => this.inner.TryGetValue(index, out value);
+
+    /// <inheritdoc />
+    public bool TryGetValue(int index, out TimeOnly value) => this.inner.TryGetValue(index, out value);
+
+#endif
+
+    /// <inheritdoc />
+    public string GetNameOfPropertyValue(int index) => this.inner.GetNameOfPropertyValue(index);
+
+    /// <inheritdoc />
+    public ReadOnlySpan<byte> GetPropertyNameRaw(int index) => this.inner.GetPropertyNameRaw(index);
+
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> GetPropertyNameRaw(int index, bool includeQuotes) => this.inner.GetPropertyNameRaw(index, includeQuotes);
+
+    /// <inheritdoc />
+    public JsonElement GetPropertyName(int index) => this.inner.GetPropertyName(index);
+
+    /// <inheritdoc />
+    public UnescapedUtf8JsonString GetPropertyNameUnescaped(int index) => this.inner.GetPropertyNameUnescaped(index);
+
+    /// <inheritdoc />
+    public string GetRawValueAsString(int index) => this.inner.GetRawValueAsString(index);
+
+    /// <inheritdoc />
+    public string GetPropertyRawValueAsString(int valueIndex) => this.inner.GetPropertyRawValueAsString(valueIndex);
+
+    /// <inheritdoc />
+    public RawUtf8JsonString GetRawValue(int index, bool includeQuotes) => this.inner.GetRawValue(index, includeQuotes);
+
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> GetRawSimpleValue(int index, bool includeQuotes) => this.inner.GetRawSimpleValue(index, includeQuotes);
+
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> GetRawSimpleValue(int index) => this.inner.GetRawSimpleValue(index);
+
+    /// <inheritdoc />
+    public ReadOnlyMemory<byte> GetRawSimpleValueUnsafe(int index) => this.inner.GetRawSimpleValueUnsafe(index);
+
+    /// <inheritdoc />
+    public bool ValueIsEscaped(int index, bool isPropertyName) => this.inner.ValueIsEscaped(index, isPropertyName);
+
+    /// <inheritdoc />
+    public bool TextEquals(int index, ReadOnlySpan<char> otherText, bool isPropertyName) => this.inner.TextEquals(index, otherText, isPropertyName);
+
+    /// <inheritdoc />
+    public bool TextEquals(int index, ReadOnlySpan<byte> otherUtf8Text, bool isPropertyName, bool shouldUnescape) => this.inner.TextEquals(index, otherUtf8Text, isPropertyName, shouldUnescape);
+
+    /// <inheritdoc />
+    public void WriteElementTo(int index, Utf8JsonWriter writer) => this.inner.WriteElementTo(index, writer);
+
+    /// <inheritdoc />
+    public void WritePropertyName(int index, Utf8JsonWriter writer) => this.inner.WritePropertyName(index, writer);
+
+    /// <inheritdoc />
+    public JsonElement CloneElement(int index) => this.inner.CloneElement(index);
+
+    /// <inheritdoc />
+    public TElement CloneElement<TElement>(int index)
+        where TElement : struct, IJsonElement<TElement>
+        => this.Create<TElement>(index);
+
+    /// <inheritdoc />
+    public int GetDbSize(int index, bool includeEndElement) => this.inner.GetDbSize(index, includeEndElement);
+
+    /// <inheritdoc />
+    public bool TryFindNextDescendantPropertyValue(int elementIndex, ref int scanIndex, ReadOnlySpan<byte> utf8PropertyName, out int valueIndex)
+        => this.inner.TryFindNextDescendantPropertyValue(elementIndex, ref scanIndex, utf8PropertyName, out valueIndex);
+
+    /// <inheritdoc />
+    public int GetStartIndex(int endIndex) => this.inner.GetStartIndex(endIndex);
+
+    /// <inheritdoc />
+    public int BuildRentedMetadataDb(int parentDocumentIndex, JsonWorkspace workspace, out byte[] rentedBacking)
+        => this.inner.BuildRentedMetadataDb(parentDocumentIndex, workspace, out rentedBacking);
+
+    /// <inheritdoc />
+    public void AppendElementToMetadataDb(int index, JsonWorkspace workspace, ref MetadataDb db)
+        => this.inner.AppendElementToMetadataDb(index, workspace, ref db);
+
+    /// <inheritdoc />
+    public int WriteElementToMetadataDb(int index, JsonWorkspace workspace, ref MetadataDb db, int writePosition)
+        => this.inner.WriteElementToMetadataDb(index, workspace, ref db, writePosition);
+
+    /// <inheritdoc />
+    public bool TryResolveJsonPointer<TValue>(ReadOnlySpan<byte> jsonPointer, int index, out TValue value)
+        where TValue : struct, IJsonElement<TValue>
+        => this.inner.TryResolveJsonPointer(jsonPointer, index, out value);
+
+    /// <inheritdoc />
+    public bool TryFormat(int index, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? formatProvider)
+        => this.inner.TryFormat(index, destination, out charsWritten, format, formatProvider);
+
+    /// <inheritdoc />
+    public bool TryFormat(int index, Span<byte> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? formatProvider)
+        => this.inner.TryFormat(index, destination, out charsWritten, format, formatProvider);
+
+    /// <inheritdoc />
+    public string ToString(int index, string? format, IFormatProvider? formatProvider) => this.inner.ToString(index, format, formatProvider);
+
+    /// <inheritdoc />
+    public bool TryGetLineAndOffset(int index, out int line, out int charOffset, out long lineByteOffset)
+        => this.inner.TryGetLineAndOffset(index, out line, out charOffset, out lineByteOffset);
+
+    /// <inheritdoc />
+    public bool TryGetLineAndOffsetForPointer(ReadOnlySpan<byte> jsonPointer, int index, out int line, out int charOffset, out long lineByteOffset)
+        => this.inner.TryGetLineAndOffsetForPointer(jsonPointer, index, out line, out charOffset, out lineByteOffset);
+
+    /// <inheritdoc />
+    public bool TryGetLine(int lineNumber, out ReadOnlyMemory<byte> line) => this.inner.TryGetLine(lineNumber, out line);
+
+    /// <inheritdoc />
+    public bool TryGetLine(int lineNumber, [NotNullWhen(true)] out string? line) => this.inner.TryGetLine(lineNumber, out line);
+
+    /// <summary>
+    /// Does nothing: this facade does not own the wrapped document, so it must not dispose it.
+    /// </summary>
+    public void Dispose()
+    {
+        // No-op. This is purely a facade over an immutable document it does not own.
+    }
+
+    // ──────────────────────────────────────────────────────────────────────────
+    // IMutableJsonDocument mutators: a default value cannot be modified in place.
+    // ──────────────────────────────────────────────────────────────────────────
+
+    /// <inheritdoc />
+    public int StoreRawNumberValue(ReadOnlySpan<byte> value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StorePrebakedValue(ReadOnlySpan<byte> prebakedValue) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreNullValue() => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreBooleanValue(bool value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int EscapeAndStoreRawStringValue(ReadOnlySpan<char> value, out bool requiredEscaping) => throw Frozen();
+
+    /// <inheritdoc />
+    public int EscapeAndStoreRawStringValue(ReadOnlySpan<byte> value, out bool requiredEscaping) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreRawStringValue(ReadOnlySpan<byte> value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(Guid value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(in DateTime value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(in DateTimeOffset value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(in OffsetDateTime value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(in OffsetDate value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(in OffsetTime value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(in LocalDate value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(in Period value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(sbyte value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(byte value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(int value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(uint value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(long value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(ulong value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(short value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(ushort value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(float value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(double value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(decimal value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(in BigInteger value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(in BigNumber value) => throw Frozen();
+
+#if NET
+
+    /// <inheritdoc />
+    public int StoreValue(Int128 value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(UInt128 value) => throw Frozen();
+
+    /// <inheritdoc />
+    public int StoreValue(Half value) => throw Frozen();
+
+#endif
+
+    /// <inheritdoc />
+    public void RemoveRange(int complexObjectStartIndex, int startIndex, int endIndex, int membersToRemove) => throw Frozen();
+
+    /// <inheritdoc />
+    public void SetAndDispose(ref ComplexValueBuilder cvb) => throw Frozen();
+
+    /// <inheritdoc />
+    public void ReplaceRootAndDispose(ref ComplexValueBuilder cvb) => throw Frozen();
+
+    /// <inheritdoc />
+    public void InsertAndDispose(int complexObjectStartIndex, int index, ref ComplexValueBuilder cvb) => throw Frozen();
+
+    /// <inheritdoc />
+    public void OverwriteAndDispose(int complexObjectStartIndex, int startIndex, int endIndex, int membersToOverwrite, ref ComplexValueBuilder cvb) => throw Frozen();
+
+    /// <inheritdoc />
+    public void InsertSimpleValue(int complexObjectStartIndex, int targetIndex, int memberCount, JsonTokenType tokenType, int location, int sizeOrLength) => throw Frozen();
+
+    /// <inheritdoc />
+    public void OverwriteSimpleValue(int complexObjectStartIndex, int startIndex, int endIndex, int memberCountToReplace, JsonTokenType tokenType, int location, int sizeOrLength) => throw Frozen();
+
+    /// <inheritdoc />
+    public void InsertSimpleProperty(int complexObjectStartIndex, int targetIndex, int memberCount, ReadOnlySpan<byte> propertyName, JsonTokenType valueTokenType, int valueLocation, int valueSizeOrLength) => throw Frozen();
+
+    /// <inheritdoc />
+    public void InsertFromDocument(int complexObjectStartIndex, int targetIndex, int memberCount, IJsonDocument sourceDocument, int sourceIndex) => throw Frozen();
+
+    /// <inheritdoc />
+    public void OverwriteFromDocument(int complexObjectStartIndex, int startIndex, int endIndex, int memberCountToReplace, IJsonDocument sourceDocument, int sourceIndex) => throw Frozen();
+
+    /// <inheritdoc />
+    public void InsertPropertyFromDocument(int complexObjectStartIndex, int targetIndex, int memberCount, ReadOnlySpan<byte> propertyName, IJsonDocument sourceDocument, int sourceIndex) => throw Frozen();
+
+    /// <inheritdoc />
+    public bool TryReplacePropertyValue(int objectIndex, ReadOnlySpan<byte> propertyName, JsonTokenType tokenType, int location, int sizeOrLength) => throw Frozen();
+
+    /// <inheritdoc />
+    public bool TryReplacePropertyFromDocument(int objectIndex, ReadOnlySpan<byte> propertyName, IJsonDocument sourceDocument, int sourceIndex) => throw Frozen();
+
+    /// <inheritdoc />
+    public void CopyValueToProperty(int srcValueIndex, int dstObjectIndex, ReadOnlySpan<byte> propertyName) => throw Frozen();
+
+    /// <inheritdoc />
+    public void CopyValueToArrayIndex(int srcValueIndex, int dstArrayIndex, int itemIndex) => throw Frozen();
+
+    /// <inheritdoc />
+    public void CopyValueToArrayEnd(int srcValueIndex, int dstArrayIndex) => throw Frozen();
+
+    /// <inheritdoc />
+    public bool MovePropertyToProperty(int srcObjectIndex, ReadOnlySpan<byte> srcPropertyName, int dstObjectIndex, ReadOnlySpan<byte> dstPropertyName) => throw Frozen();
+
+    /// <inheritdoc />
+    public bool MovePropertyToArray(int srcObjectIndex, ReadOnlySpan<byte> srcPropertyName, int dstArrayIndex, int destIndex) => throw Frozen();
+
+    /// <inheritdoc />
+    public bool MovePropertyToArrayEnd(int srcObjectIndex, ReadOnlySpan<byte> srcPropertyName, int dstArrayIndex) => throw Frozen();
+
+    /// <inheritdoc />
+    public void MoveItemToArray(int srcArrayIndex, int srcIndex, int dstArrayIndex, int destIndex) => throw Frozen();
+
+    /// <inheritdoc />
+    public void MoveItemToArrayEnd(int srcArrayIndex, int srcIndex, int dstArrayIndex) => throw Frozen();
+
+    /// <inheritdoc />
+    public void MoveItemToProperty(int srcArrayIndex, int srcIndex, int dstObjectIndex, ReadOnlySpan<byte> destPropertyName) => throw Frozen();
+
+    // Builds an element at the given index backed by this facade (never by the inner immutable
+    // document), so that mutable child elements wrap an IMutableJsonDocument and nested reads and
+    // mutation attempts continue to flow through this default-value facade.
+    private TElement Create<TElement>(int index)
+        where TElement : struct, IJsonElement<TElement>
+#if NET
+        => TElement.CreateInstance(this, index);
+#else
+        => JsonElementHelpers.CreateInstance<TElement>(this, index);
+#endif
+
+    private static InvalidOperationException Frozen() => new(SR.CannotModifyADefaultValue);
+}

--- a/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/JsonDocumentBuilder.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/JsonDocumentBuilder.cs
@@ -2580,8 +2580,10 @@ public sealed partial class JsonDocumentBuilder<T> : JsonDocument, IMutableJsonD
     /// <inheritdoc />
     void IJsonDocument.AppendElementToMetadataDb(int index, JsonWorkspace workspace, ref MetadataDb db)
     {
+        // Copying an element out of this document into another document's metadata DB only
+        // reads from this document, so it is permitted even when this document is frozen
+        // (immutable). See issue #809.
         CheckNotDisposed();
-        CheckNotImmutable();
 
         int workspaceDocumentIndex = workspace.GetDocumentIndex(this);
         AppendElement(index, workspace, ref db, workspaceDocumentIndex);
@@ -2590,8 +2592,9 @@ public sealed partial class JsonDocumentBuilder<T> : JsonDocument, IMutableJsonD
     /// <inheritdoc />
     int IJsonDocument.WriteElementToMetadataDb(int index, JsonWorkspace workspace, ref MetadataDb db, int writePosition)
     {
+        // As with AppendElementToMetadataDb, this is a read-only copy out of this document
+        // and is permitted on a frozen (immutable) document. See issue #809.
         CheckNotDisposed();
-        CheckNotImmutable();
 
         int workspaceDocumentIndex = workspace.GetDocumentIndex(this);
         return WriteElementAt(index, workspace, ref db, workspaceDocumentIndex, writePosition);

--- a/src/Corvus.Text.Json/Corvus/Text/Json/Internal/JsonElementHelpers.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/Internal/JsonElementHelpers.cs
@@ -29,6 +29,32 @@ namespace Corvus.Text.Json.Internal;
 public static partial class JsonElementHelpers
 {
     /// <summary>
+    /// Creates a read-only mutable element that surfaces a schema <c>default</c> value through the
+    /// mutable view (issue #811), without copying the underlying data.
+    /// </summary>
+    /// <typeparam name="TImmutable">The immutable element type that holds the default value.</typeparam>
+    /// <typeparam name="TMutable">The corresponding mutable element type to return.</typeparam>
+    /// <param name="immutableDefault">The immutable default instance to surface.</param>
+    /// <returns>
+    /// A <typeparamref name="TMutable"/> backed by a <see cref="DefaultValueJsonDocument"/> facade over the
+    /// immutable default's document. Reads return the default value; any attempt to mutate it throws an
+    /// <see cref="InvalidOperationException"/> directing the caller to set the value on its parent first.
+    /// </returns>
+    [CLSCompliant(false)]
+    public static TMutable CreateDefaultValueElement<TImmutable, TMutable>(in TImmutable immutableDefault)
+        where TImmutable : struct, IJsonElement<TImmutable>
+        where TMutable : struct, IMutableJsonElement<TMutable>
+    {
+        var facade = new DefaultValueJsonDocument(immutableDefault.ParentDocument);
+        int index = immutableDefault.ParentDocumentIndex;
+#if NET
+        return TMutable.CreateInstance(facade, index);
+#else
+        return CreateInstance<TMutable>(facade, index);
+#endif
+    }
+
+    /// <summary>
     /// Sets a property value on a target element.
     /// </summary>
     /// <typeparam name="TTarget">The type of the target element.</typeparam>

--- a/src/Corvus.Text.Json/Resources/Strings.resx
+++ b/src/Corvus.Text.Json/Resources/Strings.resx
@@ -465,6 +465,9 @@
   <data name="CannotModifyAnImmutableDocument" xml:space="preserve">
     <value>You cannot modify an immutable document.</value>
   </data>
+  <data name="CannotModifyADefaultValue" xml:space="preserve">
+    <value>You cannot modify a default value. Set this value on its parent (for example using the corresponding Set... method) before modifying it.</value>
+  </data>
   <data name="CannotCreateBuilderFromMutableDocument" xml:space="preserve">
     <value>You cannot create a mutable copy of a mutable document. Consider calling Freeze() on the source document.</value>
   </data>

--- a/tests/Corvus.Text.Json.CodeGenerator.Tests/InProcessGenerationTests.cs
+++ b/tests/Corvus.Text.Json.CodeGenerator.Tests/InProcessGenerationTests.cs
@@ -381,6 +381,147 @@ public class InProcessGenerationTests
         StringAssert.Contains(ex.Message, "Circular schema reference");
     }
 
+    // ── Issue #812: discriminated-union constituent-builder Source wiring ──────────────────────
+    // The constituent object-builder Source wiring (a "<Constituent>BuilderInstance" backing field
+    // and matching Kind cases) is normally suppressed when the parent has its own properties. It is
+    // re-enabled for a discriminated union (a oneOf whose branches all carry a required const
+    // discriminator and whose parent requires nothing else). These tests cover the detection branches.
+
+    private const string DiscriminatedUnionDefs = """
+        ,
+        "$defs": {
+          "circle": {
+            "title": "Circle",
+            "type": "object",
+            "required": [ "kind", "radius" ],
+            "properties": { "kind": { "const": "Circle" }, "radius": { "type": "number" } }
+          },
+          "rectangle": {
+            "title": "Rectangle",
+            "type": "object",
+            "required": [ "kind", "width", "height" ],
+            "properties": { "kind": { "const": "Rectangle" }, "width": { "type": "number" }, "height": { "type": "number" } }
+          }
+        }
+        """;
+
+    [TestMethod]
+    public async Task GenerateCode_DiscriminatedUnion_EnablesConstituentBuilderWiring()
+    {
+        string schema = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "title": "Shape",
+              "type": "object",
+              "required": [ "kind" ],
+              "properties": { "kind": { "type": "string", "enum": [ "Circle", "Rectangle" ] } },
+              "oneOf": [ { "$ref": "#/$defs/circle" }, { "$ref": "#/$defs/rectangle" } ]
+            """.TrimEnd().TrimEnd('}') + DiscriminatedUnionDefs + "\n}";
+
+        await AssertConstituentBuilderWiring(schema, expectedPresent: true);
+    }
+
+    [TestMethod]
+    public async Task GenerateCode_DiscriminatedUnion_WithNonStructuralKeywords_StillEnabled()
+    {
+        // Non-structural keywords (title/description/$comment/examples/deprecated/readOnly) on the
+        // base schema must NOT disqualify the discriminated union (they are INonStructuralKeyword).
+        string schema = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "title": "Shape",
+              "description": "A shape that is either a circle or a rectangle.",
+              "$comment": "Authoring note: discriminated by kind.",
+              "examples": [ { "kind": "Circle", "radius": 1 } ],
+              "deprecated": false,
+              "readOnly": false,
+              "type": "object",
+              "required": [ "kind" ],
+              "properties": { "kind": { "type": "string", "enum": [ "Circle", "Rectangle" ] } },
+              "oneOf": [ { "$ref": "#/$defs/circle" }, { "$ref": "#/$defs/rectangle" } ]
+            """.TrimEnd().TrimEnd('}') + DiscriminatedUnionDefs + "\n}";
+
+        await AssertConstituentBuilderWiring(schema, expectedPresent: true);
+    }
+
+    [TestMethod]
+    public async Task GenerateCode_OneOf_WithExtraRequiredProperty_DoesNotEnableWiring()
+    {
+        // The parent requires a structural property ("color") that the branches do not carry, so a
+        // constituent build would be incomplete: the wiring must stay suppressed.
+        string schema = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "title": "Shape",
+              "type": "object",
+              "required": [ "kind", "color" ],
+              "properties": {
+                "kind": { "type": "string", "enum": [ "Circle", "Rectangle" ] },
+                "color": { "type": "string" }
+              },
+              "oneOf": [ { "$ref": "#/$defs/circle" }, { "$ref": "#/$defs/rectangle" } ]
+            """.TrimEnd().TrimEnd('}') + DiscriminatedUnionDefs + "\n}";
+
+        await AssertConstituentBuilderWiring(schema, expectedPresent: false);
+    }
+
+    [TestMethod]
+    public async Task GenerateCode_OneOf_WithoutConstDiscriminator_DoesNotEnableWiring()
+    {
+        // The parent has its own property but the branches have no required const discriminator, so
+        // there is no discriminator guaranteeing a valid parent: the wiring must stay suppressed.
+        string schema = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "title": "Shape",
+              "type": "object",
+              "required": [ "id" ],
+              "properties": { "id": { "type": "string" } },
+              "oneOf": [
+                { "title": "Circle", "type": "object", "properties": { "radius": { "type": "number" } } },
+                { "title": "Rectangle", "type": "object", "properties": { "width": { "type": "number" } } }
+              ]
+            }
+            """;
+
+        await AssertConstituentBuilderWiring(schema, expectedPresent: false);
+    }
+
+    [TestMethod]
+    public async Task GenerateCode_AnyOf_WithProperties_DoesNotEnableOneOfWiring()
+    {
+        // The detection only relaxes for oneOf; an anyOf parent with its own properties is not
+        // treated as a oneOf discriminated union (covers the no-oneOf branch).
+        string schema = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "title": "Shape",
+              "type": "object",
+              "required": [ "kind" ],
+              "properties": { "kind": { "type": "string", "enum": [ "Circle", "Rectangle" ] } },
+              "anyOf": [ { "$ref": "#/$defs/circle" }, { "$ref": "#/$defs/rectangle" } ]
+            """.TrimEnd().TrimEnd('}') + DiscriminatedUnionDefs + "\n}";
+
+        await AssertConstituentBuilderWiring(schema, expectedPresent: false);
+    }
+
+    private static async Task AssertConstituentBuilderWiring(string schemaContent, bool expectedPresent)
+    {
+        IReadOnlyCollection<GeneratedCodeFile> files = await GenerateInProcessFromContent(schemaContent);
+        string allCode = string.Join("\n", files.Select(f => f.FileContent));
+
+        // "BuilderInstance" appears only as the backing field for a composed constituent builder in
+        // a parent Source (the parent's own object builder field is "_objectBuilder").
+        bool present = allCode.Contains("BuilderInstance");
+
+        Assert.AreEqual(
+            expectedPresent,
+            present,
+            expectedPresent
+                ? "Expected constituent-builder Source wiring for the discriminated union."
+                : "Did not expect constituent-builder Source wiring for this schema.");
+    }
+
     [TestMethod]
     public async Task GenerateCode_BothMode_ProducesMoreOrEqualFiles()
     {

--- a/tests/Corvus.Text.Json.CodeGenerator.Tests/InProcessGenerationTests.cs
+++ b/tests/Corvus.Text.Json.CodeGenerator.Tests/InProcessGenerationTests.cs
@@ -335,6 +335,53 @@ public class InProcessGenerationTests
     }
 
     [TestMethod]
+    public async Task GenerateCode_CircularOneOfRefs_FailsWithSchemaLocations()
+    {
+        // Issue #810: a discriminated union whose oneOf branches $ref back to the union has a
+        // circular (same-instance) composition. The branches' Evaluate would recurse forever, so
+        // generating Match/TryGetAs that call Evaluate caused a runtime stack overflow. The
+        // generator must instead detect the cycle and fail generation, naming the source and
+        // target schema locations of the recursion.
+        string schemaContent = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "$ref": "#/$defs/miniUnion",
+              "$defs": {
+                "miniUnion": {
+                  "title": "MiniUnion",
+                  "type": "object",
+                  "required": [ "kind" ],
+                  "properties": { "kind": { "type": "string", "enum": [ "LeafA", "LeafB" ] } },
+                  "oneOf": [ { "$ref": "#/$defs/miniLeafA" }, { "$ref": "#/$defs/miniLeafB" } ]
+                },
+                "miniLeafA": {
+                  "title": "MiniLeafA",
+                  "$ref": "#/$defs/miniUnion",
+                  "required": [ "a" ],
+                  "properties": { "kind": { "const": "LeafA" }, "a": { "type": "integer" } }
+                },
+                "miniLeafB": {
+                  "title": "MiniLeafB",
+                  "$ref": "#/$defs/miniUnion",
+                  "required": [ "b" ],
+                  "properties": { "kind": { "const": "LeafB" }, "b": { "type": "integer" } }
+                }
+              }
+            }
+            """;
+
+        CircularSchemaReferenceException ex = await Assert.ThrowsExactlyAsync<CircularSchemaReferenceException>(
+            () => GenerateInProcessFromContent(schemaContent));
+
+        // The error must name the source and target schema locations of the recursion (the cycle
+        // runs miniUnion <-> miniLeaf; either edge direction is a valid report).
+        string locations = ex.ReferencingLocation + "|" + ex.ReferencedLocation;
+        StringAssert.Contains(locations, "miniUnion");
+        StringAssert.Contains(locations, "miniLeaf");
+        StringAssert.Contains(ex.Message, "Circular schema reference");
+    }
+
+    [TestMethod]
     public async Task GenerateCode_BothMode_ProducesMoreOrEqualFiles()
     {
         string schemaPath = Path.Combine(SchemasDir, "numeric-and-format.json");

--- a/tests/Corvus.Text.Json.Patch.Tests/JsonDiffFrozenBuilderTests.cs
+++ b/tests/Corvus.Text.Json.Patch.Tests/JsonDiffFrozenBuilderTests.cs
@@ -1,0 +1,71 @@
+// <copyright file="JsonDiffFrozenBuilderTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using Corvus.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.Patch.Tests;
+
+/// <summary>
+/// Regression tests for issue #809: creating a patch from <em>frozen</em> elements that
+/// originate from a <see cref="JsonDocumentBuilder{T}"/> threw
+/// "You cannot modify an immutable document". Copying an element out of an immutable
+/// source document is a read-only operation and must be allowed.
+/// </summary>
+[TestClass]
+public class JsonDiffFrozenBuilderTests
+{
+    [TestMethod]
+    public void CreatePatchFromFrozenBuilderTargets()
+    {
+        using JsonWorkspace ws = JsonWorkspace.Create();
+
+        using JsonDocumentBuilder<JsonElement.Mutable> sourceBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(ws, """{"a":1}""");
+        JsonElement source = sourceBuilder.RootElement.Freeze();
+
+        using JsonDocumentBuilder<JsonElement.Mutable> targetBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(ws, """{"a":1,"b":2}""");
+        JsonElement target = targetBuilder.RootElement.Freeze();
+
+        // Before the fix this threw InvalidOperationException: "You cannot modify an immutable document."
+        JsonPatchDocument patch = JsonDiffExtensions.CreatePatch(source, target, ws);
+
+        int count = 0;
+        foreach (JsonPatchDocument.PatchOperation op in patch.EnumerateArray())
+        {
+            _ = op;
+            count++;
+        }
+
+        Assert.AreEqual(1, count, "Adding property 'b' should produce a single 'add' operation.");
+    }
+
+    [TestMethod]
+    public void CreatePatchFromFrozenBuilderRoundTrips()
+    {
+        const string sourceJson = """{"name":"Alice","scores":[1,2,3],"nested":{"x":1}}""";
+        const string targetJson = """{"name":"Bob","scores":[1,2,3,4],"nested":{"x":2},"added":true}""";
+
+        using JsonWorkspace ws = JsonWorkspace.Create();
+
+        using JsonDocumentBuilder<JsonElement.Mutable> sourceBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(ws, sourceJson);
+        JsonElement source = sourceBuilder.RootElement.Freeze();
+
+        using JsonDocumentBuilder<JsonElement.Mutable> targetBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(ws, targetJson);
+        JsonElement target = targetBuilder.RootElement.Freeze();
+
+        JsonPatchDocument patch = JsonDiffExtensions.CreatePatch(source, target, ws);
+
+        // Apply the patch to a mutable copy of the source and confirm we reach the target.
+        using JsonDocumentBuilder<JsonElement.Mutable> applyBuilder = source.CreateBuilder(ws);
+        JsonElement.Mutable mutable = applyBuilder.RootElement;
+        Assert.IsTrue(mutable.TryApplyPatch(patch), "Patch application should succeed.");
+
+        using ParsedJsonDocument<JsonElement> expected = ParsedJsonDocument<JsonElement>.Parse(targetJson);
+        Assert.AreEqual(expected.RootElement, mutable.Clone());
+    }
+}

--- a/tests/Corvus.Text.Json.Tests.GeneratedModels.NullOrUndefinedExceptNonNullDefaulted/Corvus.Text.Json.Tests.GeneratedModels.NullOrUndefinedExceptNonNullDefaulted.csproj
+++ b/tests/Corvus.Text.Json.Tests.GeneratedModels.NullOrUndefinedExceptNonNullDefaulted/Corvus.Text.Json.Tests.GeneratedModels.NullOrUndefinedExceptNonNullDefaulted.csproj
@@ -17,6 +17,7 @@
 
   <ItemGroup>
     <AdditionalFiles Include="object-with-default-properties-2020-12.json" />
+    <AdditionalFiles Include="object-with-default-array-2020-12.json" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Corvus.Text.Json.Tests.GeneratedModels.NullOrUndefinedExceptNonNullDefaulted/ObjectWithDefaultArray.cs
+++ b/tests/Corvus.Text.Json.Tests.GeneratedModels.NullOrUndefinedExceptNonNullDefaulted/ObjectWithDefaultArray.cs
@@ -1,0 +1,6 @@
+namespace Corvus.Text.Json.Tests.GeneratedModels.NullOrUndefinedExceptNonNullDefaulted.Draft202012;
+
+[JsonSchemaTypeGenerator("./object-with-default-array-2020-12.json")]
+public readonly partial struct ObjectWithDefaultArray
+{
+}

--- a/tests/Corvus.Text.Json.Tests.GeneratedModels.NullOrUndefinedExceptNonNullDefaulted/object-with-default-array-2020-12.json
+++ b/tests/Corvus.Text.Json.Tests.GeneratedModels.NullOrUndefinedExceptNonNullDefaulted/object-with-default-array-2020-12.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "type": "object",
+    "properties": {
+        "values": {
+            "type": "array",
+            "items": {
+                "type": "integer"
+            },
+            "default": [1]
+        }
+    }
+}

--- a/tests/Corvus.Text.Json.Tests.GeneratedModels/Corvus.Text.Json.Tests.GeneratedModels.csproj
+++ b/tests/Corvus.Text.Json.Tests.GeneratedModels/Corvus.Text.Json.Tests.GeneratedModels.csproj
@@ -12,6 +12,8 @@
 
   <ItemGroup>
     <AdditionalFiles Include="format-types-2020-12.json" />
+    <AdditionalFiles Include="shape-discriminated-2020-12.json" />
+    <AdditionalFiles Include="shape-holder-2020-12.json" />
     <AdditionalFiles Include="object-with-mixed-properties-2020-12.json" />
     <AdditionalFiles Include="nested-object-2020-12.json" />
     <AdditionalFiles Include="context-named-property-2020-12.json" />

--- a/tests/Corvus.Text.Json.Tests.GeneratedModels/ShapeDiscriminated.cs
+++ b/tests/Corvus.Text.Json.Tests.GeneratedModels/ShapeDiscriminated.cs
@@ -1,0 +1,6 @@
+namespace Corvus.Text.Json.Tests.GeneratedModels.Draft202012;
+
+[JsonSchemaTypeGenerator("./shape-discriminated-2020-12.json")]
+public readonly partial struct Shape
+{
+}

--- a/tests/Corvus.Text.Json.Tests.GeneratedModels/ShapeHolder.cs
+++ b/tests/Corvus.Text.Json.Tests.GeneratedModels/ShapeHolder.cs
@@ -1,0 +1,6 @@
+namespace Corvus.Text.Json.Tests.GeneratedModels.Draft202012;
+
+[JsonSchemaTypeGenerator("./shape-holder-2020-12.json")]
+public readonly partial struct ShapeHolder
+{
+}

--- a/tests/Corvus.Text.Json.Tests.GeneratedModels/shape-discriminated-2020-12.json
+++ b/tests/Corvus.Text.Json.Tests.GeneratedModels/shape-discriminated-2020-12.json
@@ -1,0 +1,37 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "Shape",
+    "type": "object",
+    "required": [ "kind" ],
+    "properties": {
+        "kind": {
+            "type": "string",
+            "enum": [ "Circle", "Rectangle" ]
+        }
+    },
+    "oneOf": [
+        { "$ref": "#/$defs/circle" },
+        { "$ref": "#/$defs/rectangle" }
+    ],
+    "$defs": {
+        "circle": {
+            "title": "Circle",
+            "type": "object",
+            "required": [ "kind", "radius" ],
+            "properties": {
+                "kind": { "const": "Circle" },
+                "radius": { "type": "number" }
+            }
+        },
+        "rectangle": {
+            "title": "Rectangle",
+            "type": "object",
+            "required": [ "kind", "width", "height" ],
+            "properties": {
+                "kind": { "const": "Rectangle" },
+                "width": { "type": "number" },
+                "height": { "type": "number" }
+            }
+        }
+    }
+}

--- a/tests/Corvus.Text.Json.Tests.GeneratedModels/shape-holder-2020-12.json
+++ b/tests/Corvus.Text.Json.Tests.GeneratedModels/shape-holder-2020-12.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "title": "ShapeHolder",
+    "type": "object",
+    "required": [ "shape" ],
+    "properties": {
+        "shape": { "$ref": "#/$defs/shape" }
+    },
+    "$defs": {
+        "shape": {
+            "title": "HeldShape",
+            "type": "object",
+            "required": [ "kind" ],
+            "properties": {
+                "kind": {
+                    "type": "string",
+                    "enum": [ "Circle", "Rectangle" ]
+                }
+            },
+            "oneOf": [
+                { "$ref": "#/$defs/circle" },
+                { "$ref": "#/$defs/rectangle" }
+            ]
+        },
+        "circle": {
+            "title": "HeldCircle",
+            "type": "object",
+            "required": [ "kind", "radius" ],
+            "properties": {
+                "kind": { "const": "Circle" },
+                "radius": { "type": "number" }
+            }
+        },
+        "rectangle": {
+            "title": "HeldRectangle",
+            "type": "object",
+            "required": [ "kind", "width", "height" ],
+            "properties": {
+                "kind": { "const": "Rectangle" },
+                "width": { "type": "number" },
+                "height": { "type": "number" }
+            }
+        }
+    }
+}

--- a/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
+++ b/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
@@ -162,6 +162,7 @@
     <Compile Include="GeneratedMixedCompositionTests.cs" />
     <Compile Include="GeneratedNullableOptionalTests.cs" />
     <Compile Include="GeneratedNonNullDefaultedTests.cs" />
+    <Compile Include="DiscriminatedUnionConversionTests.cs" />
     <Compile Include="GeneratedV4NonNullDefaultedTests.cs" />
     <Compile Include="GeneratedTupleArrayTests.cs" />
     <Compile Include="GeneratedComposedTupleTests.cs" />

--- a/tests/Corvus.Text.Json.Tests/DiscriminatedUnionConversionTests.cs
+++ b/tests/Corvus.Text.Json.Tests/DiscriminatedUnionConversionTests.cs
@@ -67,4 +67,26 @@ public class DiscriminatedUnionConversionTests
         Assert.IsTrue(shape.TryGetAsCircle(out ShapeHolder.Circle built));
         Assert.AreEqual(2.5, (double)built.Radius);
     }
+
+    [TestMethod]
+    public void Constituent_BuiltInline_FlowsIntoContainingTypeBuild()
+    {
+        // Issue #812: build a branch with Circle.Build(...) and pass the result straight into a
+        // containing type's CreateBuilder for the union property, with no intermediate document.
+        using JsonWorkspace ws = JsonWorkspace.Create();
+
+        using JsonDocumentBuilder<ShapeHolder.Mutable> holderBuilder = ShapeHolder.CreateBuilder(
+            ws,
+            ShapeHolder.Circle.Build(static (ref ShapeHolder.Circle.Builder b) =>
+            {
+                b.AddProperty("kind"u8, "Circle"u8);
+                b.AddProperty("radius"u8, 2.5);
+            }));
+        ShapeHolder.Mutable holder = holderBuilder.RootElement;
+
+        ShapeHolder.Shape shape = holder.ShapeValue;
+        Assert.AreEqual("Circle", (string)shape.Kind);
+        Assert.IsTrue(shape.TryGetAsCircle(out ShapeHolder.Circle built));
+        Assert.AreEqual(2.5, (double)built.Radius);
+    }
 }

--- a/tests/Corvus.Text.Json.Tests/DiscriminatedUnionConversionTests.cs
+++ b/tests/Corvus.Text.Json.Tests/DiscriminatedUnionConversionTests.cs
@@ -1,0 +1,70 @@
+// Copyright (c) Matthew Adams. All rights reserved.
+// Licensed under the Apache-2.0 license.
+
+using Corvus.Text.Json.Tests.GeneratedModels.Draft202012;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.Tests;
+
+/// <summary>
+/// Tests for the discriminated-union conversions (issues #812 / #806): a composed branch's
+/// mutable view converts directly to the composing union type in a single implicit hop.
+/// </summary>
+[TestClass]
+public class DiscriminatedUnionConversionTests
+{
+    [TestMethod]
+    public void BranchMutable_ConvertsToUnion_InOneHop()
+    {
+        using JsonWorkspace ws = JsonWorkspace.Create();
+        using JsonDocumentBuilder<Shape.Circle.Mutable> builder =
+            JsonDocumentBuilder<Shape.Circle.Mutable>.Parse(ws, """{"kind":"Circle","radius":2.5}""");
+
+        Shape.Circle.Mutable circle = builder.RootElement;
+
+        // Before #812/#806 this required two hops (Circle.Mutable -> Circle -> Shape), which C#
+        // will not chain. The direct Circle.Mutable -> Shape conversion makes this a single hop.
+        Shape shape = circle;
+
+        Assert.AreEqual(JsonValueKind.Object, shape.ValueKind);
+        Assert.IsTrue(shape.TryGetAsCircle(out Shape.Circle asCircle));
+        Assert.AreEqual(2.5, (double)asCircle.Radius);
+    }
+
+    [TestMethod]
+    public void BranchMutable_PassedWhereUnionExpected()
+    {
+        using JsonWorkspace ws = JsonWorkspace.Create();
+        using JsonDocumentBuilder<Shape.Rectangle.Mutable> builder =
+            JsonDocumentBuilder<Shape.Rectangle.Mutable>.Parse(ws, """{"kind":"Rectangle","width":3,"height":4}""");
+
+        // The mutable branch flows straight into a method expecting the union, no intermediate.
+        string kind = DescribeShape(builder.RootElement);
+
+        Assert.AreEqual("Rectangle", kind);
+
+        static string DescribeShape(Shape shape) => (string)shape.Kind;
+    }
+
+    [TestMethod]
+    public void Constituent_FlowsIntoContainingTypeBuild()
+    {
+        // Issue #812: a discriminated-union branch can be passed directly where the union's Source
+        // is expected (here a containing type's CreateBuilder), so a containing structure can be
+        // built from a branch without first materialising the union. This exercises the
+        // constituent-builder Source wiring that is enabled for discriminated unions.
+        using JsonWorkspace ws = JsonWorkspace.Create();
+        using ParsedJsonDocument<ShapeHolder.Circle> circleDoc =
+            ParsedJsonDocument<ShapeHolder.Circle>.Parse("""{"kind":"Circle","radius":2.5}""");
+        ShapeHolder.Circle circle = circleDoc.RootElement;
+
+        // 'circle' converts implicitly to ShapeHolder.Shape.Source for the required 'shape' property.
+        using JsonDocumentBuilder<ShapeHolder.Mutable> holderBuilder = ShapeHolder.CreateBuilder(ws, circle);
+        ShapeHolder.Mutable holder = holderBuilder.RootElement;
+
+        ShapeHolder.Shape shape = holder.ShapeValue;
+        Assert.AreEqual("Circle", (string)shape.Kind);
+        Assert.IsTrue(shape.TryGetAsCircle(out ShapeHolder.Circle built));
+        Assert.AreEqual(2.5, (double)built.Radius);
+    }
+}

--- a/tests/Corvus.Text.Json.Tests/GeneratedNonNullDefaultedTests.cs
+++ b/tests/Corvus.Text.Json.Tests/GeneratedNonNullDefaultedTests.cs
@@ -193,16 +193,18 @@ public class GeneratedNonNullDefaultedTests
     }
 
     [TestMethod]
-    public void Mutable_NonNullDefault_Status_Absent_NotSynthesised()
+    public void Mutable_NonNullDefault_Status_Absent_ReturnsReadOnlyDefault()
     {
         using var workspace = JsonWorkspace.Create();
         using var doc = ParsedJsonDocument<ObjectWithDefaultProperties>.Parse("""{"name":"test"}""");
         using JsonDocumentBuilder<ObjectWithDefaultProperties.Mutable> builder = doc.RootElement.CreateBuilder(workspace);
 
-        // The mutable view does not synthesise the schema default for an absent property
-        // (the default is materialised on the immutable read), exercising the absent path.
+        // For an absent non-nullable defaulted property the mutable view returns the read-only
+        // default instance (issue #811): the value reads as the schema default, but the document
+        // itself is not mutated, so it is not synthesised into the stored JSON.
         ObjectWithDefaultProperties.Mutable root = builder.RootElement;
-        _ = root.Status;
+        ObjectWithDefaultProperties.StatusEntity.Mutable status = root.Status;
+        Assert.AreEqual("active", (string)status);
         Assert.IsFalse(root.ToString().Contains("status"));
     }
 
@@ -219,6 +221,74 @@ public class GeneratedNonNullDefaultedTests
 
         using var roundTrip = ParsedJsonDocument<ObjectWithDefaultProperties>.Parse(json);
         Assert.AreEqual("archived", (string)roundTrip.RootElement.Status);
+    }
+
+    #endregion
+
+    #region Issue #811 — defaulted array property in a mutable document
+
+    [TestMethod]
+    public void Immutable_NonNullDefault_Values_Absent_ReturnsDefaultArray()
+    {
+        using var doc = ParsedJsonDocument<ObjectWithDefaultArray>.Parse("""{}""");
+
+        ObjectWithDefaultArray.JsonIntegerArray values = doc.RootElement.Values;
+        Assert.AreEqual(1, values.GetArrayLength());
+        Assert.AreEqual(1, (int)values[0]);
+    }
+
+    [TestMethod]
+    public void Mutable_NonNullDefault_Values_Absent_ReadsDefaultWithoutThrowing()
+    {
+        // Issue #811: parsing "{}" into a builder and reading the absent, non-nullable defaulted
+        // array property previously returned an Undefined value, so GetArrayLength()/indexing
+        // threw InvalidOperationException ("Operation is not valid due to the current state of
+        // the object"). It must now return the read-only schema default instead.
+        using JsonWorkspace ws = JsonWorkspace.Create();
+        using JsonDocumentBuilder<ObjectWithDefaultArray.Mutable> builder =
+            JsonDocumentBuilder<ObjectWithDefaultArray.Mutable>.Parse(ws, """{}""");
+
+        ObjectWithDefaultArray.Mutable obj = builder.RootElement;
+
+        ObjectWithDefaultArray.JsonIntegerArray.Mutable values = obj.Values;
+        Assert.AreEqual(1, values.GetArrayLength());
+        Assert.AreEqual(1, (int)values[0]);
+
+        // The default is read-only (backed by a frozen document): the underlying document is
+        // not mutated by reading it.
+        Assert.IsFalse(obj.ToString().Contains("values"));
+    }
+
+    [TestMethod]
+    public void Mutable_NonNullDefault_Values_Absent_MutatingDefaultThrows()
+    {
+        // The read-only default is backed by a frozen document, so attempting to mutate it
+        // (rather than assigning a fresh value through SetValues) throws.
+        using JsonWorkspace ws = JsonWorkspace.Create();
+        using JsonDocumentBuilder<ObjectWithDefaultArray.Mutable> builder =
+            JsonDocumentBuilder<ObjectWithDefaultArray.Mutable>.Parse(ws, """{}""");
+
+        ObjectWithDefaultArray.Mutable obj = builder.RootElement;
+
+        InvalidOperationException ex = Assert.ThrowsExactly<InvalidOperationException>(() => obj.Values.AddItem(42));
+
+        // The message must be the indicative "default value" guidance, not the generic immutable error.
+        StringAssert.Contains(ex.Message, "default value");
+    }
+
+    [TestMethod]
+    public void Mutable_NonNullDefault_Values_Present_IsMutable()
+    {
+        // When the property is actually present it remains fully mutable.
+        using JsonWorkspace ws = JsonWorkspace.Create();
+        using JsonDocumentBuilder<ObjectWithDefaultArray.Mutable> builder =
+            JsonDocumentBuilder<ObjectWithDefaultArray.Mutable>.Parse(ws, """{"values":[1]}""");
+
+        ObjectWithDefaultArray.Mutable obj = builder.RootElement;
+        obj.Values.AddItem(42);
+
+        Assert.AreEqual(2, obj.Values.GetArrayLength());
+        Assert.IsTrue(obj.ToString().Contains("42"));
     }
 
     #endregion


### PR DESCRIPTION
This PR fixes three open bugs and implements one feature, each in its own commit.

## `fix(#809)`: `CreatePatch` with frozen `JsonDocumentBuilder` elements
`IJsonDocument.AppendElementToMetadataDb`/`WriteElementToMetadataDb` performed a `CheckNotImmutable()` even though they only copy data *out*. That made `CreatePatch` throw when either side was a frozen builder element. Removed the spurious immutability check (these paths are read-only copy-out).

- Test: `JsonDiffFrozenBuilderTests` — `CreatePatchFromFrozenBuilderTargets`, `CreatePatchFromFrozenBuilderRoundTrips`.

## `fix(#811)`: surface schema defaults through the mutable view
A non-null `default` was invisible through the mutable view, and attempting to read it could corrupt the pooled workspace. The mutable getter now returns a zero-copy **frozen facade** (`DefaultValueJsonDocument`) over the immutable default: reads forward to the inner document, child elements rebase onto the facade, and any mutation throws a clear `InvalidOperationException` instructing the caller to set the value on its parent first. `Dispose()` is a no-op (the facade owns no resources).

- Tests: `GeneratedNonNullDefaultedTests`, plus `ObjectWithDefaultArray` generated model.

## `fix(#810)`: fail generation on circular-composition schemas
A `oneOf`/`allOf`/`anyOf`/`$ref` cycle that evaluates against the *same instance* produced infinitely-recursive `Match()`/`TryGetAs` code. Rather than silently omitting the code, codegen now **detects the non-terminating composition cycle** and throws `CircularSchemaReferenceException` naming the referencing and referenced schema locations. The source generators surface this as diagnostic `CRV1002`. Data-driven recursion (through properties/items) is correctly **not** flagged — verified against the OpenAPI 3.0/3.1/3.2 and the v4 Draft 2020-12 metaschemas. Applies to both v5 and v4.

- Test: `GenerateCode_CircularOneOfRefs_FailsWithSchemaLocations`.

## `feat(#812)`: create discriminated unions from a constituent
A discriminated union (`oneOf` whose branches carry a required `const` discriminator, with no further required structure on the base) can now be **constructed from one of its branches**:

- A branch's mutable view converts to the union in a **single implicit hop** (`Circle.Mutable -> Shape`), so a branch flows wherever the union is expected.
- The union's builder `Source` accepts a branch by value, so a built branch can be passed straight into a containing type's `CreateBuilder` for a union-typed property — e.g. `ShapeHolder.CreateBuilder(ws, Circle.Build(...))` — with no intermediate document.
- Detection is precise: extra required properties on the base, a missing/non-required `const`, or an `anyOf` (rather than `oneOf`) do **not** enable the wiring; additional `INonStructuralKeyword`s (e.g. `title`, `description`) on the base still **do**.

- Tests: `DiscriminatedUnionConversionTests` (conversions + containing-type build), plus codegen-detection tests in `InProcessGenerationTests` covering the positive and negative gating cases.
- Docs/playground: `docs/JsonDocumentBuilder.md` gains a "Creating Discriminated Unions" section, and example recipe `013-PolymorphismWithDiscriminators` demonstrates branch-based creation (its `Program.cs` is embedded as a playground sample).

Full v5 suite green at 32,068 tests; OpenAPI 3.0/3.1/3.2 and the v4 metaschema generate cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)