### PR TITLE
Fix #825: make generated type names deterministic across operating systems

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -20,4 +20,4 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "5.1"
+next-version: "5.2"

--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,13 @@
 # Version History
 
+## V5.2.0
+
+V5.2.0 makes generated JSON Schema type names deterministic across operating systems, fixing a rare case where the same schema produced a different generated type name on Windows than on Linux or macOS.
+
+### Breaking changes
+
+- **Generated type names no longer depend on the host operating system** — In a **rare** case, the documentation-based type-name heuristic could derive a different name for the same anonymous (inline) subschema depending on which OS the generator ran on. When such a subschema had a `description` and no `title`, the heuristic only named the type from that description when its length was under a 64-character cap — but the length it measured included a trailing line break assembled with `Environment.NewLine`, which is `"\r\n"` on Windows and `"\n"` on Linux and macOS. A `description` whose length landed exactly on that boundary (or one carrying trailing whitespace) therefore passed the cap on Linux/macOS — yielding a name derived from the description — yet failed it on Windows by a single character, where the generator fell back to the next heuristic (typically the required-property name, e.g. `TheIdentifierOfTheAssociatedRequiredDocument` on Linux/macOS versus `RequiredDocumentId` on Windows). The assembled documentation is now joined with a fixed `'\n'` separator and the length is measured after trimming, so the heuristic reaches the same decision on every platform. This affects only the **narrow** set of schemas whose documentation-derived name sat exactly on the boundary; for those, regenerating may change a generated type name (and any hand-written code that referenced it). Because the fix is in the shared code-generation core, it applies to the V4 and V5 engines, the `corvusjson` CLI, and the source generators. See [#825](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/825).
+
 ## V5.1.19
 
 V5.1.19 adds a KYAML output mode to the JSON→YAML writer.

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/NameHeuristics/DocumentationNameHeuristic.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/NameHeuristics/DocumentationNameHeuristic.cs
@@ -43,13 +43,19 @@ public sealed class DocumentationNameHeuristic : INameHeuristicBeforeSubschema
             }
         }
 
-        if (typeDeclaration.LongDocumentation() is string longDocumentation &&
-            longDocumentation.Length > 0 && longDocumentation.Length < 64)
+        if (typeDeclaration.LongDocumentation() is string longDocumentation)
         {
-            written = Formatting.FormatTypeNameComponent(typeDeclaration, longDocumentation.AsSpan(), typeNameBuffer);
-            if (written > 1 && written < 64 && !typeDeclaration.CollidesWithParent(typeNameBuffer[..written]))
+            // Measure the trimmed length so trailing whitespace (or any separator introduced
+            // while assembling multi-keyword documentation) cannot influence the decision. This
+            // keeps the heuristic's outcome identical across platforms regardless of newline style.
+            ReadOnlySpan<char> trimmedLongDocumentation = longDocumentation.AsSpan().TrimEnd();
+            if (trimmedLongDocumentation.Length > 0 && trimmedLongDocumentation.Length < 64)
             {
-                return true;
+                written = Formatting.FormatTypeNameComponent(typeDeclaration, trimmedLongDocumentation, typeNameBuffer);
+                if (written > 1 && written < 64 && !typeDeclaration.CollidesWithParent(typeNameBuffer[..written]))
+                {
+                    return true;
+                }
             }
         }
 

--- a/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Documentation/Documentation.cs
+++ b/src-v4/Corvus.Json.CodeGeneration/Corvus.Json.CodeGeneration/Documentation/Documentation.cs
@@ -45,7 +45,7 @@ public static class Documentation
     /// <returns><see langword="true"/> if the long form documentation was found.</returns>
     /// <remarks>
     /// Long form documentation is expected to be a multi-line string. If multiple long-form provider keywords are present,
-    /// then the results will be appended in alphabetical order by keyword, to help with stability.
+    /// then the results are joined in alphabetical order by keyword, to help with stability.
     /// </remarks>
     public static bool TryGetLongDocumentation(TypeDeclaration typeDeclaration, [NotNullWhen(true)] out string? longDocumentation)
     {
@@ -54,7 +54,17 @@ public static class Documentation
         {
             if (keyword.TryGetLongDocumentation(typeDeclaration, out string? docs))
             {
-                builder.AppendLine(docs);
+                // Join entries with a fixed '\n' (never Environment.NewLine) and emit no
+                // trailing newline. This assembled length feeds the documentation name
+                // heuristic, so it must be identical on every platform; Environment.NewLine
+                // ("\r\n" on Windows vs "\n" elsewhere) would otherwise make generated type
+                // names depend on the build OS. See DocumentationNameHeuristic.
+                if (builder.Length > 0)
+                {
+                    builder.Append('\n');
+                }
+
+                builder.Append(docs);
             }
         }
 

--- a/src/Corvus.Text.Json.CodeGeneration/NameHeuristics/DocumentationNameHeuristic.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/NameHeuristics/DocumentationNameHeuristic.cs
@@ -51,13 +51,19 @@ public sealed class DocumentationNameHeuristic : INameHeuristicBeforeSubschema
             }
         }
 
