### PR TITLE
Fix: HttpClientTransport combines base-path prefix with operation paths (V5.2.3)

### DIFF
--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,13 @@
 # Version History
 
+## V5.2.3
+
+V5.2.3 fixes the `HttpClient`-backed OpenAPI transport so that a base URL carrying a path prefix — for example an API-gateway route — is preserved in every request URI.
+
+### Bug fixes
+
+- **`HttpClientTransport` now preserves a base URL's path prefix** — Generated operation paths always begin with `/`, and the transport previously sent them as relative URIs for `HttpClient` to resolve against `HttpClient.BaseAddress`. Under RFC 3986 §5.3, an absolute-path reference such as `/transactions` **replaces** the base URI's entire path, so any deployment whose base URL carries a path prefix — the Azure API Management pattern, `https://apim.example/inventory/` — silently lost the prefix: requests landed on `https://apim.example/transactions` instead of `https://apim.example/inventory/transactions`, and because generated paths always start with `/` there was no `BaseAddress` spelling that avoided it. The transport now composes the final absolute URI itself — the base address up to and including its path, with any trailing `/` trimmed, followed by the resolved operation path and query — so the prefix is preserved; this is the same composition NSwag- and Kiota-generated clients use. For a base address with no path segment the composed URI is byte-identical to the previous resolution, and a client with no `BaseAddress` at all still fails with `HttpClient`'s usual invalid-request-URI error, so no other behavior changes. This is a runtime fix in `Corvus.Text.Json.OpenApi.HttpTransport`; no regeneration of generated clients is required.
+
 ## V5.2.2
 
 V5.2.2 lets the property-parameter `Build(...)` factory be used directly as an array element (or object-property value) inside a mutable builder callback.

--- a/src/Corvus.Text.Json.OpenApi.HttpTransport/HttpClientTransport.cs
+++ b/src/Corvus.Text.Json.OpenApi.HttpTransport/HttpClientTransport.cs
@@ -27,6 +27,18 @@ namespace Corvus.Text.Json.OpenApi.HttpTransport;
 /// the <see langword="string"/> required by <see cref="HttpRequestMessage"/>.
 /// </para>
 /// <para>
+/// The final request URI is composed by the transport itself. The resolved operation path
+/// (which always begins with <c>/</c>) is appended textually to
+/// <see cref="HttpClient.BaseAddress"/>, preserving any path prefix the base address
+/// carries — for example an API-gateway route such as <c>https://apim.example/inventory/</c>,
+/// which yields <c>https://apim.example/inventory/pets</c>. Had resolution been left to
+/// <see cref="HttpClient"/>, RFC 3986 §5.3 absolute-path-reference semantics would replace
+/// the base address's entire path and silently drop the prefix. For a base address with no
+/// path segment the composed URI is identical to the RFC 3986 resolution. If the client has
+/// no <see cref="HttpClient.BaseAddress"/>, the request URI is left relative and
+/// <see cref="HttpClient"/> raises its usual error.
+/// </para>
+/// <para>
 /// The transport does not own the <see cref="HttpClient"/> by default.
 /// Pass <c>disposeClient: true</c> to the constructor if the transport should dispose
 /// the client when it is itself disposed.
