### PR TITLE
Align the Create() feature's VERSIONHISTORY heading with the released 5.2.7 tag

### DIFF
--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,8 +1,8 @@
 # Version History
 
-## V5.3.0
+## V5.2.7
 
-V5.3.0 adds `Create()` factory methods to generated types: the `ParsedJsonDocument<T>`-producing analogue of `CreateBuilder()`, for the create-but-don't-modify pattern.
+V5.2.7 adds `Create()` factory methods to generated types: the `ParsedJsonDocument<T>`-producing analogue of `CreateBuilder()`, for the create-but-don't-modify pattern.
 
 ### Breaking changes
 


### PR DESCRIPTION
The release automation tagged the #836/#837 merge as 5.2.7; the version history entry said V5.3.0. This aligns the heading and intro sentence with the released version. Documentation-only; labelled `no_release`.

(The wider 5.2.x ladder realignment was split into a follow-up PR — it was pushed to this branch after the merge had already happened.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)