-        if (typeDeclaration.LongDocumentation() is string longDocumentation &&
-            longDocumentation.Length > 0 && longDocumentation.Length < 64)
+        if (typeDeclaration.LongDocumentation() is string longDocumentation)
         {
-            written = Formatting.FormatTypeNameComponent(typeDeclaration, longDocumentation.AsSpan(), typeNameBuffer);
-            if (written > 1 && written < 64 && !typeDeclaration.CollidesWithParent(typeNameBuffer[..written]))
+            // Measure the trimmed length so trailing whitespace (or any separator introduced
+            // while assembling multi-keyword documentation) cannot influence the decision. This
+            // keeps the heuristic's outcome identical across platforms regardless of newline style.
+            ReadOnlySpan<char> trimmedLongDocumentation = longDocumentation.AsSpan().TrimEnd();
+            if (trimmedLongDocumentation.Length > 0 && trimmedLongDocumentation.Length < 64)
             {
-                return true;
+                written = Formatting.FormatTypeNameComponent(typeDeclaration, trimmedLongDocumentation, typeNameBuffer);
+                if (written > 1 && written < 64 && !typeDeclaration.CollidesWithParent(typeNameBuffer[..written]))
+                {
+                    return true;
+                }
             }
         }
 

--- a/tests/Corvus.Text.Json.CodeGenerator.Tests/NameHeuristicTests.cs
+++ b/tests/Corvus.Text.Json.CodeGenerator.Tests/NameHeuristicTests.cs
@@ -157,4 +157,97 @@ public class NameHeuristicTests : IDisposable
             !fileNames.Any(f => f.Contains("WithA1AndB2AndC3AndD4AndE5", StringComparison.Ordinal)),
             $"Expected const heuristic to bail out with 5 properties. Got: {string.Join(", ", fileNames)}");
     }
+
+    [TestMethod]
+    public async Task Generate_LongDescriptionAtNewlineBoundary_NamesFromDocumentationNotPlatformDependent()
+    {
+        // Regression for cross-platform naming divergence (issue #825): the documentation
+        // name heuristic gated on a length that included a trailing Environment.NewLine
+        // ("\n" on Linux vs "\r\n" on Windows), so a description whose length landed on the
+        // < 64 boundary produced the documentation name on Linux but fell back to the
+        // required-property name on Windows.
+        //
+        // This description is exactly 63 characters with no `title`, so it lands on that
+        // boundary. The generated type must be named from the description text alone, on
+        // every platform — never from the `identifier` required property.
+        const string description = "Sphinx canonical reference for the associated stored documents.";
+        Assert.AreEqual(63, description.Length, "Test description must be exactly 63 chars to sit on the boundary.");
+
+        string schemaContent = $$"""
+            {
+              "type": "object",
+              "properties": {
+                "widget": {
+                  "type": "object",
+                  "description": "{{description}}",
+                  "required": ["identifier"],
+                  "properties": { "identifier": { "type": "string" } }
+                }
+              }
+            }
+            """;
+
+        string[] fileNames = await GenerateInlineAndGetTypeNamesAsync(schemaContent);
+        string joined = string.Join(", ", fileNames);
+
+        Assert.IsTrue(
+            fileNames.Any(f => f.Contains("SphinxCanonicalReference", StringComparison.Ordinal)),
+            $"Expected the inline type to be named from its description. Got: {joined}");
+        Assert.IsFalse(
+            fileNames.Any(f => f.Contains("RequiredIdentifier", StringComparison.Ordinal)),
+            $"Expected NO required-property fallback name (that is the Windows-only regression). Got: {joined}");
+    }
+
+    [TestMethod]
+    public async Task Generate_LongDescriptionWithTrailingWhitespace_NamesFromTrimmedDocumentation()
+    {
+        // Regression for issue #825: trailing whitespace (or a separator added while
+        // assembling multi-keyword documentation) must not push the documentation length
+        // over the < 64 gate. The name must derive from the trimmed description.
+        string description = "Obelisk summary of the associated stored record" + new string(' ', 20);
+        Assert.IsTrue(description.Length >= 64, "Trailing whitespace must take the raw length over the 64 gate.");
+
+        string schemaContent = $$"""
+            {
+              "type": "object",
+              "properties": {
+                "widget": {
+                  "type": "object",
+                  "description": "{{description}}",
+                  "required": ["identifier"],
+                  "properties": { "identifier": { "type": "string" } }
+                }
+              }
+            }
+            """;
+
+        string[] fileNames = await GenerateInlineAndGetTypeNamesAsync(schemaContent);
+        string joined = string.Join(", ", fileNames);
+
+        Assert.IsTrue(
+            fileNames.Any(f => f.Contains("ObeliskSummaryOfTheAssociatedStoredRecord", StringComparison.Ordinal)),
+            $"Expected the inline type to be named from its trimmed description. Got: {joined}");
+        Assert.IsFalse(
+            fileNames.Any(f => f.Contains("RequiredIdentifier", StringComparison.Ordinal)),
+            $"Expected NO required-property fallback name. Got: {joined}");
+    }
+
+    private async Task<string[]> GenerateInlineAndGetTypeNamesAsync(string schemaContent)
+    {
+        string schemaPath = Path.Combine(_outputDir, "schema.json");
+        await File.WriteAllTextAsync(schemaPath, schemaContent);
+
+        string outputDir = Path.Combine(_outputDir, "output");
+        Directory.CreateDirectory(outputDir);
+
+        ProcessResult result = await CodeGeneratorRunner.RunAsync(
+            $"jsonschema \"{schemaPath}\" --rootNamespace TestGenerated --outputPath \"{outputDir}\"");
+
+        Assert.AreEqual(0, result.ExitCode, $"Generation failed. Stderr: {result.StandardError}");
+
+        string[] files = Directory.GetFiles(outputDir, "*.cs", SearchOption.AllDirectories);
+        Assert.IsTrue(files.Length > 0, $"Expected generated files. Stderr: {result.StandardError}");
+
+        return files.Select(Path.GetFileNameWithoutExtension).ToArray()!;
+    }
 }


