### PR TITLE
Fix #820: refresh stale parent handle during nested merge patch

### DIFF
--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,17 @@
 # Version History
 
+## V5.1.17
+
+V5.1.17 fixes an RFC 7396 JSON Merge Patch bug where merging a nested object corrupted the parent element handle.
+
+### Bug fixes
+
+- **`ApplyMergePatch` no longer leaves the parent element stale when merging a nested object** — When a merge patch recursed into a nested object (`JsonMergePatchExtensions.ApplyMergePatch`), the recursion mutated the document but the parent `JsonElement.Mutable` it was iterating kept its now-stale cached document version. Processing any further property of that same (non-root) parent then failed its staleness check, and a frozen patch document copied into the merge could appear disposed on a subsequent read — surfacing as `InvalidOperationException` ("Operation is not valid due to the current state of the object") during the merge or `ObjectDisposedException: 'JsonDocument'` when the patch was read afterwards. Because a recursive merge only mutates the child's own subtree, the parent element's start index is still valid; the merge now re-mints the parent handle with the current version after each nested merge so subsequent siblings and reads succeed. Simple single-property-per-level merges were unaffected, which is why the existing RFC 7396 suite did not catch it. See [#820](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/820).
+
+### New features
+
+- **`JsonMarshal.RefreshUnsafe<T>(in T)`** — Returns a fresh handle to a mutable JSON element whose cached document version is brought up to date with its parent document's current version, without re-validating the element's position. This is a deliberately **dangerous** marshalling helper: it must only be called when the caller knows the element's start index is still valid — i.e. the document has been mutated only *within that element's own subtree* (descendant nodes). It backs the RFC 7396 merge-patch fix above, where a recursive merge into a child object leaves the (structurally still valid) parent element version-stale. See [#820](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/820).
+
 ## V5.1.16
 
 V5.1.16 fixes schema reference resolution for `$ref`s expressed as `file://` URIs.

--- a/docs/JsonDocumentBuilder.md
+++ b/docs/JsonDocumentBuilder.md
@@ -1366,6 +1366,35 @@ Version tracking is a **safety feature** that prevents bugs caused by:
 
 Without version tracking, you could silently access incorrect data or crash with memory corruption. The `InvalidOperationException` is intentional and helps you write correct code. The root element exemption is safe because the root is always at index 0 and is never relocated.
 
+### Refreshing a stale reference without re-navigating (`JsonMarshal.RefreshUnsafe`) — advanced
+
+> ⚠️ **`JsonMarshal.RefreshUnsafe<T>` is a deliberately unsafe, high-performance escape hatch.** It is **only** for use where you *know* your changes cannot have altered the element's index in its parent document. Reach for it only in allocation- and lookup-sensitive code where you can *prove* the rule below holds. The safe, idiomatic option is always to re-navigate from the root (see [Best Practices](#best-practices-for-version-tracking)).
+
+There is one common case where re-navigating from the root is wasteful: you hold a cached *intermediate* element and then mutate **only inside that element's own subtree** (a descendant property or item). The mutation bumps the document version, so your cached handle is now version-stale — but the element itself has **not** moved: every descendant lives at a higher index than the element's own start row, so that start row is unchanged. Re-navigating from the root to find it again would be pure overhead.
+
+`Corvus.Runtime.InteropServices.JsonMarshal.RefreshUnsafe<T>(in T element)` takes such an element and returns a fresh handle to the *same* element, stamped with the document's current version — no lookup, no allocation:
+
+```csharp
+using Corvus.Runtime.InteropServices;
+
+JsonElement.Mutable root = doc.RootElement;
+JsonElement.Mutable order = root.GetProperty("order"u8);
+
+// Mutate only WITHIN 'order' (a descendant). This bumps the version, so 'order' is now stale,
+// but 'order' itself has not moved — only its subtree grew.
+order.GetProperty("lines"u8).SetProperty("count"u8, 3);
+
+// Refresh the handle in place instead of re-navigating from the root.
+order = JsonMarshal.RefreshUnsafe(in order);
+
+// 'order' is usable again.
+order.SetProperty("status"u8, "packed"u8);
+```
+
+This is exactly how RFC 7396 merge-patch application (`JsonMergePatchExtensions.ApplyMergePatch`) keeps the parent object live while recursively merging into its children.
+
+**The contract you must guarantee.** Use `RefreshUnsafe` **only where you know your changes cannot have modified the element's index in the parent document** — i.e. the document has been mutated **solely within the refreshed element's own subtree**, never at or before the element's position (the node itself replaced, an ancestor, or a *preceding sibling* changing size). If anything at or before the element moved, its start index is no longer valid and `RefreshUnsafe` returns a handle that **silently addresses the wrong node** — the very memory-corruption class that version tracking exists to prevent. `RefreshUnsafe` only checks for document disposal, never the correctness of the position, so it cannot catch this for you. When in doubt, re-navigate from the (always-live) root instead.
+
 ## Comparison with System.Text.Json.Nodes
 
 ### Similar Capabilities

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -967,11 +967,12 @@ main-docs:
       - {index: 38, language: csharp, lines: [1331, 1337], category: compilable, verified: false}
       - {index: 39, language: csharp, lines: [1340, 1348], category: compilable, verified: false}
       - {index: 40, language: csharp, lines: [1351, 1358], category: compilable, verified: false}
-      - {index: 41, language: csharp, lines: [1401, 1407], category: compilable, verified: false}
-      - {index: 42, language: csharp, lines: [1410, 1417], category: compilable, verified: false}
-      - {index: 43, language: csharp, lines: [1441, 1445], category: compilable, verified: false}
-      - {index: 44, language: csharp, lines: [1448, 1452], category: compilable, verified: false}
-      - {index: 45, language: csharp, lines: [1455, 1459], category: compilable, verified: false}
+      - {index: 41, language: csharp, lines: [1377, 1392], category: compilable, verified: false}
+      - {index: 42, language: csharp, lines: [1430, 1436], category: compilable, verified: false}
+      - {index: 43, language: csharp, lines: [1439, 1446], category: compilable, verified: false}
+      - {index: 44, language: csharp, lines: [1470, 1474], category: compilable, verified: false}
+      - {index: 45, language: csharp, lines: [1477, 1481], category: compilable, verified: false}
+      - {index: 46, language: csharp, lines: [1484, 1488], category: compilable, verified: false}
   - path: "docs/JsonLogic.md"
     blocks:
       - {index: 0, language: bash, lines: [29, 32]}

--- a/src/Corvus.Text.Json.Patch/JsonMergePatchExtensions.cs
+++ b/src/Corvus.Text.Json.Patch/JsonMergePatchExtensions.cs
@@ -2,6 +2,7 @@
 // Copyright (c) Endjin Limited. All rights reserved.
 // </copyright>
 
+using Corvus.Runtime.InteropServices;
 using Corvus.Text.Json.Internal;
 
 namespace Corvus.Text.Json.Patch;
@@ -65,6 +66,12 @@ public static class JsonMergePatchExtensions
                 }
 
                 ApplyMergePatch(ref child, in patchValue);
+
+                // The recursive merge mutated only `child`'s subtree, so `target`'s start index is
+                // still valid, but its cached document version is now stale. Mint a fresh handle for
+                // the same element so the next property's staleness check — and any read of `target`
+                // after this method returns — succeeds.
+                target = JsonMarshal.RefreshUnsafe(in target);
             }
             else
             {

--- a/src/Corvus.Text.Json/Corvus/Runtime/InteropServices/JsonMarshal.cs
+++ b/src/Corvus.Text.Json/Corvus/Runtime/InteropServices/JsonMarshal.cs
@@ -87,4 +87,45 @@ public static class JsonMarshal
         element.CheckValidInstance();
         return element.ParentDocument.GetRawValue(element.ParentDocumentIndex, includeQuotes: true);
     }
