### PR TITLE
Fix #832: generated code for `["boolean","null"]` schemas compiles on .NET 10 (V5.2.4)

### DIFF
--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,13 @@
 # Version History
 
+## V5.2.4
+
+V5.2.4 fixes the V4 engine so that a schema typed as a nullable boolean — `"type": ["boolean", "null"]` — again generates code that compiles on .NET 8 and later.
+
+### Bug fixes
+
+- **A `["boolean", "null"]` (nullable boolean) schema generated with the V4 engine now compiles on .NET 8+** — The generated type carries `[JsonConverter(typeof(JsonValueConverter<T>))]` and explicit `IJsonValue`/`IJsonValue<T>` member implementations, all of which require the type to implement `IJsonValue<T>`. A single-type value obtains `IJsonValue<T>` transitively from its type-family interface (`IJsonBoolean<T>`, `IJsonString<T>`, and so on), and a union obtains it from whichever of those interfaces its member types contribute. On .NET 8+, `IJsonBoolean<T>` declares a `static abstract implicit operator bool(T)`, which a union cannot satisfy because a union converts to `bool` *explicitly* (the value may not be a boolean); the boolean interface is therefore declared only on pre-.NET 8 frameworks for a multi-type union. For a `["boolean", "null"]` union the boolean is the **only** member contributing a type-family interface (`null` contributes none), so on .NET 8+ nothing supplied `IJsonValue<T>` and the generated code failed to compile with `CS0315` (the `JsonValueConverter<T>` constraint) and `CS0540` (the explicit `IJsonValue` implementations). The generator now declares `IJsonValue<T>` directly on the core partial for such a union on .NET 8+, so the type implements it on every target framework. Other unions containing a boolean (for example `["boolean", "string"]`) were unaffected — they already obtained `IJsonValue<T>` from their other member's interface — and their output is unchanged. This is a V4 code-generation fix; regenerate any affected models to pick it up. See [#832](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/832).
+
 ## V5.2.3
 
 V5.2.3 fixes the `HttpClient`-backed OpenAPI transport so that a base URL carrying a path prefix — for example an API-gateway route — is preserved in every request URI.

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/BooleanPartial.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/BooleanPartial.cs
@@ -84,6 +84,12 @@ public sealed class BooleanPartial : ICodeFileBuilder
                  : FrameworkType.NotEmitted;
         }
 
+        // A single-core-type boolean converts to bool implicitly, so it can satisfy
+        // IJsonBoolean<T>'s "static abstract implicit operator bool" on net8.0+ and declares
+        // the interface everywhere. A multi-core-type union (e.g. ["boolean", "null"]) converts
+        // to bool *explicitly* (the value may not be a boolean), so it cannot satisfy that static
+        // abstract member on net8.0+; there the interface is declared only on pre-net8.0
+        // frameworks. For such unions IJsonValue<T> is supplied on net8.0+ by CorePartial instead.
         static FrameworkType EmitIJsonBooleanInterface(TypeDeclaration typeDeclaration)
         {
             return typeDeclaration.ImpliedCoreTypes().CountTypes() == 1

--- a/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/CorePartial.cs
+++ b/src-v4/Corvus.Json.CodeGeneration.CSharp/Corvus.Json.CodeGeneration/CSharp/CodeFileBuilders/CorePartial.cs
@@ -132,11 +132,29 @@ public sealed class CorePartial : ICodeFileBuilder
 
         static ConditionalCodeSpecification JsonAnyType(TypeDeclaration typeDeclaration)
         {
-            bool isNull = (typeDeclaration.ImpliedCoreTypes() & CoreTypes.Null) != 0 && typeDeclaration.ImpliedCoreTypes().CountTypes() == 1;
+            CoreTypes impliedCoreTypes = typeDeclaration.ImpliedCoreTypes();
+            bool isNull = (impliedCoreTypes & CoreTypes.Null) != 0 && impliedCoreTypes.CountTypes() == 1;
             bool isAny = typeDeclaration.LocallyImpliedCoreTypes().CountTypes() == 0;
+
+            // A ["boolean", "null"] union has no type-family interface to supply IJsonValue<T>
+            // on net8.0+: "null" contributes no interface, and IJsonBoolean<T> is declared only on
+            // pre-net8.0 frameworks for a union (its static abstract "implicit operator bool" cannot
+            // be satisfied because a union converts to bool explicitly). Without this, the type does
+            // not implement IJsonValue<T> on net8.0+ and the generated code fails to compile
+            // (CS0315 / CS0540). Emit IJsonValue<T> directly on net8.0+ to close that gap (#832).
+            bool isBooleanOnlyUnionWithoutOtherInterfaces =
+                (impliedCoreTypes & CoreTypes.Boolean) != 0 &&
+                (impliedCoreTypes & ~(CoreTypes.Boolean | CoreTypes.Null)) == 0 &&
+                impliedCoreTypes.CountTypes() > 1;
+
+            FrameworkType frameworkType =
+                isNull || isAny ? FrameworkType.All
+                : isBooleanOnlyUnionWithoutOtherInterfaces ? FrameworkType.Net80OrGreater
+                : FrameworkType.NotEmitted;
+
             return new(
                 g => g.GenericTypeOf("IJsonValue", typeDeclaration),
-                isNull || isAny ? FrameworkType.All : FrameworkType.NotEmitted);
+                frameworkType);
         }
     }
 }

