### PR TITLE
Fix #823: add a KYAML emitter profile to the JSON→YAML writer

### DIFF
--- a/.github/skills/corvus-yaml/SKILL.md
+++ b/.github/skills/corvus-yaml/SKILL.md
@@ -54,6 +54,26 @@ YamlDocument.ConvertToYaml(jsonElement, bufferWriter);
 YamlDocument.ConvertToYaml(jsonElement, utf8Stream);
 ```
 
+### KYAML output
+
+KYAML (Kubernetes KEP-5295) is a strict subset of YAML 1.2: explicit `{ }` / `[ ]`
+delimiters laid out across indented lines, string values always double-quoted, numbers/
+booleans/null bare, keys quoted only when ambiguous, trailing comma after every element.
+Output is always valid YAML 1.2 (read it back with `YamlDocument.Parse`, no config needed).
+
+Enable it on any `ConvertToYaml*` overload (or `Utf8YamlWriter`) via the options:
+
+```csharp
+// Preset (easiest):
+string kyaml = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);
+
+// Or set the format explicitly:
+var options = new YamlWriterOptions { Format = YamlWriterFormat.Kyaml };
+```
+
+Implemented entirely in `Utf8YamlWriter` (gated on `YamlWriterFormat.Kyaml`); the JSON→YAML
+converter is format-agnostic. Output is canonical (non-"cuddled") KYAML.
+
 ## Schema Modes
 
 Four YAML schema modes control how scalar values are interpreted:

--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,13 @@
 # Version History
 
+## V5.1.19
+
+V5.1.19 adds a KYAML output mode to the JSON→YAML writer.
+
+### New features
+
+- **JSON→YAML conversion can now emit [KYAML](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/5295-kyaml)** — KYAML (Kubernetes KEP-5295) is a strict subset of YAML 1.2 designed to be unambiguous: every mapping uses explicit `{ }` braces and every sequence explicit `[ ]` brackets, laid out across indented lines with a trailing comma after each element; string values (and ambiguous keys) are always double-quoted while numbers, booleans, and `null` are written bare. This eliminates the "Norway problem" and indentation-sensitivity pitfalls, and because KYAML is valid YAML 1.2 the output round-trips through any conforming parser (including this library's reader, which already accepts it with no configuration). Enable it with the new `YamlWriterOptions.Kyaml` preset (or `YamlWriterFormat.Kyaml`) on any `ConvertToYaml`/`ConvertToYamlString` overload or directly on `Utf8YamlWriter`; the default output remains canonical block-style YAML. The feature lives entirely in `Utf8YamlWriter`, so both the `Corvus.Text.Json.Yaml` and `Corvus.Yaml.SystemTextJson` packages gain it. See [#823](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/823).
+
 ## V5.1.18
 
 V5.1.18 fixes a numeric validation bug where a zero-valued bound mis-validated `number` values whose magnitude was just below `0.1`.

--- a/docs/Yaml.md
+++ b/docs/Yaml.md
@@ -426,10 +426,87 @@ The writer validates structural correctness by default (e.g., property names mus
 ```csharp
 var options = new YamlWriterOptions
 {
-    IndentSize = 2,          // Spaces per indent level (default: 2)
-    SkipValidation = false,  // Disable structural validation for max throughput
+    IndentSize = 2,                      // Spaces per indent level (default: 2)
+    SkipValidation = false,              // Disable structural validation for max throughput
+    Format = YamlWriterFormat.Yaml,      // Output dialect: Yaml (default) or Kyaml
 };
 ```
+
+## KYAML output
+
+[KYAML](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/5295-kyaml)
+(Kubernetes KEP-5295) is a **strict subset of YAML 1.2** designed to be unambiguous and
+free of its usual ambiguity pitfalls. Because it is a subset, any KYAML document is also valid
+YAML — it can be read back by any conforming YAML parser, including this library's reader.
+
+The library can **emit** KYAML from any JSON input. In KYAML mode the writer:
+
+- renders every mapping with explicit `{ }` braces and every sequence with explicit `[ ]`
+  brackets, laid out across indented lines (no reliance on significant indentation);
+- **always double-quotes string values**, so a value like `NO` stays a string (the "Norway
+  problem") and a string such as `"123"` or `"true"` is never mistaken for a number or boolean;
+- writes numbers, booleans, and `null` bare;
+- quotes mapping **keys only when they would otherwise be ambiguous** (e.g. `true`, `123`, or
+  a YAML 1.1 word like `no`);
+- writes a trailing comma after every element;
+- renders empty collections as `{}` and `[]`.
+
+### Enabling KYAML
+
+Pass KYAML options to any of the `ConvertToYaml`/`ConvertToYamlString` overloads (or to a
+`Utf8YamlWriter` directly). Use the ready-made preset:
+
+```csharp
+using Corvus.Text.Json.Yaml;
+
+string json = """{"apiVersion":"v1","kind":"Service","metadata":{"name":"hostnames"},"spec":{"ports":[{"port":80,"protocol":"TCP"}]}}""";
+
+// Easiest: the built-in preset.
+string kyaml = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);
+```
+
+…or set the format explicitly (handy when you also want to tweak `IndentSize`):
+
+```csharp
+var options = new YamlWriterOptions { Format = YamlWriterFormat.Kyaml };
+string kyaml = YamlDocument.ConvertToYamlString(json, options);
+```
+
+The example above produces:
+
+```yaml
+{
+  apiVersion: "v1",
+  kind: "Service",
+  metadata: {
+    name: "hostnames",
+  },
+  spec: {
+    ports: [
+      {
+        port: 80,
+        protocol: "TCP",
+      },
+    ],
+  },
+}
+```
+
+The same options work with the streaming overloads (`ConvertToYaml(..., IBufferWriter<byte>)`
+and `ConvertToYaml(..., Stream)`) and with the low-level `Utf8YamlWriter`:
+
+```csharp
+ArrayBufferWriter<byte> output = new(256);
+Utf8YamlWriter writer = new(output, YamlWriterOptions.Kyaml);
+// ...write mappings/sequences/values as usual; KYAML layout and quoting are applied automatically.
+```
+
+> **Reading KYAML** needs no special configuration — since KYAML is valid YAML 1.2, the
+> standard `YamlDocument.Parse` overloads read it directly.
+
+> **Note:** Output is canonical, non-"cuddled" KYAML (each collection broken across its own
+> lines). It is fully spec-conformant KYAML; the optional cuddled bracket layout that kubectl
+> emits for compactness is not produced.
 
 ## Performance
 
@@ -505,6 +582,7 @@ The following benchmarks compare JSON→YAML conversion across four paths: **Yam
 |---|---|---|
 | **YAML→JSON conversion** | ✅ Native zero-copy tokenizer to `Utf8JsonWriter` | ⚠️ Deserialize to object graph, then re-serialize with `JsonCompatible()` |
 | **JSON→YAML conversion** | ✅ Native `Utf8YamlWriter` (16–66× faster) | ⚠️ Deserialize JSON to object graph, then serialize to YAML |
+| **KYAML output** | ✅ `YamlWriterOptions.Kyaml` (Kubernetes KEP-5295 subset) | ❌ |
 | **YAML 1.2 conformance** | ✅ 100% of yaml-test-suite JSON-comparison cases (373/373 applicable) | ⚠️ 68.9% (257/373) [*](#conformance-note) |
 | **YAML 1.1 support** | ✅ `YamlSchema.Yaml11` mode | ✅ Default schema |
 | **C# object → YAML serialization** | ❌ | ✅ `Serializer` with naming conventions, type converters, callbacks |
@@ -528,14 +606,14 @@ The following benchmarks compare JSON→YAML conversion across four paths: **Yam
 ### When to use Corvus.Yaml
 
 - **YAML configuration → JSON pipeline:** You need to convert YAML files (Kubernetes manifests, CI configs, OpenAPI specs) into JSON for processing by `System.Text.Json`, JSON Schema validation, or the Corvus document model.
-- **JSON→YAML output:** You need to convert JSON data to canonical YAML for configuration generation, API responses, or human-readable output — using `ConvertToYamlString` or the low-level `Utf8YamlWriter`.
+- **JSON→YAML output:** You need to convert JSON data to canonical YAML — or to [KYAML](#kyaml-output), the unambiguous YAML 1.2 subset — for configuration generation, API responses, or human-readable output, using `ConvertToYamlString` or the low-level `Utf8YamlWriter`.
 - **High-throughput / low-allocation:** You're processing YAML in a hot path — an API server, a build tool, a code generator — where 7–66× speed and near-zero GC pressure matter.
 - **Spec conformance:** You need accurate YAML 1.2 parsing with correct type resolution (Core schema) and strict error detection.
 - **Corvus ecosystem:** You're already using Corvus.Text.Json for JSON Schema, JSONata, JMESPath, or JSON Patch and want YAML input to flow into the same pipeline.
 
 ### When to use YamlDotNet
 
-- **YAML round-tripping:** You need to read YAML, modify it, and write it back as YAML preserving comments and formatting — Corvus.Yaml converts JSON→YAML as canonical block style only.
+- **YAML round-tripping:** You need to read YAML, modify it, and write it back as YAML preserving comments and formatting — Corvus.Yaml converts JSON→YAML as canonical block-style YAML or [KYAML](#kyaml-output), but does not preserve source comments or layout.
 - **Object serialization:** You need to serialize C# objects directly to/from YAML with naming conventions, type converters, and custom deserialization callbacks.
 - **YAML DOM manipulation:** You need to build or transform a YAML document tree (`YamlStream`, `YamlNode`) programmatically.
 - **Event-level parsing with allocation:** You need a materialized event stream you can store and replay — Corvus provides a zero-allocation callback-based parser, while YamlDotNet's `IParser` produces heap-allocated event objects.

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -1478,8 +1478,12 @@ main-docs:
       - {index: 16, language: csharp, lines: [372, 377], category: v4-before, verified: false}
       - {index: 17, language: csharp, lines: [381, 385], category: compilable, verified: false}
       - {index: 18, language: csharp, lines: [391, 418], category: compilable, verified: false}
-      - {index: 19, language: csharp, lines: [426, 432], category: compilable, verified: false}
-      - {index: 20, language: csharp, lines: [548, 558], category: compilable, verified: false}
+      - {index: 19, language: csharp, lines: [426, 433], category: compilable, verified: false}
+      - {index: 20, language: csharp, lines: [459, 466], category: compilable, verified: false}
+      - {index: 21, language: csharp, lines: [470, 473], category: compilable, verified: false}
+      - {index: 22, language: yaml, lines: [477, 493]}
+      - {index: 23, language: csharp, lines: [498, 502], category: compilable, verified: false}
+      - {index: 24, language: csharp, lines: [626, 636], category: compilable, verified: false}
 
 v4-docs:
   - path: "docs/V4/GettingStartedWithJsonSchemaCodeGeneration.md"
@@ -1818,7 +1822,8 @@ skills:
     blocks:
       - {index: 0, language: csharp, lines: [32, 42], category: compilable, verified: false}
       - {index: 1, language: csharp, lines: [46, 55], category: compilable, verified: false}
-      - {index: 2, language: powershell, lines: [77, 79]}
+      - {index: 2, language: csharp, lines: [66, 72], category: compilable, verified: false}
+      - {index: 3, language: powershell, lines: [97, 99]}
   - path: ".github/skills/ref-struct-delegates/SKILL.md"
     blocks:
       - {index: 0, language: csharp, lines: [21, 26], category: compilable, verified: false}

--- a/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/Utf8YamlWriter.cs
+++ b/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/Utf8YamlWriter.cs
@@ -24,7 +24,11 @@ namespace Corvus.Text.Json.Yaml;
 /// <remarks>
 /// <para>
 /// Supports both block and flow collection styles. Block style uses indentation;
-/// flow style uses inline comma-separated syntax.
+/// flow style uses inline comma-separated syntax. When
+/// <see cref="YamlWriterOptions.Format"/> is <see cref="YamlWriterFormat.Kyaml"/>,
+/// the writer emits KYAML — explicit <c>{ }</c> / <c>[ ]</c> delimiters laid out
+/// across indented lines with a trailing comma after every element, string values
+/// always double-quoted.
 /// </para>
 /// <para>
 /// When <see cref="YamlWriterOptions.SkipValidation"/> is <see langword="false"/>,
@@ -49,6 +53,7 @@ public ref struct Utf8YamlWriter
     private int _indentLevel;
     private readonly int _indentSize;
     private readonly bool _skipValidation;
+    private readonly bool _kyaml;
     private bool _wroteRootValue;
     private bool _hasWrittenAny;
     private bool _disposed;
@@ -66,6 +71,7 @@ public ref struct Utf8YamlWriter
         _arrayBufferWriter = null;
         _indentSize = options.IndentSize > 0 ? options.IndentSize : 2;
         _skipValidation = options.SkipValidation;
+        _kyaml = options.Format == YamlWriterFormat.Kyaml;
         _indentLevel = -1;
         _wroteRootValue = false;
         _hasWrittenAny = false;
@@ -95,6 +101,7 @@ public ref struct Utf8YamlWriter
         _arrayBufferWriter = new ArrayBufferWriter<byte>();
         _indentSize = options.IndentSize > 0 ? options.IndentSize : 2;
         _skipValidation = options.SkipValidation;
+        _kyaml = options.Format == YamlWriterFormat.Kyaml;
         _indentLevel = -1;
         _wroteRootValue = false;
         _hasWrittenAny = false;
@@ -112,6 +119,11 @@ public ref struct Utf8YamlWriter
     /// <param name="style">The collection style to use.</param>
     public void WriteStartMapping(YamlCollectionStyle style = YamlCollectionStyle.Block)
     {
+        if (_kyaml)
+        {
+            style = YamlCollectionStyle.Flow;
+        }
+
         if (!_skipValidation)
         {
             ValidateStartContainer();
@@ -139,6 +151,18 @@ public ref struct Utf8YamlWriter
 
         WriteContext ctx = _contextStack.Pop();
 
+        if (_kyaml)
+        {
+            if (ctx.ItemCount > 0)
+            {
+                WriteKyamlNewlineIndent();
+            }
+
+            WriteRaw("}"u8);
+            CompleteValue();
+            return;
+        }
+
         if (ctx.Style == YamlCollectionStyle.Flow)
         {
             WriteRaw("}"u8);
@@ -157,6 +181,11 @@ public ref struct Utf8YamlWriter
     /// <param name="style">The collection style to use.</param>
     public void WriteStartSequence(YamlCollectionStyle style = YamlCollectionStyle.Block)
     {
+        if (_kyaml)
+        {
+            style = YamlCollectionStyle.Flow;
+        }
+
         if (!_skipValidation)
         {
             ValidateStartContainer();
@@ -184,6 +213,18 @@ public ref struct Utf8YamlWriter
 
         WriteContext ctx = _contextStack.Pop();
 
+        if (_kyaml)
+        {
+            if (ctx.ItemCount > 0)
+            {
+                WriteKyamlNewlineIndent();
+            }
+
+            WriteRaw("]"u8);
+            CompleteValue();
+            return;
+        }
+
         if (ctx.Style == YamlCollectionStyle.Flow)
         {
             WriteRaw("]"u8);
@@ -208,6 +249,15 @@ public ref struct Utf8YamlWriter
         }
 
         ref WriteContext ctx = ref _contextStack[_contextStack.Length - 1];
+
+        if (_kyaml)
+        {
+            WriteKyamlNewlineIndent();
+            WriteScalarValue(utf8Name, isKey: true);
+            WriteRaw(": "u8);
+            ctx.State = WriteState.MappingValue;
+            return;
+        }
 
         if (ctx.Style == YamlCollectionStyle.Flow)
         {
@@ -351,6 +401,18 @@ public ref struct Utf8YamlWriter
 
         ref WriteContext ctx = ref _contextStack[_contextStack.Length - 1];
 
+        if (_kyaml)
+        {
+            if (ctx.State == WriteState.SequenceItem)
+            {
+                WriteKyamlNewlineIndent();
+            }
+
+            // For mapping values the ": " was already written by WritePropertyName;
+            // the value follows inline.
+            return;
+        }
+
         if (ctx.Style == YamlCollectionStyle.Flow)
         {
             if (ctx.State == WriteState.SequenceItem)
@@ -392,6 +454,18 @@ public ref struct Utf8YamlWriter
         }
 
         ref WriteContext ctx = ref _contextStack[_contextStack.Length - 1];
+
+        if (_kyaml)
+        {
+            if (ctx.State == WriteState.SequenceItem)
+            {
+                WriteKyamlNewlineIndent();
+            }
+
+            // For mapping values the "key: " was already written by WritePropertyName,
+            // so the container's opening bracket follows inline.
+            return;
+        }
 
         if (ctx.Style == YamlCollectionStyle.Flow)
         {
@@ -453,6 +527,29 @@ public ref struct Utf8YamlWriter
         {
             ctx.ItemCount++;
         }
+
+        if (_kyaml)
+        {
+            // KYAML writes a trailing comma after every element.
+            WriteRaw(","u8);
+        }
+    }
+
+    /// <summary>
+    /// Writes a newline followed by KYAML indentation for the current depth
+    /// (<see cref="_contextStack"/> length × indent size).
+    /// </summary>
+    private void WriteKyamlNewlineIndent()
+    {
+        WriteRaw("\n"u8);
+
+        int spaces = _contextStack.Length * _indentSize;
+        if (spaces > 0)
+        {
+            Span<byte> indent = stackalloc byte[spaces];
+            indent.Fill(YamlConstants.Space);
+            WriteRaw(indent);
+        }
     }
 
     private void WriteNewlineAndIndent()
@@ -478,6 +575,14 @@ public ref struct Utf8YamlWriter
 
     private void WriteScalarValue(scoped ReadOnlySpan<byte> utf8Value, bool isKey)
     {
+        // KYAML always double-quotes string values; keys remain conditionally
+        // quoted (only when they would otherwise be ambiguous).
+        if (_kyaml && !isKey)
+        {
+            WriteDoubleQuoted(utf8Value);
+            return;
+        }
+
         if (NeedsQuoting(utf8Value, isKey))
         {
             WriteDoubleQuoted(utf8Value);

--- a/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/YamlWriterFormat.cs
+++ b/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/YamlWriterFormat.cs
@@ -1,0 +1,40 @@
+// <copyright file="YamlWriterFormat.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+#if STJ
+namespace Corvus.Yaml;
+#else
+namespace Corvus.Text.Json.Yaml;
+#endif
+
+/// <summary>
+/// Specifies the output dialect produced by the YAML writer.
+/// </summary>
+public enum YamlWriterFormat
+{
+    /// <summary>
+    /// Canonical YAML (the default). Block style by default, with scalars quoted
+    /// only when required to round-trip safely.
+    /// </summary>
+    Yaml,
+
+    /// <summary>
+    /// KYAML — a strict subset of YAML 1.2 (Kubernetes KEP-5295) intended for
+    /// unambiguous, predictable output.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// In this mode every mapping is rendered with explicit <c>{ }</c> braces and
+    /// every sequence with explicit <c>[ ]</c> brackets, laid out across multiple
+    /// indented lines with a trailing comma after every element. String values are
+    /// always double-quoted; numbers, booleans, and <c>null</c> are written bare.
+    /// Mapping keys are quoted only when they would otherwise be ambiguous.
+    /// </para>
+    /// <para>
+    /// KYAML output is always valid YAML 1.2, so it can be read by any conforming
+    /// YAML parser (including this library's reader).
+    /// </para>
+    /// </remarks>
+    Kyaml,
+}

--- a/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/YamlWriterOptions.cs
+++ b/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/YamlWriterOptions.cs
@@ -14,9 +14,20 @@ namespace Corvus.Text.Json.Yaml;
 public readonly struct YamlWriterOptions
 {
     /// <summary>
-    /// Gets the default options: 2-space indentation, structural validation enabled.
+    /// Gets the default options: canonical YAML, 2-space indentation, structural validation enabled.
     /// </summary>
     public static readonly YamlWriterOptions Default = new();
+
+    /// <summary>
+    /// Gets options that produce KYAML output (a strict subset of YAML 1.2; Kubernetes KEP-5295)
+    /// with 2-space indentation and structural validation enabled.
+    /// </summary>
+    /// <remarks>
+    /// KYAML uses explicit <c>{ }</c> / <c>[ ]</c> delimiters laid out across indented lines,
+    /// always double-quotes string values, and writes numbers, booleans, and <c>null</c> bare.
+    /// The output is always valid YAML 1.2. See <see cref="YamlWriterFormat.Kyaml"/>.
+    /// </remarks>
+    public static readonly YamlWriterOptions Kyaml = new() { Format = YamlWriterFormat.Kyaml };
 
     /// <summary>
     /// Initializes a new instance of the <see cref="YamlWriterOptions"/> struct with default values.
@@ -25,6 +36,7 @@ public readonly struct YamlWriterOptions
     {
         this.IndentSize = 2;
         this.SkipValidation = false;
+        this.Format = YamlWriterFormat.Yaml;
     }
 
     /// <summary>
@@ -39,4 +51,10 @@ public readonly struct YamlWriterOptions
     /// write operations produce structurally valid YAML.
     /// </summary>
     public bool SkipValidation { get; init; }
+
+    /// <summary>
+    /// Gets the output dialect produced by the writer.
+    /// Defaults to <see cref="YamlWriterFormat.Yaml"/>.
+    /// </summary>
+    public YamlWriterFormat Format { get; init; }
 }

--- a/src/Corvus.Yaml.SystemTextJson/Corvus.Yaml.SystemTextJson.csproj
+++ b/src/Corvus.Yaml.SystemTextJson/Corvus.Yaml.SystemTextJson.csproj
@@ -43,6 +43,7 @@
     <Compile Include="$(CtjYamlSourceDir)YamlScalarStyle.cs" Link="Corvus\Yaml\YamlScalarStyle.cs" />
     <Compile Include="$(CtjYamlSourceDir)YamlSchema.cs" Link="Corvus\Yaml\YamlSchema.cs" />
     <Compile Include="$(CtjYamlSourceDir)YamlWriterOptions.cs" Link="Corvus\Yaml\YamlWriterOptions.cs" />
+    <Compile Include="$(CtjYamlSourceDir)YamlWriterFormat.cs" Link="Corvus\Yaml\YamlWriterFormat.cs" />
     <Compile Include="$(CtjYamlSourceDir)YamlDocument.cs" Link="Corvus\Yaml\YamlDocument.cs" />
   </ItemGroup>
   <!-- Shared internal types from CTJ YAML project (with #if STJ namespace) -->

--- a/tests/Corvus.Text.Json.Yaml.Tests/KyamlTests.cs
+++ b/tests/Corvus.Text.Json.Yaml.Tests/KyamlTests.cs
@@ -1,0 +1,297 @@
+// <copyright file="KyamlTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.Buffers;
+using System.Text;
+#if STJ
+using System.Text.Json;
+using Corvus.Yaml;
+#else
+using Corvus.Text.Json;
+using Corvus.Text.Json.Yaml;
+#endif
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+#if STJ
+namespace Corvus.Yaml.SystemTextJson.Tests;
+#else
+namespace Corvus.Text.Json.Yaml.Tests;
+#endif
+
+/// <summary>
+/// Tests for KYAML output (<see cref="YamlWriterFormat.Kyaml"/>): a strict subset of
+/// YAML 1.2 with explicit delimiters, quoted string values, and trailing commas.
+/// </summary>
+[TestClass]
+public class KyamlTests
+{
+    // ===================================================================
+    // Output shape
+    // ===================================================================
+
+    [TestMethod]
+    public void NestedObject_ProducesExpectedLayout()
+    {
+        string json =
+            """{"name":"hostnames","port":80,"enabled":true,"meta":{"a":"b"},"tags":["x","y"],"empty":{},"none":null}""";
+
+        string expected =
+            """
+            {
+              name: "hostnames",
+              port: 80,
+              enabled: true,
+              meta: {
+                a: "b",
+              },
+              tags: [
+                "x",
+                "y",
+              ],
+              empty: {},
+              none: null,
+            }
+            """;
+
+        string kyaml = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);
+        Assert.AreEqual(Lf(expected), kyaml);
+    }
+
+    [TestMethod]
+    public void ArrayOfObjects_ProducesExpectedLayout()
+    {
+        string json = """[{"a":1},{"b":2}]""";
+
+        string expected =
+            """
+            [
+              {
+                a: 1,
+              },
+              {
+                b: 2,
+              },
+            ]
+            """;
+
+        string kyaml = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);
+        Assert.AreEqual(Lf(expected), kyaml);
+    }
+
+    // ===================================================================
+    // Scalar quoting — strings always quoted; numbers/bools/null bare
+    // ===================================================================
+
+    [TestMethod]
+    public void StringValuesAreAlwaysQuoted_IncludingTypeAmbiguousWords()
+    {
+        // The "Norway problem": NO must remain a quoted string, and a string
+        // that looks like a number ("123") or a bool ("true") must be quoted too.
+        string json = """{"country":"NO","str":"123","flag":"true"}""";
+
+        string expected =
+            """
+            {
+              country: "NO",
+              str: "123",
+              flag: "true",
+            }
+            """;
+
+        string kyaml = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);
+        Assert.AreEqual(Lf(expected), kyaml);
+    }
+
+    [TestMethod]
+    public void NumbersBooleansAndNullAreBare()
+    {
+        string json = """{"num":42,"real":3.14,"flagOn":true,"flagOff":false,"nothing":null}""";
+
+        string expected =
+            """
+            {
+              num: 42,
+              real: 3.14,
+              flagOn: true,
+              flagOff: false,
+              nothing: null,
+            }
+            """;
+
+        string kyaml = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);
+        Assert.AreEqual(Lf(expected), kyaml);
+    }
+
+    [TestMethod]
+    public void AmbiguousKeysAreQuoted_SafeKeysAreNot()
+    {
+        // Keys that would resolve to a non-string scalar (true, 123) or are a
+        // YAML 1.1 type-ambiguous word (no) are quoted; ordinary identifier keys
+        // are left bare.
+        string json = """{"safeKey":"a","true":"b","123":"c","no":"d"}""";
+
+        string expected =
+            """
+            {
+              safeKey: "a",
+              "true": "b",
+              "123": "c",
+              "no": "d",
+            }
+            """;
+
+        string kyaml = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);
+        Assert.AreEqual(Lf(expected), kyaml);
+    }
+
+    // ===================================================================
+    // Empty and root values
+    // ===================================================================
+
+    [TestMethod]
+    [DataRow("{}", "{}")]
+    [DataRow("[]", "[]")]
+    [DataRow("\"hello\"", "\"hello\"")]
+    [DataRow("42", "42")]
+    [DataRow("true", "true")]
+    [DataRow("null", "null")]
+    public void RootScalarsAndEmptyContainers(string json, string expectedKyaml)
+    {
+        string kyaml = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);
+        Assert.AreEqual(expectedKyaml, kyaml);
+    }
+
+    // ===================================================================
+    // Enabling KYAML via Format vs the preset are equivalent
+    // ===================================================================
+
+    [TestMethod]
+    public void FormatPropertyAndPresetAreEquivalent()
+    {
+        string json = """{"a":"b","c":[1,2]}""";
+
+        string viaPreset = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);
+        string viaFormat = YamlDocument.ConvertToYamlString(
+            json,
+            new YamlWriterOptions { Format = YamlWriterFormat.Kyaml });
+
+        Assert.AreEqual(viaPreset, viaFormat);
+    }
+
+    [TestMethod]
+    public void DefaultFormatIsStillBlockYaml()
+    {
+        // Guard against regressing the default (canonical block) output.
+        string json = """{"name":"Alice","age":30}""";
+
+        string expected =
+            """
+            name: Alice
+            age: 30
+            """;
+
+        string yaml = YamlDocument.ConvertToYamlString(json);
+        Assert.AreEqual(Lf(expected), yaml);
+    }
+
+    // ===================================================================
+    // Round-trip — KYAML is valid YAML and parses back to the same data
+    // ===================================================================
+
+    [TestMethod]
+    public void RoundTripsThroughTheParser()
+    {
+        string json =
+            """{"country":"NO","port":80,"enabled":true,"nested":{"items":["a","b"]},"none":null}""";
+
+        string kyaml = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);
+
+        using var doc = YamlTestHelper.Parse(Encoding.UTF8.GetBytes(kyaml));
+        JsonElement root = doc.RootElement;
+
+        Assert.AreEqual("NO", root.GetProperty("country"u8).GetString());
+        Assert.AreEqual(80, root.GetProperty("port"u8).GetInt32());
+        Assert.IsTrue(root.GetProperty("enabled"u8).GetBoolean());
+        Assert.AreEqual(JsonValueKind.Null, root.GetProperty("none"u8).ValueKind);
+
+        JsonElement items = root.GetProperty("nested"u8).GetProperty("items"u8);
+        Assert.AreEqual(2, items.GetArrayLength());
+        Assert.AreEqual("a", items[0].GetString());
+        Assert.AreEqual("b", items[1].GetString());
+    }
+
+    // ===================================================================
+    // Low-level Utf8YamlWriter honours the KYAML format
+    // ===================================================================
+
+    [TestMethod]
+    public void Utf8YamlWriter_KyamlOptions_EmitsKyaml()
+    {
+        ArrayBufferWriter<byte> buffer = new();
+        Utf8YamlWriter writer = new(buffer, YamlWriterOptions.Kyaml);
+
+        try
+        {
+            writer.WriteStartMapping();
+            writer.WritePropertyName("key"u8);
+            writer.WriteStringValue("value"u8);
+            writer.WriteEndMapping();
+            writer.Flush();
+        }
+        finally
+        {
+            writer.Dispose();
+        }
+
+        string kyaml = Encoding.UTF8.GetString(buffer.WrittenSpan.ToArray());
+
+        string expected =
+            """
+            {
+              key: "value",
+            }
+            """;
+
+        Assert.AreEqual(Lf(expected), kyaml);
+    }
+
+    // ===================================================================
+    // The exact example published in docs/Yaml.md (guards against drift)
+    // ===================================================================
+
+    [TestMethod]
+    public void KubernetesServiceExample_MatchesDocumentation()
+    {
+        string json =
+            """{"apiVersion":"v1","kind":"Service","metadata":{"name":"hostnames"},"spec":{"ports":[{"port":80,"protocol":"TCP"}]}}""";
+
+        string expected =
+            """
+            {
+              apiVersion: "v1",
+              kind: "Service",
+              metadata: {
+                name: "hostnames",
+              },
+              spec: {
+                ports: [
+                  {
+                    port: 80,
+                    protocol: "TCP",
+                  },
+                ],
+              },
+            }
+            """;
+
+        string kyaml = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);
+        Assert.AreEqual(Lf(expected), kyaml);
+    }
+
+    /// <summary>
+    /// Normalizes CRLF to LF so expected values match the writer's LF output
+    /// regardless of how this source file is checked out.
+    /// </summary>
+    private static string Lf(string value) => value.Replace("\r\n", "\n");
+}

--- a/tests/Corvus.Yaml.SystemTextJson.Tests/Corvus.Yaml.SystemTextJson.Tests.csproj
+++ b/tests/Corvus.Yaml.SystemTextJson.Tests/Corvus.Yaml.SystemTextJson.Tests.csproj
@@ -15,6 +15,7 @@
     <Compile Include="$(CtjTestDir)ScalarTests.cs" Link="ScalarTests.cs" />
     <Compile Include="$(CtjTestDir)CollectionTests.cs" Link="CollectionTests.cs" />
     <Compile Include="$(CtjTestDir)JsonToYamlTests.cs" Link="JsonToYamlTests.cs" />
+    <Compile Include="$(CtjTestDir)KyamlTests.cs" Link="KyamlTests.cs" />
     <Compile Include="$(CtjTestDir)Utf8YamlWriterTests.cs" Link="Utf8YamlWriterTests.cs" />
     <Compile Include="$(CtjTestDir)YamlCoverageTests.cs" Link="YamlCoverageTests.cs" />
     <Compile Include="$(CtjTestDir)YamlDocumentParseOverloadTests.cs" Link="YamlDocumentParseOverloadTests.cs" />


### PR DESCRIPTION
## Summary

Adds a **KYAML** output mode to the JSON→YAML writer. [KYAML](https://github.com/kubernetes/enhancements/tree/master/keps/sig-cli/5295-kyaml) (Kubernetes KEP-5295) is a strict subset of YAML 1.2 designed to be unambiguous and free of the usual YAML pitfalls.

Closes #823.

## What it does

In KYAML mode the writer:
- renders every mapping with explicit `{ }` braces and every sequence with explicit `[ ]` brackets, laid out across indented lines (no reliance on significant indentation);
- **always double-quotes string values**, so a value like `NO` stays a string (the "Norway problem") and `"123"`/`"true"` are never mistaken for a number/bool;
- writes numbers, booleans, and `null` bare;
- quotes mapping **keys only when they would otherwise be ambiguous** (e.g. `true`, `123`, or a YAML 1.1 word like `no`);
- writes a trailing comma after every element; renders empty collections as `{}` / `[]`.

KYAML output is always valid YAML 1.2, so it round-trips through any conforming parser — including this library's own reader, which already accepts trailing commas in flow collections (no reader changes needed).

### Enabling it

```csharp
// Preset (easiest):
string kyaml = YamlDocument.ConvertToYamlString(json, YamlWriterOptions.Kyaml);