+
+    /// <summary>
+    /// Returns a fresh handle to a mutable JSON element whose cached document version is brought up to
+    /// date with the parent document's current version, <strong>without</strong> re-validating the
+    /// element's position.
+    /// </summary>
+    /// <typeparam name="T">The type of the mutable <see cref="IJsonElement"/>.</typeparam>
+    /// <param name="element">The mutable element to refresh.</param>
+    /// <returns>A new <typeparamref name="T"/> for the same element, stamped with the parent document's
+    /// current version.</returns>
+    /// <exception cref="ObjectDisposedException">The underlying <see cref="JsonDocument"/> has been disposed.</exception>
+    /// <remarks>
+    /// <para>
+    /// This is a <strong>dangerous</strong>, high-performance helper. It is <strong>only</strong> safe
+    /// to call when you know that your mutations cannot have changed <paramref name="element"/>'s index
+    /// in its parent document. Unlike the other accessors here it deliberately does <strong>not</strong>
+    /// validate the element first — refreshing a version-stale handle is the whole point — so the
+    /// position is taken on trust.
+    /// </para>
+    /// <para>
+    /// That guarantee holds <strong>only</strong> when the document has been mutated entirely
+    /// <em>within this element's own subtree</em> (its descendant nodes) — never the element itself
+    /// (e.g. replaced), an ancestor, or a <em>preceding sibling</em> (whose size change would shift this
+    /// element). A descendant mutation only grows or shrinks the document at indices <em>after</em> the
+    /// element's start row, so that start row — and hence the element's index — is unchanged, and only
+    /// the cached version needs bringing up to date so subsequent staleness checks pass. Call it after
+    /// any other kind of mutation and it returns a handle that <strong>silently addresses the wrong
+    /// node</strong> — the memory-corruption class that version tracking exists to prevent. If you
+    /// cannot prove the index is unchanged, re-navigate from the (always-live) root element instead.
+    /// </para>
+    /// <para>
+    /// The canonical use is RFC 7396 merge-patch application, which re-mints the parent element after
+    /// recursively merging into one of its child objects.
+    /// </para>
+    /// </remarks>
+    [CLSCompliant(false)]
+    public static T RefreshUnsafe<T>(in T element)
+        where T : struct, IMutableJsonElement<T>
+    {
+        return ((IMutableJsonDocument)element.ParentDocument).RefreshElementUnsafe<T>(element.ParentDocumentIndex);
+    }
 }