@@ -159,8 +171,11 @@ public sealed class HttpClientTransport : IApiTransport
     {
         string relativePath = BuildUri(in request);
 
-        // Use the string-accepting constructor. HttpClient.SendAsync resolves
-        // this relative path against HttpClient.BaseAddress automatically.
+        // Use the string-accepting constructor to hold the relative operation URI.
+        // SendCoreAsync composes the final absolute URI itself (see ApplyBaseAddress),
+        // preserving any path prefix carried by HttpClient.BaseAddress — HttpClient's
+        // own RFC 3986 resolution would replace the base path entirely, because
+        // operation paths always begin with '/'.
         HttpRequestMessage httpRequest = new(MapMethod<TRequest>(TRequest.Method), relativePath);
 
         if (TRequest.HasHeaderParameters)
@@ -233,6 +248,8 @@ public sealed class HttpClientTransport : IApiTransport
         CancellationToken cancellationToken)
         where TResponse : struct, IApiResponse<TResponse>
     {
+        this.ApplyBaseAddress(httpRequest);
+
         if (this.authenticationProvider is not null)
         {
             await this.authenticationProvider
@@ -265,6 +282,40 @@ public sealed class HttpClientTransport : IApiTransport
         {
             httpResponse.Dispose();
             throw;
+        }
+    }
+
+    /// <summary>
+    /// Composes the final absolute request URI from <see cref="HttpClient.BaseAddress"/>
+    /// and the relative operation URI produced by <see cref="BuildHttpRequest"/>,
+    /// preserving any path prefix carried by the base address.
+    /// </summary>
+    /// <param name="httpRequest">The request whose <see cref="HttpRequestMessage.RequestUri"/>
+    /// is rewritten in place.</param>
+    /// <remarks>
+    /// <para>
+    /// Generated operation paths always begin with <c>/</c>, so leaving resolution to
+    /// <see cref="HttpClient"/> would apply RFC 3986 §5.3 absolute-path-reference semantics
+    /// and replace the base address's entire path — silently dropping a prefix such as an
+    /// API-gateway route (<c>https://apim.example/inventory/</c>). Composing the URI
+    /// textually — the base up to its path with any trailing <c>/</c> trimmed, followed by
+    /// the operation path and query — keeps the prefix. For a base address with no path
+    /// segment the result is identical to the RFC 3986 resolution.
+    /// </para>
+    /// <para>
+    /// If the client has no <see cref="HttpClient.BaseAddress"/>, or the request URI is
+    /// already absolute or does not begin with <c>/</c>, the request is left untouched and
+    /// <see cref="HttpClient"/> behaves exactly as before.
+    /// </para>
+    /// </remarks>
+    private void ApplyBaseAddress(HttpRequestMessage httpRequest)
+    {
+        if (this.httpClient.BaseAddress is Uri baseAddress
+            && httpRequest.RequestUri is { IsAbsoluteUri: false } relativeUri
+            && relativeUri.OriginalString.StartsWith('/'))
+        {
+            string basePart = baseAddress.GetLeftPart(UriPartial.Path).TrimEnd('/');
+            httpRequest.RequestUri = new Uri(basePart + relativeUri.OriginalString, UriKind.Absolute);
         }
     }
 

--- a/src/Corvus.Text.Json.OpenApi.HttpTransport/HttpClientTransport.cs
+++ b/src/Corvus.Text.Json.OpenApi.HttpTransport/HttpClientTransport.cs
@@ -307,6 +307,13 @@ public sealed class HttpClientTransport : IApiTransport
     /// already absolute or does not begin with <c>/</c>, the request is left untouched and
     /// <see cref="HttpClient"/> behaves exactly as before.
     /// </para>
+    /// <para>
+    /// The composition allocates exactly one string per request (the composed URI passed to
+    /// the <see cref="Uri"/> constructor). The base part is always a prefix of
+    /// <see cref="Uri.AbsoluteUri"/> — which the base <see cref="Uri"/> caches — because the
+    /// query/fragment cut and the trailing-<c>/</c> trim only ever shorten it from the end,
+    /// so both halves are written straight into the final string.
+    /// </para>
     /// </remarks>
     private void ApplyBaseAddress(HttpRequestMessage httpRequest)
     {
@@ -314,8 +321,29 @@ public sealed class HttpClientTransport : IApiTransport
             && httpRequest.RequestUri is { IsAbsoluteUri: false } relativeUri
             && relativeUri.OriginalString.StartsWith('/'))
         {
-            string basePart = baseAddress.GetLeftPart(UriPartial.Path).TrimEnd('/');
-            httpRequest.RequestUri = new Uri(basePart + relativeUri.OriginalString, UriKind.Absolute);
+            string baseUri = baseAddress.AbsoluteUri;
+            int baseLength = baseUri.AsSpan().IndexOfAny('?', '#');
+            if (baseLength < 0)
+            {
+                baseLength = baseUri.Length;
+            }
+
+            while (baseLength > 0 && baseUri[baseLength - 1] == '/')
+            {
+                baseLength--;
+            }
+
+            string relative = relativeUri.OriginalString;
+            string composed = string.Create(
+                baseLength + relative.Length,
+                (baseUri, baseLength, relative),
+                static (span, state) =>
+                {
+                    state.baseUri.AsSpan(0, state.baseLength).CopyTo(span);
+                    state.relative.CopyTo(span[state.baseLength..]);
+                });
+
+            httpRequest.RequestUri = new Uri(composed, UriKind.Absolute);
         }
     }
 