--- a/tests/Corvus.Text.Json.CodeGenerator.Tests/GenerateCommandTests.cs
+++ b/tests/Corvus.Text.Json.CodeGenerator.Tests/GenerateCommandTests.cs
@@ -111,6 +111,48 @@ public class GenerateCommandTests : IDisposable
     }
 
     [TestMethod]
+    public async Task Generate_V4BooleanNullUnion_ImplementsJsonValueInterfaceOnNet8Plus()
+    {
+        // Regression test for #832. A ["boolean", "null"] union generated with the V4 engine did not
+        // implement IJsonValue<T> on net8.0+, so the generated code failed to compile: CS0315 (the
+        // JsonValueConverter<T> attribute constraint) and CS0540 (the explicit IJsonValue members).
+        // The "null" core type contributes no type-family interface, and IJsonBoolean<T> — the only
+        // other candidate supplier of IJsonValue<T> — is declared only on pre-net8.0 frameworks for a
+        // union (a union converts to bool explicitly, so it cannot satisfy IJsonBoolean<T>'s static
+        // abstract "implicit operator bool" on net8.0+). The generator must therefore declare
+        // IJsonValue<T> directly on net8.0+.
+        string schema = CodeGeneratorRunner.GetFixturePath("Schemas", "boolean-null-union.json");
+
+        ProcessResult result = await CodeGeneratorRunner.RunAsync(
+            $"jsonschema \"{schema}\" --rootNamespace TestGenerated --outputRootTypeName NullableBool --outputPath \"{_outputDir}\" --engine V4");
+
+        Assert.AreEqual(0, result.ExitCode, $"Stdout: {result.StandardOutput} Stderr: {result.StandardError}");
+
+        // The core partial carries [JsonConverter(typeof(JsonValueConverter<NullableBool>))], whose type
+        // argument requires NullableBool : IJsonValue<NullableBool>. Inspect that file's base list.
+        string coreFile = Directory
+            .GetFiles(_outputDir, "*.cs", SearchOption.AllDirectories)
+            .Single(f => File.ReadAllText(f).Contains("JsonValueConverter<NullableBool>", StringComparison.Ordinal));
+        string content = await File.ReadAllTextAsync(coreFile);
+
+        // Isolate the struct's base-interface list (from the declaration to the opening body brace).
+        int structIndex = content.IndexOf("partial struct NullableBool", StringComparison.Ordinal);
+        int bodyBraceIndex = content.IndexOf('{', structIndex);
+        string baseList = content.Substring(structIndex, bodyBraceIndex - structIndex);
+
+        Assert.IsTrue(
+            baseList.Contains("IJsonValue<", StringComparison.Ordinal),
+            "Expected the core partial for a [\"boolean\", \"null\"] union to declare IJsonValue<T> in its " +
+            $"base-interface list so it implements IJsonValue<T> on net8.0+ (regression #832). Base list:\n{baseList}");
+
+        // The IJsonValue<T> base declaration must be present on net8.0+, not confined to pre-net8.0.
+        Assert.IsFalse(
+            baseList.Contains("#if !NET8_0_OR_GREATER", StringComparison.Ordinal),
+            "The IJsonValue<T> base declaration for a [\"boolean\", \"null\"] union must be present on net8.0+ " +
+            $"(regression #832). Base list:\n{baseList}");
+    }
+
+    [TestMethod]
     public async Task Generate_WithOptionalAsNullable_ProducesFiles()
     {
         string schema = CodeGeneratorRunner.GetFixturePath("Schemas", "simple-object.json");

--- a/tests/Corvus.Text.Json.CodeGenerator.Tests/TestFixtures/Schemas/boolean-null-union.json
+++ b/tests/Corvus.Text.Json.CodeGenerator.Tests/TestFixtures/Schemas/boolean-null-union.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "NullableBool",
+  "type": [ "boolean", "null" ]
+}