--- a/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/Internal/DefaultValueJsonDocument.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/Internal/DefaultValueJsonDocument.cs
@@ -85,6 +85,15 @@ public sealed class DefaultValueJsonDocument(IJsonDocument inner) : IMutableJson
 #endif
 
     /// <inheritdoc />
+    public TElement RefreshElementUnsafe<TElement>(int index)
+        where TElement : struct, IJsonElement<TElement>
+#if NET
+        => TElement.CreateInstance(this, index);
+#else
+        => JsonElementHelpers.CreateInstance<TElement>(this, index);
+#endif
+
+    /// <inheritdoc />
     public JsonElement.Mutable GetArrayIndexElement(int currentIndex, int arrayIndex)
     {
         this.inner.GetArrayIndexElement(currentIndex, arrayIndex, out _, out int valueIndex);

--- a/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/Internal/IMutableJsonDocument.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/Internal/IMutableJsonDocument.cs
@@ -34,6 +34,27 @@ public interface IMutableJsonDocument : IWorkspaceManagedDocument
         where TElement : struct, IJsonElement<TElement>;
 
     /// <summary>
+    /// Creates a fresh element of type <typeparamref name="TElement"/> for the element at the
+    /// specified index, capturing the document's current version.
+    /// </summary>
+    /// <typeparam name="TElement">The element type to return.</typeparam>
+    /// <param name="index">The metadata index of the element.</param>
+    /// <returns>A new element pointing at <paramref name="index"/>, stamped with the document's
+    /// current <see cref="Version"/>.</returns>
+    /// <remarks>
+    /// <para>
+    /// This is an <strong>unsafe</strong> operation: it does not validate that <paramref name="index"/>
+    /// still addresses the same logical element. It exists to refresh a held element after mutations
+    /// that are known to have affected only that element's descendant nodes (so its own start index —
+    /// which precedes all of its content — is unchanged), bringing its cached version up to date so
+    /// subsequent staleness checks pass. For example, RFC 7396 merge-patch application re-mints the
+    /// parent element after recursively merging into one of its child objects.
+    /// </para>
+    /// </remarks>
+    TElement RefreshElementUnsafe<TElement>(int index)
+        where TElement : struct, IJsonElement<TElement>;
+
+    /// <summary>
     /// Gets the array element at the specified index as a mutable JSON element.
     /// </summary>
     /// <param name="currentIndex">The current index in the document.</param>

--- a/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/JsonDocumentBuilder.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/JsonDocumentBuilder.cs
@@ -2119,6 +2119,17 @@ public sealed partial class JsonDocumentBuilder<T> : JsonDocument, IMutableJsonD
 #endif
     }
 
+    /// <inheritdoc />
+    TElement IMutableJsonDocument.RefreshElementUnsafe<TElement>(int index)
+    {
+        CheckNotDisposed();
+#if NET
+        return TElement.CreateInstance(this, index);
+#else
+        return JsonElementHelpers.CreateInstance<TElement>(this, index);
+#endif
+    }
+
     /// <summary>
     /// Initializes this builder as a frozen (immutable) copy of a segment of the
     /// source builder's metadb and value backing.