### PR DESCRIPTION
Fixes #825.

## Problem

Generating C# from the **same** JSON Schema produced **different generated type names on Windows vs Linux/macOS**. The documentation-based type-name heuristic only names an anonymous (inline) subschema from its `description` when the length is under a 64-character cap — but the length it measured included a trailing line break assembled with `Environment.NewLine` (`"\r\n"` on Windows, `"\n"` elsewhere). A `description` landing exactly on that boundary (or carrying trailing whitespace) passed the cap on Linux/macOS but failed it on Windows by one character, where generation fell back to the next heuristic (typically the required-property name) — e.g. `TheIdentifierOfTheAssociatedRequiredDocument` vs `RequiredDocumentId`.

This made generated output non-deterministic across build hosts (CI vs dev, Windows vs WSL), which can break `partial` extensions and hand-written references to generated types.

## Fix (both root-cause angles)

| File | Change |
|---|---|
| `src-v4/…/Documentation/Documentation.cs` | Assemble long-form documentation with a fixed `'\n'` separator (never `Environment.NewLine`) and no trailing newline. Shared core → fixes **both** engines. |
| `src/Corvus.Text.Json.CodeGeneration/NameHeuristics/DocumentationNameHeuristic.cs` | Gate on the **trimmed** length (`TrimEnd().Length < 64`) — V5. |
| `src-v4/…CSharp/…/NameHeuristics/DocumentationNameHeuristic.cs` | Same trimmed-length gate — V4, for consistency. |

Because the fix is in the shared code-generation core, it applies to the V4 and V5 engines, the `corvusjson` CLI, and the source generators. There is **no change to generated documentation output** — the doc emitters already split paragraphs with blank-line removal, so dropping the trailing newline is behaviour-neutral.

## Tests

Two regression tests added to `NameHeuristicTests.cs`:
- a 63-char `description` at the newline boundary (this case **falls back to the required-property name on Linux pre-fix**, so it genuinely guards the regression — not just on Windows);
- a `description` with trailing whitespace pushing the raw length over the cap.

All six name-heuristic tests pass on net10.0.

## Versioning

This is a **rare** breaking change to generated type names (only schemas whose documentation-derived name sat exactly on the boundary are affected), so the minor version is bumped to **V5.2.0** (`next-version` in `GitVersion.yml`), with a `### Breaking changes` entry in `VERSIONHISTORY.md` as the sole item for the release.

## Note on generated baselines

This is a model-generator change, so it does affect the generated *type names* for a handful of benchmark model schemas whose descriptions sit on the boundary (~10 of the `*BenchmarkModels`). The benchmark `C/` directories are **intentionally not regenerated here** — that resync is owned by the dedicated `benchmarks/scripts/Regenerate-CurrentBenchmarks.ps1` effort (which never touches the frozen `B/` baselines) and will pick up this change when run against merged `main`. The example recipes are unaffected by this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