### PR DESCRIPTION
Fixes #832.

## Problem

The **V4 engine** generated non-compiling code for a nullable-boolean schema (`"type": ["boolean", "null"]`) on .NET 8/9/10. All errors landed in the boolean value type, e.g.:

```
NullableBool.ValueEntity.cs(33,98):  error CS0315: 'ValueEntity' cannot be used as type parameter 'T' in 'JsonValueConverter<T>' — no conversion to 'IJsonValue<ValueEntity>'.
NullableBool.ValueEntity.cs(148,20): error CS0540: 'ValueEntity.IJsonValue.AsString': containing type does not implement 'IJsonValue'.
… (CS0540 ×7, one per explicit IJsonValue member)
```

It worked with the older `corvus.json.jsonschema.typegeneratortool 4.3.10`, so this is a regression.

## Root cause

The generated type carries `[JsonConverter(typeof(JsonValueConverter<T>))]` and explicit `IJsonValue`/`IJsonValue<T>` members — all of which require the type to implement `IJsonValue<T>`. A type obtains `IJsonValue<T>` transitively from a type-family interface (`IJsonBoolean/String/Number/Object/Array<T>`).

On .NET 8+, `IJsonBoolean<T>` declares a `static abstract implicit operator bool(T)`. A **union** converts to `bool` *explicitly* (the value may be null), so it cannot satisfy that member — hence `BooleanPartial` correctly declares `IJsonBoolean<T>` only on pre-.NET 8 frameworks for a union. For `["boolean", "null"]` the boolean is the **only** member contributing an interface (`null` contributes none), so on .NET 8+ nothing supplied `IJsonValue<T>`. Other boolean unions such as `["boolean", "string"]` were unaffected — `IJsonString<T>` supplied it.

The regression was introduced in the 5.1 release, which added the (correct) `PreNet80` special-case to `BooleanPartial` without addressing the resulting `IJsonValue<T>` gap.

## Fix

`CorePartial.JsonAnyType` now emits `IJsonValue<T>` **directly on .NET 8+** for a boolean-only union (boolean + null, no other interface-bearing member), closing the gap:

- pre-.NET 8 → `IJsonBoolean<T>` (from the boolean partial) supplies `IJsonValue<T>`
- .NET 8+ → `IJsonValue<T>` is declared directly on the core partial

`BooleanPartial` is unchanged apart from a clarifying comment. The fix is in the shared V4 code-generation core, so it applies to the `corvusjson` CLI and the V4 source generator alike. **Regenerate affected models to pick it up.**

## Verification

- **Failing-test-first**: added `Generate_V4BooleanNullUnion_ImplementsJsonValueInterfaceOnNet8Plus` + fixture; verified it fails before the fix and passes after (revert → fail → reapply → pass).
- **Compile matrix** across every boolean union (`bool+null`, `+string`, `+number`, `+integer`, `+object`, `+array`, `+string+null`, `+null+integer`, and the exact issue repro with `--optionalAsNullable NullOrUndefined`) on **net8.0/net9.0/net10.0**: was 1 failure (`bool+null`) → now **0 errors, 0 warnings**, no regressions.
- Full `Corvus.Text.Json.slnx` build: **0 warnings, 0 errors**.
- `CodeGenerator.Tests`: **1812/1812 pass**.
- No example-recipe or benchmark-`C/` regeneration required (those use the V5 engine; confirmed regeneration produces only timestamp/line-ending noise).
- Added **V5.2.4** to `VERSIONHISTORY.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011CHWvmTgbi7nfF2LcpgmjH