--- a/tests/Corvus.Text.Json.Patch.Tests/JsonMergePatchFrozenBuilderTests.cs
+++ b/tests/Corvus.Text.Json.Patch.Tests/JsonMergePatchFrozenBuilderTests.cs
@@ -1,0 +1,168 @@
+// <copyright file="JsonMergePatchFrozenBuilderTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using Corvus.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.Patch.Tests;
+
+/// <summary>
+/// Regression tests for issue #820: applying an RFC 7396 merge patch where the merge recurses
+/// into a nested object left the parent element version-stale, so the next sibling property threw
+/// (<see cref="InvalidOperationException"/> / <see cref="ObjectDisposedException"/>) during apply,
+/// and a frozen patch document was reported as unreadable afterwards.
+/// </summary>
+[TestClass]
+public class JsonMergePatchFrozenBuilderTests
+{
+    /// <summary>
+    /// The exact shape from issue #820: parse the patch into a mutable builder, freeze it, apply
+    /// it, then read the frozen patch back. The frozen patch must remain fully readable and
+    /// unchanged.
+    /// </summary>
+    [TestMethod]
+    public void FrozenMutablePatch_RemainsReadableAfterApply()
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+
+        using JsonDocumentBuilder<JsonElement.Mutable> targetBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, """{"a":{"b":"c"}}""");
+        JsonElement.Mutable target = targetBuilder.RootElement;
+
+        using JsonDocumentBuilder<JsonElement.Mutable> patchBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, """{"a":{"b":"d","e":"f"}}""");
+        JsonElement frozenPatch = patchBuilder.RootElement.Freeze();
+
+        string before = frozenPatch.ToString();
+
+        JsonMergePatchExtensions.ApplyMergePatch(ref target, in frozenPatch);
+
+        // Previously threw ObjectDisposedException: 'JsonDocument'.
+        Assert.AreEqual(before, frozenPatch.ToString(), "the frozen patch must be unchanged and readable");
+        Assert.AreEqual("""{"a":{"b":"d","e":"f"}}""", target.ToString());
+    }
+
+    /// <summary>
+    /// The core defect: a merge that recurses into a nested object and then processes a further
+    /// sibling property of the same (non-root) parent. Before the fix the recursion left the parent
+    /// element version-stale and the sibling threw during apply.
+    /// </summary>
+    [TestMethod]
+    [DataRow("{}", """{"a":{"b":{"x":1},"c":2}}""", """{"a":{"b":{"x":1},"c":2}}""", DisplayName = "object-then-sibling into empty target")]
+    [DataRow("""{"a":{}}""", """{"a":{"b":{"x":1},"c":2}}""", """{"a":{"b":{"x":1},"c":2}}""", DisplayName = "object-then-sibling into empty nested object")]
+    [DataRow("""{"a":{"b":{"old":0},"c":0}}""", """{"a":{"b":{"x":1},"c":2}}""", """{"a":{"b":{"old":0,"x":1},"c":2}}""", DisplayName = "object-then-sibling merging existing")]
+    [DataRow("""{"a":{"b":1}}""", """{"a":{"c":{"d":1},"e":2}}""", """{"a":{"b":1,"c":{"d":1},"e":2}}""", DisplayName = "nested new object then sibling")]
+    [DataRow("{}", """{"a":{"b":{"c":{"d":1},"e":2},"f":3}}""", """{"a":{"b":{"c":{"d":1},"e":2},"f":3}}""", DisplayName = "object-then-sibling at two depths")]
+    public void NestedMerge_ObjectThenSibling(string targetJson, string patchJson, string expected)
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+
+        using JsonDocumentBuilder<JsonElement.Mutable> targetBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, targetJson);
+        JsonElement.Mutable target = targetBuilder.RootElement;
+
+        using JsonDocumentBuilder<JsonElement.Mutable> patchBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, patchJson);
+        JsonElement frozenPatch = patchBuilder.RootElement.Freeze();
+
+        string patchBefore = frozenPatch.ToString();
+
+        JsonMergePatchExtensions.ApplyMergePatch(ref target, in frozenPatch);
+
+        using ParsedJsonDocument<JsonElement> expectedDoc = ParsedJsonDocument<JsonElement>.Parse(expected);
+        Assert.IsTrue(
+            target.Equals(expectedDoc.RootElement),
+            $"Expected: {expected}\nActual: {target}");
+        Assert.AreEqual(patchBefore, frozenPatch.ToString(), "the frozen patch must be unchanged and readable");
+    }
+
+    /// <summary>
+    /// The merge target may itself be a non-root element of a larger document. After the recursion
+    /// the non-root target must be refreshed so its subsequent siblings (and reads) succeed.
+    /// </summary>
+    [TestMethod]
+    public void MergeIntoNonRootTarget()
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+
+        using JsonDocumentBuilder<JsonElement.Mutable> targetBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, """{"outer":{"a":{"b":1}}}""");
+        JsonElement.Mutable root = targetBuilder.RootElement;
+        Assert.IsTrue(root.TryGetProperty("outer"u8, out JsonElement.Mutable inner));
+
+        using JsonDocumentBuilder<JsonElement.Mutable> patchBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, """{"a":{"c":{"d":1},"e":2}}""");
+        JsonElement frozenPatch = patchBuilder.RootElement.Freeze();
+
+        JsonMergePatchExtensions.ApplyMergePatch(ref inner, in frozenPatch);
+
+        using ParsedJsonDocument<JsonElement> expectedDoc =
+            ParsedJsonDocument<JsonElement>.Parse("""{"outer":{"a":{"b":1,"c":{"d":1},"e":2}}}""");
+        Assert.IsTrue(
+            root.Equals(expectedDoc.RootElement),
+            $"Actual: {root}");
+    }
+
+    /// <summary>
+    /// A frozen patch built by mutation (its values are dynamic-value blobs rather than raw JSON)
+    /// must also remain readable after the merge copies values out of it.
+    /// </summary>
+    [TestMethod]
+    public void MutatedThenFrozenPatch_RemainsReadable()
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+
+        using JsonDocumentBuilder<JsonElement.Mutable> targetBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, """{"a":{"b":"c"}}""");
+        JsonElement.Mutable target = targetBuilder.RootElement;
+
+        using JsonDocumentBuilder<JsonElement.Mutable> patchBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, """{"a":{}}""");
+        JsonElement.Mutable patchRoot = patchBuilder.RootElement;
+        Assert.IsTrue(patchRoot.TryGetProperty("a"u8, out JsonElement.Mutable patchA));
+        patchA.SetProperty("b"u8, "d"u8);
+        patchA.SetProperty("e"u8, "f"u8);
+
+        JsonElement frozenPatch = patchRoot.Freeze();
+        string before = frozenPatch.ToString();
+
+        JsonMergePatchExtensions.ApplyMergePatch(ref target, in frozenPatch);
+
+        Assert.AreEqual(before, frozenPatch.ToString());
+        Assert.AreEqual("""{"a":{"b":"d","e":"f"}}""", target.ToString());
+    }
+
+    /// <summary>
+    /// A realistic merge (nested object merge, null removal, wholesale array replacement and a new
+    /// scalar) from a frozen mutable patch — the frozen patch stays readable afterwards.
+    /// </summary>
+    [TestMethod]
+    public void RealisticMerge_FrozenMutablePatch_RemainsReadable()
+    {
+        const string targetJson =
+            """{"title":"Goodbye!","author":{"givenName":"John","familyName":"Doe"},"tags":["example","sample"],"content":"unchanged"}""";
+        const string patchJson =
+            """{"title":"Hello!","author":{"familyName":null},"tags":["example"],"phoneNumber":"+01-123-456-7890"}""";
+
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+
+        using JsonDocumentBuilder<JsonElement.Mutable> targetBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, targetJson);
+        JsonElement.Mutable target = targetBuilder.RootElement;
+
+        using JsonDocumentBuilder<JsonElement.Mutable> patchBuilder =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, patchJson);
+        JsonElement frozenPatch = patchBuilder.RootElement.Freeze();
+
+        string before = frozenPatch.ToString();
+
+        JsonMergePatchExtensions.ApplyMergePatch(ref target, in frozenPatch);
+
+        Assert.AreEqual(before, frozenPatch.ToString());
+
+        using ParsedJsonDocument<JsonElement> expectedDoc = ParsedJsonDocument<JsonElement>.Parse(
+            """{"title":"Hello!","author":{"givenName":"John"},"tags":["example"],"content":"unchanged","phoneNumber":"+01-123-456-7890"}""");
+        Assert.IsTrue(target.Equals(expectedDoc.RootElement), $"Actual: {target}");
+    }
+}