// Or set the format explicitly:
var options = new YamlWriterOptions { Format = YamlWriterFormat.Kyaml };
```

Works on every `ConvertToYaml`/`ConvertToYamlString` overload and directly on `Utf8YamlWriter`. The default output remains canonical block-style YAML.

## Design notes

- A single `YamlWriterFormat` switch (+ `YamlWriterOptions.Kyaml` preset) rather than raw `QuoteAllStrings`/`DefaultCollectionStyle` knobs — those only produce valid KYAML in one specific combination, easy to misuse.
- The behaviour lives **entirely in `Utf8YamlWriter`** (gated on `_kyaml`); the block and inline-flow paths are untouched and `JsonToYamlConverter` is unchanged, so both `Corvus.Text.Json.Yaml` and `Corvus.Yaml.SystemTextJson` gain it.
- Output is canonical, non-"cuddled" KYAML (each collection broken across its own lines). Fully spec-conformant; the optional cuddled-bracket layout kubectl emits for compactness is not produced.

## Tests

`KyamlTests.cs` (16 tests, shared across both packages): output shape, the Norway problem, ambiguous-key quoting (incl. the YAML 1.1 `no` case), bare scalars, empties/root values, preset ≡ `Format`, a default-still-block regression guard, round-trip through the parser, the low-level writer, and the exact example published in the docs (guards against drift). Expectations are EOL-normalized so they hold under `.gitattributes` CRLF conversion.

## Docs

- New `## KYAML output` section in `docs/Yaml.md` (what it is + how to enable, with a verified example), plus updated feature-comparison table and "when to use" guidance.
- KYAML note added to the `corvus-yaml` skill.
- Code-sample catalog refreshed; `VERSIONHISTORY.md` entry added (V5.1.19).

## Verification

- `dotnet build Corvus.Text.Json.slnx` → **0 Warnings, 0 Errors**
- YAML suites: **1472** (CTJ) + **1392** (STJ) pass, incl. 16 KYAML tests each
- `update-code-sample-catalog.ps1 -Check` → exit 0

> Note: tests were run on `net10.0` (this dev env can't run the `net481` target under mono); CI runs the full matrix. The change is platform-agnostic span/byte code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

