### PR TITLE
Fix #819: zero-valued numeric bound mis-validates number values in (0, 0.1)

### DIFF
--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,13 @@
 # Version History
 
+## V5.1.18
+
+V5.1.18 fixes a numeric validation bug where a zero-valued bound mis-validated `number` values whose magnitude was just below `0.1`.
+
+### Bug fixes
+
+- **A zero-valued numeric bound (`minimum`/`exclusiveMinimum`/`maximum`/`exclusiveMaximum` = `0`) no longer mis-validates `number` values in the open interval `(0, 0.1)`** — The shared numeric comparator `JsonElementHelpers.CompareNormalizedJsonNumbers` orders two normalized numbers by their *effective length* (significand length + exponent), the position of the most significant digit. Zero normalizes to an **empty significand** with exponent `0`, giving it effective length `0` — the same band as values in `[0.1, 1)`. As a result any value whose absolute magnitude was less than `0.1` (effective length `< 0`, e.g. `0.05`, `0.083`) was ordered as if it were *smaller* than zero: `minimum: 0` and `exclusiveMinimum: 0` wrongly **rejected** such values, while `maximum: 0` and `exclusiveMaximum: 0` wrongly **accepted** them. Values of `0`, values `>= 0.1`, negative values (handled by the sign comparison), and the same keywords with non-zero bounds were all unaffected, as were `integer`-typed schemas (only integer magnitudes reach the comparator). The comparator now detects an empty significand and orders zero explicitly — less than every positive value, greater than every negative value — before the effective-length comparison. This is a runtime fix in the shared comparator used by generated models, the standalone evaluator, the dynamic `Validator`, and JsonLogic; no regeneration of generated code is required. See [#819](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/819).
+
 ## V5.1.17
 
 V5.1.17 fixes an RFC 7396 JSON Merge Patch bug where merging a nested object corrupted the parent element handle.

--- a/src/Corvus.Text.Json/Corvus/Text/Json/Internal/JsonElementHelpers.Numeric.Core.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/Internal/JsonElementHelpers.Numeric.Core.cs
@@ -297,6 +297,28 @@ public static partial class JsonElementHelpers
         ReadOnlySpan<byte> rightFractional,
         int rightExponent)
     {
+        // Step 0: Handle zero explicitly.
+        // Zero has an empty significand (both integral and fractional empty). Its
+        // order of magnitude cannot be expressed by the effective-length comparison
+        // below — that heuristic would treat an empty significand as belonging to
+        // [0.1, 1) (effective length 0), so any value with magnitude < 0.1 was wrongly
+        // ordered against zero (issue #819). Zero is less than every positive value and
+        // greater than every negative value.
+        bool leftIsZero = leftIntegral.IsEmpty && leftFractional.IsEmpty;
+        bool rightIsZero = rightIntegral.IsEmpty && rightFractional.IsEmpty;
+        if (leftIsZero || rightIsZero)
+        {
+            if (leftIsZero && rightIsZero)
+            {
+                return 0;
+            }
+
+            // The non-zero side's sign determines the ordering.
+            return leftIsZero
+                ? (rightIsNegative ? 1 : -1)
+                : (leftIsNegative ? -1 : 1);
+        }
+
         // Step 1: Compare signs
         if (leftIsNegative != rightIsNegative)
         {

--- a/tests/Corvus.Text.Json.Tests/NumericCoreOperationsTests.cs
+++ b/tests/Corvus.Text.Json.Tests/NumericCoreOperationsTests.cs
@@ -216,6 +216,23 @@ public class NumericCoreOperationsTests
     [DataRow(false, "15", "", -1, false, "14", "", -1, 1)]     // 1.5 > 1.4
     [DataRow(false, "15", "", -1, false, "15", "", -1, 0)]     // 1.5 == 1.5
     [DataRow(false, "123", "45", -3, false, "123", "44", -3, 1)] // 12.345 > 12.344
+
+    // Issue #819: a zero bound has an empty significand (integral and fractional both
+    // empty). The effective-length heuristic treats an empty significand as if it were
+    // in [0.1, 1), so any positive value with magnitude < 0.1 (effective length < 0)
+    // was wrongly compared as smaller than zero, and vice versa.
+    [DataRow(false, "", "", 0, false, "", "", 0, 0)]           // 0 == 0
+    [DataRow(false, "", "5", -2, false, "", "", 0, 1)]         // 0.05 > 0
+    [DataRow(false, "", "", 0, false, "", "5", -2, -1)]        // 0 < 0.05
+    [DataRow(false, "", "83", -3, false, "", "", 0, 1)]        // 0.083 > 0
+    [DataRow(false, "", "", 0, false, "", "83", -3, -1)]       // 0 < 0.083
+    [DataRow(false, "5", "", -50, false, "", "", 0, 1)]        // 5e-50 > 0 (tiny positive)
+    [DataRow(false, "", "", 0, false, "5", "", -50, -1)]       // 0 < 5e-50
+    [DataRow(true, "", "5", -2, false, "", "", 0, -1)]         // -0.05 < 0 (sign path)
+    [DataRow(false, "", "", 0, true, "", "5", -2, 1)]          // 0 > -0.05 (sign path)
+    [DataRow(false, "", "5", -1, false, "", "", 0, 1)]         // 0.5 > 0 (>= 0.1, regression guard)
+    [DataRow(false, "1", "", -1, false, "", "", 0, 1)]         // 0.1 > 0 (boundary, regression guard)
+    [DataRow(false, "", "", 0, false, "", "5", -1, -1)]        // 0 < 0.5 (regression guard)
     public void CompareNormalizedJsonNumbers(
         bool leftNeg, string leftIntg, string leftFrac, int leftExp,
         bool rightNeg, string rightIntg, string rightFrac, int rightExp,

--- a/tests/Corvus.Text.Json.Validator.Tests/Corvus/Text/Json/Validator/Tests/ZeroNumericBoundTests.cs
+++ b/tests/Corvus.Text.Json.Validator.Tests/Corvus/Text/Json/Validator/Tests/ZeroNumericBoundTests.cs
@@ -1,0 +1,91 @@
+// <copyright file="ZeroNumericBoundTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.Validator.Tests;
+
+/// <summary>
+/// Regression tests for issue #819: a <c>number</c>-typed schema with a zero-valued
+/// numeric bound (<c>minimum</c>/<c>exclusiveMinimum</c>/<c>maximum</c> = <c>0</c>)
+/// mis-validated values whose absolute value lies in the open interval <c>(0, 0.1)</c>.
+/// </summary>
+[TestClass]
+public class ZeroNumericBoundTests
+{
+    private static readonly JsonSchema MinimumZero = JsonSchema.FromText(
+        """{ "$schema": "https://json-schema.org/draft/2020-12/schema", "type": "number", "minimum": 0 }""",
+        "https://example.com/test/819/minimum-zero");
+
+    private static readonly JsonSchema ExclusiveMinimumZero = JsonSchema.FromText(
+        """{ "$schema": "https://json-schema.org/draft/2020-12/schema", "type": "number", "exclusiveMinimum": 0 }""",
+        "https://example.com/test/819/exclusive-minimum-zero");
+
+    private static readonly JsonSchema MaximumZero = JsonSchema.FromText(
+        """{ "$schema": "https://json-schema.org/draft/2020-12/schema", "type": "number", "maximum": 0 }""",
+        "https://example.com/test/819/maximum-zero");
+
+    private static readonly JsonSchema ExclusiveMaximumZero = JsonSchema.FromText(
+        """{ "$schema": "https://json-schema.org/draft/2020-12/schema", "type": "number", "exclusiveMaximum": 0 }""",
+        "https://example.com/test/819/exclusive-maximum-zero");
+
+    [TestMethod]
+    [DataRow("0", true)]
+    [DataRow("0.05", true)]
+    [DataRow("0.083", true)]
+    [DataRow("0.1", true)]
+    [DataRow("0.5", true)]
+    [DataRow("1", true)]
+    [DataRow("-0.05", false)]
+    [DataRow("-0.083", false)]
+    [DataRow("-1", false)]
+    public void MinimumZero_Number(string json, bool expected)
+    {
+        Assert.AreEqual(expected, MinimumZero.Validate(json));
+    }
+
+    [TestMethod]
+    [DataRow("0", false)]
+    [DataRow("0.05", true)]
+    [DataRow("0.083", true)]
+    [DataRow("0.1", true)]
+    [DataRow("0.5", true)]
+    [DataRow("1", true)]
+    [DataRow("-0.05", false)]
+    [DataRow("-1", false)]
+    public void ExclusiveMinimumZero_Number(string json, bool expected)
+    {
+        Assert.AreEqual(expected, ExclusiveMinimumZero.Validate(json));
+    }
+
+    [TestMethod]
+    [DataRow("0", true)]
+    [DataRow("0.05", false)]
+    [DataRow("0.083", false)]
+    [DataRow("0.1", false)]
+    [DataRow("0.5", false)]
+    [DataRow("1", false)]
+    [DataRow("-0.05", true)]
+    [DataRow("-0.083", true)]
+    [DataRow("-1", true)]
+    public void MaximumZero_Number(string json, bool expected)
+    {
+        Assert.AreEqual(expected, MaximumZero.Validate(json));
+    }
+
+    [TestMethod]
+    [DataRow("0", false)]
+    [DataRow("0.05", false)]
+    [DataRow("0.083", false)]
+    [DataRow("0.1", false)]
+    [DataRow("0.5", false)]
+    [DataRow("1", false)]
+    [DataRow("-0.05", true)]
+    [DataRow("-0.083", true)]
+    [DataRow("-1", true)]
+    public void ExclusiveMaximumZero_Number(string json, bool expected)
+    {
+        Assert.AreEqual(expected, ExclusiveMaximumZero.Validate(json));
+    }
+}


### PR DESCRIPTION
Fixes #819.

## Problem

For a `number`-typed schema with a **zero-valued** numeric bound (`minimum`, `exclusiveMinimum`, `maximum`, or `exclusiveMaximum` = `0`), validation was wrong for any value whose absolute magnitude lay in the open interval `(0, 0.1)` (e.g. `0.05`, `0.083`):

- `minimum: 0` / `exclusiveMinimum: 0` wrongly **rejected** such values.
- `maximum: 0` / `exclusiveMaximum: 0` wrongly **accepted** them.

Values of `0`, values `>= 0.1`, negatives, the same keywords with non-zero bounds, and all `integer` schemas were unaffected.

## Root cause

The single shared comparator `JsonElementHelpers.CompareNormalizedJsonNumbers` orders two normalized numbers by their **effective length** = `significand length + exponent` (the position of the most-significant digit). Zero normalizes to an **empty significand** with `exponent = 0`, giving it effective length `0` — the same band as values in `[0.1, 1)`. Any value with magnitude `< 0.1` has effective length `< 0`, so it was ordered as if it were *smaller* than zero. Values `>= 0.1` share effective length `0` with zero and fall through to the correct digit-by-digit step — which is exactly why the failure band is `|v| ∈ (0, 0.1)`.

This is a runtime-library bug, not a codegen bug, which is why the generated comparator code was byte-for-byte identical across releases.

## Fix

Detect the empty-significand (zero) case up front and order it explicitly — zero is less than every positive value and greater than every negative value — before the effective-length comparison:

```csharp
// Step 0: Handle zero explicitly.
bool leftIsZero  = leftIntegral.IsEmpty  && leftFractional.IsEmpty;
bool rightIsZero = rightIntegral.IsEmpty && rightFractional.IsEmpty;
if (leftIsZero || rightIsZero)
{
    if (leftIsZero && rightIsZero)
    {
        return 0;
    }

    return leftIsZero
        ? (rightIsNegative ? 1 : -1)
        : (leftIsNegative ? -1 : 1);
}
```

One-site fix in the shared comparator used by generated models, the standalone evaluator, the dynamic `Validator`, and JsonLogic. The only generation-time caller (`IsUInt64`) guards `exponent != 0` and compares integers ≥ 1, so generated output is unchanged — **no regeneration of generated code, recipes, or benchmarks is required.**

## Tests (test-first — each fails before the fix, passes after)

- `NumericCoreOperationsTests.CompareNormalizedJsonNumbers` — 12 new comparator-level rows: zero vs sub-`0.1` magnitudes in both directions (`0.05`, `0.083`, `5e-50`), plus sign-path and `>= 0.1` regression guards. 6 failed before the fix.
- New `ZeroNumericBoundTests` — end-to-end dynamic-`Validator` coverage of `minimum` / `exclusiveMinimum` / `maximum` / **`exclusiveMaximum`** = `0` against `0`, `0.05`, `0.083`, `0.1`, `0.5`, `1`, and negatives. 6 failed before the fix. (`exclusiveMaximum: 0` wasn't in the original report but is affected identically.)

## Verification

- Full-solution build: **0 Warning(s), 0 Error(s)**.
- All affected suites green: `Corvus.Text.Json.Tests` 31229/31229 · SchemaTestSuite min/max (model-gen path) 185/185 · EvaluatorTestSuite min/max (standalone-evaluator path) 185/185 · `Validator.Tests` 94/94 · JsonLogic 878/878 · Numerics 1233/1233 (net10.0; net481 runs in CI on Windows — fix is pure managed code with no TFM branches).
- `VERSIONHISTORY.md` updated to V5.1.18.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