--- a/tests/Corvus.Text.Json.OpenApi.HttpTransport.Tests/HttpClientTransportTests.cs
+++ b/tests/Corvus.Text.Json.OpenApi.HttpTransport.Tests/HttpClientTransportTests.cs
@@ -246,6 +246,128 @@ public class HttpClientTransportTests
     }
 
     [TestMethod]
+    public async Task SendAsync_BaseAddressWithPathPrefixAndTrailingSlash_PrefixPreserved()
+    {
+        HttpRequestMessage? captured = null;
+
+        using HttpClient client = CreateMockClient(
+            HttpStatusCode.OK,
+            "[]"u8.ToArray(),
+            onRequest: req => { captured = req; return Task.CompletedTask; },
+            baseAddress: "https://apim.example/inventory/");
+
+        await using HttpClientTransport transport = new(client);
+
+        TestGetRequest request = default;
+        await using TestResponse response =
+            await transport.SendAsync<TestGetRequest, TestResponse>(in request);
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual("https://apim.example/inventory/pets/1", captured.RequestUri?.AbsoluteUri);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_BaseAddressWithPathPrefixNoTrailingSlash_PrefixPreserved()
+    {
+        HttpRequestMessage? captured = null;
+
+        using HttpClient client = CreateMockClient(
+            HttpStatusCode.OK,
+            "[]"u8.ToArray(),
+            onRequest: req => { captured = req; return Task.CompletedTask; },
+            baseAddress: "https://apim.example/inventory");
+
+        await using HttpClientTransport transport = new(client);
+
+        TestGetRequest request = default;
+        await using TestResponse response =
+            await transport.SendAsync<TestGetRequest, TestResponse>(in request);
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual("https://apim.example/inventory/pets/1", captured.RequestUri?.AbsoluteUri);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_BaseAddressWithoutPathPrefix_ResolvesAsBefore()
+    {
+        HttpRequestMessage? captured = null;
+
+        using HttpClient client = CreateMockClient(
+            HttpStatusCode.OK,
+            "[]"u8.ToArray(),
+            onRequest: req => { captured = req; return Task.CompletedTask; },
+            baseAddress: "https://api.example/");
+
+        await using HttpClientTransport transport = new(client);
+
+        TestGetRequest request = default;
+        await using TestResponse response =
+            await transport.SendAsync<TestGetRequest, TestResponse>(in request);
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual("https://api.example/pets/1", captured.RequestUri?.AbsoluteUri);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_QueryParameters_WithPathPrefixedBaseAddress_PathAndQueryPreserved()
+    {
+        HttpRequestMessage? captured = null;
+
+        using HttpClient client = CreateMockClient(
+            HttpStatusCode.OK,
+            "[]"u8.ToArray(),
+            onRequest: req => { captured = req; return Task.CompletedTask; },
+            baseAddress: "https://apim.example/inventory/");
+
+        await using HttpClientTransport transport = new(client);
+
+        TestQueryRequest request = new(limit: 10, offset: 20);
+        await using TestResponse response =
+            await transport.SendAsync<TestQueryRequest, TestResponse>(in request);
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual("https://apim.example/inventory/pets?limit=10&offset=20", captured.RequestUri?.AbsoluteUri);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_PathAndQueryParameters_WithPathPrefixedBaseAddress_AllPreserved()
+    {
+        HttpRequestMessage? captured = null;
+
+        using HttpClient client = CreateMockClient(
+            HttpStatusCode.OK,
+            "[]"u8.ToArray(),
+            onRequest: req => { captured = req; return Task.CompletedTask; },
+            baseAddress: "https://apim.example/inventory/");
+
+        await using HttpClientTransport transport = new(client);
+
+        TestPathAndQueryRequest request = new(42, 10);
+        await using TestResponse response =
+            await transport.SendAsync<TestPathAndQueryRequest, TestResponse>(in request);
+
+        Assert.IsNotNull(captured);
+        Assert.AreEqual("https://apim.example/inventory/pets/42?limit=10", captured.RequestUri?.AbsoluteUri);
+    }
+
+    [TestMethod]
+    public async Task SendAsync_NoBaseAddress_ThrowsInvalidOperationException()
+    {
+        using MockHandler handler = new(HttpStatusCode.OK, "[]"u8.ToArray());
+        using HttpClient client = new(handler);
+
+        await using HttpClientTransport transport = new(client);
+
+        TestGetRequest request = default;
+
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(async () =>
+        {
+            await using TestResponse response =
+                await transport.SendAsync<TestGetRequest, TestResponse>(in request);
+        });
+    }
+
+    [TestMethod]
     public async Task SendAsync_PutMethod_MapsCorrectly()
     {
         HttpRequestMessage? captured = null;
@@ -516,10 +638,11 @@ public class HttpClientTransportTests
     private static HttpClient CreateMockClient(
         HttpStatusCode statusCode,
         byte[] responseBody,
-        Func<HttpRequestMessage, Task>? onRequest = null)
+        Func<HttpRequestMessage, Task>? onRequest = null,
+        string baseAddress = "http://localhost")
     {
         MockHandler handler = new(statusCode, responseBody, onRequest);
-        return new HttpClient(handler) { BaseAddress = new Uri("http://localhost") };
+        return new HttpClient(handler) { BaseAddress = new Uri(baseAddress) };
     }
 
     private sealed class MockHandler : HttpMessageHandler


### PR DESCRIPTION
## The bug

Generated OpenAPI operation paths always begin with `/`. `HttpClientTransport` sent them as relative URIs and left resolution to `HttpClient.BaseAddress`. Under RFC 3986 §5.3, an absolute-path reference such as `/transactions` **replaces** the base URI's entire path, so any deployment whose base URL carries a path prefix — the API-gateway pattern, e.g. `https://apim.example/inventory/` — silently lost the prefix: requests landed on `https://apim.example/transactions` instead of `https://apim.example/inventory/transactions`. Because generated paths always start with `/`, no spelling of `BaseAddress` could avoid it.

## The fix

The transport now composes the final absolute request URI itself (`ApplyBaseAddress`, called from `SendCoreAsync`): the base address up to and including its path with any trailing `/` trimmed, followed by the resolved operation path and query. This is the same composition NSwag- and Kiota-generated clients use.

Behavior is otherwise unchanged:

- A base address with no path segment composes a URI byte-identical to the previous RFC 3986 resolution.
- A client with no `BaseAddress` still fails with `HttpClient`'s usual invalid-request-URI error (`InvalidOperationException`).
- Runtime-only fix in `Corvus.Text.Json.OpenApi.HttpTransport`; no regeneration of generated clients is required.

## Test coverage

Six new tests in `HttpClientTransportTests`:

- Prefix preserved with a trailing-slash base (`https://apim.example/inventory/`) and without (`https://apim.example/inventory`).
- No-prefix base resolves exactly as before.
- Query-only and path+query parameter composition under a prefixed base.
- No `BaseAddress` throws `InvalidOperationException`.

Verified failing-repro discipline: with the `src` change reverted, the four prefix-preservation tests fail; with the fix, all 30 tests in the project pass. Full solution builds with 0 warnings (`TreatWarningsAsErrors=true`).

`VERSIONHISTORY.md` gains the V5.2.3 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)