--- a/tests/Corvus.Text.Json.Patch.Tests/JsonMergePatchFuzzTests.cs
+++ b/tests/Corvus.Text.Json.Patch.Tests/JsonMergePatchFuzzTests.cs
@@ -1,0 +1,219 @@
+// <copyright file="Issue820Fuzz.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.Text;
+using System.Text.Json.Nodes;
+using Corvus.Text.Json;
+using Corvus.Text.Json.Patch;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.Patch.Tests;
+
+[TestClass]
+public class JsonMergePatchFuzzTests
+{
+    [TestMethod]
+    public void FuzzFrozenMutablePatchReads()
+    {
+        var rnd = new Random(12345);
+        int failures = 0;
+        var sb = new StringBuilder();
+
+        for (int i = 0; i < 2000; i++)
+        {
+            string targetJson = RandomObject(rnd, 0);
+            string patchJson = RandomObject(rnd, 0);
+
+            using JsonWorkspace workspace = JsonWorkspace.Create();
+            using var targetBuilder = JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, targetJson);
+            JsonElement.Mutable target = targetBuilder.RootElement;
+
+            using var patchBuilder = JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, patchJson);
+            JsonElement frozenPatch = patchBuilder.RootElement.Freeze();
+
+            string before = frozenPatch.ToString();
+
+            try
+            {
+                JsonMergePatchExtensions.ApplyMergePatch(ref target, in frozenPatch);
+            }
+            catch (Exception ex)
+            {
+                failures++;
+                sb.AppendLine($"[apply] target={targetJson} patch={patchJson} -> {ex.GetType().Name}: {ex.Message}");
+                continue;
+            }
+
+            // The frozen patch must remain fully readable and unchanged after the merge.
+            try
+            {
+                string after = frozenPatch.ToString();
+                if (after != before)
+                {
+                    failures++;
+                    sb.AppendLine($"[mutated] target={targetJson} patch={patchJson} before={before} after={after}");
+                }
+            }
+            catch (Exception ex)
+            {
+                failures++;
+                sb.AppendLine($"[read] target={targetJson} patch={patchJson} -> {ex.GetType().Name}: {ex.Message}");
+                continue;
+            }
+
+            // The merge result must match an independent RFC 7396 reference implementation.
+            try
+            {
+                string actual = Canonicalize(target.ToString());
+                string expected = Canonicalize(ReferenceMerge(targetJson, patchJson));
+                if (actual != expected)
+                {
+                    failures++;
+                    sb.AppendLine($"[result] target={targetJson} patch={patchJson} expected={expected} actual={actual}");
+                }
+            }
+            catch (Exception ex)
+            {
+                failures++;
+                sb.AppendLine($"[result-read] target={targetJson} patch={patchJson} -> {ex.GetType().Name}: {ex.Message}");
+            }
+        }
+
+        Assert.AreEqual(0, failures, sb.ToString());
+    }
+
+    // Independent RFC 7396 merge over System.Text.Json.Nodes, returning the merged JSON text.
+    private static string ReferenceMerge(string targetJson, string patchJson)
+    {
+        JsonNode? merged = MergeNode(JsonNode.Parse(targetJson), JsonNode.Parse(patchJson));
+        return merged?.ToJsonString() ?? "null";
+    }
+
+    private static JsonNode? MergeNode(JsonNode? target, JsonNode? patch)
+    {
+        if (patch is not JsonObject patchObj)
+        {
+            // Non-object patch replaces the target wholesale (deep clone to detach).
+            return patch?.DeepClone();
+        }
+
+        JsonObject targetObj = target as JsonObject ?? new JsonObject();
+
+        // Detach into a fresh object we own.
+        var result = new JsonObject();
+        foreach (KeyValuePair<string, JsonNode?> kvp in targetObj)
+        {
+            result[kvp.Key] = kvp.Value?.DeepClone();
+        }
+
+        foreach (KeyValuePair<string, JsonNode?> kvp in patchObj)
+        {
+            if (kvp.Value is null || kvp.Value.GetValueKind() == System.Text.Json.JsonValueKind.Null)
+            {
+                result.Remove(kvp.Key);
+            }
+            else
+            {
+                result[kvp.Key] = MergeNode(result.TryGetPropertyValue(kvp.Key, out JsonNode? existing) ? existing : null, kvp.Value);
+            }
+        }
+
+        return result;
+    }
+
+    // Normalize via reparse with recursively sorted object keys, so values compare structurally
+    // regardless of formatting or property order (RFC 7396 does not mandate property order).
+    private static string Canonicalize(string json)
+    {
+        return SortNode(JsonNode.Parse(json))?.ToJsonString() ?? "null";
+    }
+
+    private static JsonNode? SortNode(JsonNode? node)
+    {
+        switch (node)
+        {
+            case JsonObject obj:
+                var sorted = new JsonObject();
+                foreach (KeyValuePair<string, JsonNode?> kvp in obj.OrderBy(p => p.Key, StringComparer.Ordinal))
+                {
+                    sorted[kvp.Key] = SortNode(kvp.Value?.DeepClone());
+                }
+
+                return sorted;
+            case JsonArray arr:
+                var arrCopy = new JsonArray();
+                foreach (JsonNode? item in arr)
+                {
+                    arrCopy.Add(SortNode(item?.DeepClone()));
+                }
+
+                return arrCopy;
+            default:
+                return node?.DeepClone();
+        }
+    }
+
+    private static string RandomObject(Random rnd, int depth)
+    {
+        int props = rnd.Next(0, 4);
+        var sb = new StringBuilder("{");
+
+        // Unique keys per object (valid JSON object).
+        var keys = new List<char>();
+        for (char c = 'a'; c <= 'h'; c++)
+        {
+            keys.Add(c);
+        }
+
+        for (int i = 0; i < props && keys.Count > 0; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(',');
+            }
+
+            int k = rnd.Next(0, keys.Count);
+            char key = keys[k];
+            keys.RemoveAt(k);
+
+            sb.Append('"').Append(key).Append("\":");
+            sb.Append(RandomValue(rnd, depth));
+        }
+
+        sb.Append('}');
+        return sb.ToString();
+    }
+
+    private static string RandomValue(Random rnd, int depth)
+    {
+        int choice = depth >= 3 ? rnd.Next(0, 4) : rnd.Next(0, 6);
+        return choice switch
+        {
+            0 => "\"s" + rnd.Next(0, 9) + "\"",
+            1 => rnd.Next(0, 100).ToString(),
+            2 => rnd.Next(0, 2) == 0 ? "true" : "false",
+            3 => "null",
+            4 => RandomArray(rnd, depth + 1),
+            _ => RandomObject(rnd, depth + 1),
+        };
+    }
+
+    private static string RandomArray(Random rnd, int depth)
+    {
+        int items = rnd.Next(0, 3);
+        var sb = new StringBuilder("[");
+        for (int i = 0; i < items; i++)
+        {
+            if (i > 0)
+            {
+                sb.Append(',');
+            }
+
+            sb.Append(RandomValue(rnd, depth));
+        }
+
+        sb.Append(']');
+        return sb.ToString();
+    }
+}

--- a/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
+++ b/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
@@ -65,6 +65,7 @@
     <Compile Include="BigNumber\BigNumberComparisonTests.cs" />
     <Compile Include="BigNumber\BigNumberConversionTests.cs" />
     <Compile Include="JsonStringUnescaperTests.cs" />
+    <Compile Include="JsonMarshalRefreshUnsafeTests.cs" />
     <Compile Include="MigrationEquivalenceTests\AllOfConversionEquivalenceTests.cs" />
     <Compile Include="MigrationEquivalenceTests\ArrayEquivalenceTests.cs" />
     <Compile Include="MigrationEquivalenceTests\CreateBuilderEquivalenceTests.cs" />

--- a/tests/Corvus.Text.Json.Tests/JsonMarshalRefreshUnsafeTests.cs
+++ b/tests/Corvus.Text.Json.Tests/JsonMarshalRefreshUnsafeTests.cs
@@ -1,0 +1,69 @@
+// <copyright file="JsonMarshalRefreshUnsafeTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using Corvus.Runtime.InteropServices;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.Tests;
+
+/// <summary>
+/// Tests for <see cref="JsonMarshal.RefreshUnsafe{T}"/>.
+/// </summary>
+[TestClass]
+public class JsonMarshalRefreshUnsafeTests
+{
+    [TestMethod]
+    public void RefreshUnsafe_RevivesAVersionStaleParentAfterDescendantMutation()
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+        using JsonDocumentBuilder<JsonElement.Mutable> doc =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, """{"a":{"b":{"c":1}}}""");
+
+        // Hold a handle to a non-root element ("a").
+        Assert.IsTrue(doc.RootElement.TryGetProperty("a"u8, out JsonElement.Mutable a));
+
+        // Mutate a *descendant* of "a" (a's grandchild "b") through a separate handle. This bumps the
+        // document version, leaving the held "a" handle version-stale while its start index is still
+        // valid (the mutation is inside a's subtree).
+        Assert.IsTrue(a.TryGetProperty("b"u8, out JsonElement.Mutable b));
+        b.SetProperty("d"u8, 2);
+
+        // The stale, non-root handle now fails its staleness check on use.
+        Assert.ThrowsExactly<InvalidOperationException>(() => a.TryGetProperty("b"u8, out _));
+
+        // RefreshUnsafe mints a fresh handle for the same element with the current version.
+        JsonElement.Mutable refreshed = JsonMarshal.RefreshUnsafe(in a);
+        Assert.AreEqual(JsonValueKind.Object, refreshed.ValueKind);
+        Assert.IsTrue(refreshed.TryGetProperty("b"u8, out JsonElement.Mutable refreshedB));
+        Assert.AreEqual("""{"c":1,"d":2}""", refreshedB.ToString());
+    }
+
+    [TestMethod]
+    public void RefreshUnsafe_OnRootIsANoOpReturningEquivalentElement()
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+        using JsonDocumentBuilder<JsonElement.Mutable> doc =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, """{"a":1}""");
+
+        JsonElement.Mutable root = doc.RootElement;
+        JsonElement.Mutable refreshed = JsonMarshal.RefreshUnsafe(in root);
+
+        Assert.AreEqual(root.ToString(), refreshed.ToString());
+        Assert.IsTrue(refreshed.TryGetProperty("a"u8, out _));
+    }
+
+    [TestMethod]
+    public void RefreshUnsafe_ThrowsObjectDisposedWhenDocumentDisposed()
+    {
+        JsonWorkspace workspace = JsonWorkspace.Create();
+        JsonDocumentBuilder<JsonElement.Mutable> doc =
+            JsonDocumentBuilder<JsonElement.Mutable>.Parse(workspace, """{"a":1}""");
+        JsonElement.Mutable root = doc.RootElement;
+
+        doc.Dispose();
+        workspace.Dispose();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() => JsonMarshal.RefreshUnsafe(in root));
+    }
+}


### PR DESCRIPTION
Fixes #820.

## Problem

`JsonMergePatchExtensions.ApplyMergePatch` recurses into a nested target object through a held `JsonElement.Mutable`, but the recursion mutates the document (bumping its version) without refreshing that parent handle. The next sibling property of the same **non-root** parent then fails its staleness check — surfacing as `InvalidOperationException` during the merge, or `ObjectDisposedException: 'JsonDocument'` when a value copied in from a frozen patch is read afterwards.

The root element is exempt from the staleness check (always index 0, never relocated), so only *nested* ("real") merges with an object-valued property **followed by another property** were affected. The existing RFC 7396 suite is all top-level / single-property-per-level, so it never caught it.

See the [issue comment](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/820#issuecomment-4727238592) for a minimal repro and the full analysis.

## Fix

A recursive merge mutates only the child's own subtree, so the parent's start index is unchanged — only its cached version is stale. `ApplyMergePatch` now re-mints the parent handle after each nested merge.

- New `IMutableJsonDocument.RefreshElementUnsafe<TElement>(int index)` seam (generic over the element type, mirroring `FreezeElement<TElement>`), implemented in `JsonDocumentBuilder` and `DefaultValueJsonDocument`.
- Surfaced as a public, deliberately **unsafe** high-performance helper `JsonMarshal.RefreshUnsafe<T>(in T element)` — only valid where the caller knows their mutations cannot have changed the element's index in its parent document (i.e. mutations were confined to its own subtree).
- **No `InternalsVisibleTo`** — an IVT from the core package to the Patch package leaked the internal netstandard `ObsoleteAttribute` polyfill into Patch (`CS0433` on `netstandard2.0`). The merge reaches the seam allocation-free through the existing constrained-generic pattern.

## Tests & docs

- `JsonMergePatchFrozenBuilderTests` — nested object-then-sibling merges (the bug), frozen-mutable patch readability after apply, merge into a non-root target, realistic merge.
- `JsonMergePatchFuzzTests` — 2000 randomised merges checked against an independent RFC 7396 reference (catches silent corruption, not just throws).
- `JsonMarshalRefreshUnsafeTests` — direct coverage of the new helper (refresh after descendant mutation, root no-op, disposed-document throw).
- `JsonMarshal.RefreshUnsafe` documented under the version-tracking / staleness section of `JsonDocumentBuilder.md`, clearly flagged as an unsafe helper for high-performance code.
- `VERSIONHISTORY.md` → V5.1.17.

Full Patch suite (429) and touched core tests (Mutable/Freeze/DocumentBuilder/JsonMarshal, 4193) pass; core + Patch build clean for `netstandard2.0` and `net10.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
