### PR TITLE
feat: add EndLine/EndColumn to YamlEvent

### DIFF
--- a/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/Internal/YamlEventParser.cs
+++ b/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/Internal/YamlEventParser.cs
@@ -22,6 +22,11 @@ internal ref struct YamlEventParser
     private int _line;
     private int _column;
     private int _depth;
+
+    // End (0-based) of the last completed node; block collection-ends read it.
+    private int _lastNodeEndLine;
+    private int _lastNodeEndColumn;
+
     private byte[] _scratchBuffer;
     private int _scratchPos;
 
@@ -88,39 +93,45 @@ internal ref struct YamlEventParser
         }
     }
 
-    private bool EmitEvent(YamlEventType type, int line, int column)
+    private bool EmitEvent(YamlEventType type, int line, int column, int endLine, int endColumn)
     {
-        YamlEvent e = new(type, line, column);
+        YamlEvent e = new(type, line, column, endLine, endColumn);
         return _callback(in e);
     }
 
-    private bool EmitDocumentEvent(YamlEventType type, bool isImplicit, int line, int column)
+    private bool EmitDocumentEvent(YamlEventType type, bool isImplicit, int line, int column, int endLine, int endColumn)
     {
-        YamlEvent e = new(type, isImplicit, line, column);
+        YamlEvent e = new(type, isImplicit, line, column, endLine, endColumn);
         return _callback(in e);
     }
 
-    private bool EmitCollectionStartEvent(YamlEventType type, int line, int column, ReadOnlySpan<byte> anchor, ReadOnlySpan<byte> tag, bool isFlowStyle = false)
+    private bool EmitCollectionStartEvent(YamlEventType type, int line, int column, ReadOnlySpan<byte> anchor, ReadOnlySpan<byte> tag, int endLine, int endColumn, bool isFlowStyle = false)
     {
-        YamlEvent e = new(type, anchor, tag, isFlowStyle, line, column);
+        YamlEvent e = new(type, anchor, tag, isFlowStyle, line, column, endLine, endColumn);
         return _callback(in e);
     }
 
-    private bool EmitScalarEvent(int line, int column, ReadOnlySpan<byte> value, YamlScalarStyle style, ReadOnlySpan<byte> anchor, ReadOnlySpan<byte> tag)
+    private bool EmitScalarEvent(int line, int column, ReadOnlySpan<byte> value, YamlScalarStyle style, ReadOnlySpan<byte> anchor, ReadOnlySpan<byte> tag, int endLine, int endColumn)
     {
-        YamlEvent e = new(value, style, anchor, tag, line, column);
+        YamlEvent e = new(value, style, anchor, tag, line, column, endLine, endColumn);
         return _callback(in e);
     }
 
-    private bool EmitAliasEvent(ReadOnlySpan<byte> name, int line, int column)
+    private bool EmitAliasEvent(ReadOnlySpan<byte> name, int line, int column, int endLine, int endColumn)
     {
-        YamlEvent e = YamlEvent.Alias(name, line, column);
+        YamlEvent e = YamlEvent.Alias(name, line, column, endLine, endColumn);
         return _callback(in e);
+    }
+
+    private void RecordNodeEnd(int endLine, int endColumn)
+    {
+        _lastNodeEndLine = endLine;
+        _lastNodeEndColumn = endColumn;
     }
 
     private bool ParseAllDocuments()
     {
-        if (!EmitEvent(YamlEventType.StreamStart, 1, 1)) { return false; }
+        if (!EmitEvent(YamlEventType.StreamStart, 1, 1, 1, 1)) { return false; }
 
         SkipBom();
         SkipWhitespaceAndComments();
@@ -152,7 +163,7 @@ internal ref struct YamlEventParser
             SkipWhitespaceAndComments();
         }
 
-        return EmitEvent(YamlEventType.StreamEnd, _line + 1, _column + 1);
+        return EmitEvent(YamlEventType.StreamEnd, _line + 1, _column + 1, _line + 1, _column + 1);
     }
 
     private bool ParseSingleDocument(bool firstDoc)
@@ -162,7 +173,7 @@ internal ref struct YamlEventParser
 
         if (IsDocumentStart())
         {
-            if (!EmitDocumentEvent(YamlEventType.DocumentStart, false, _line + 1, _column + 1)) { return false; }
+            if (!EmitDocumentEvent(YamlEventType.DocumentStart, false, _line + 1, _column + 1, _line + 1, _column + 1)) { return false; }
 
             int docStartLine = _line;
             Advance(3);
@@ -175,7 +186,8 @@ internal ref struct YamlEventParser
             }
             else
             {
-                if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                RecordNodeEnd(_line, _column);
+                if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
             }
         }
         else
@@ -186,7 +198,7 @@ internal ref struct YamlEventParser
                 ThrowDirectiveWithoutDocumentStart();
             }
 
-            if (!EmitDocumentEvent(YamlEventType.DocumentStart, true, _line + 1, _column + 1)) { return false; }
+            if (!EmitDocumentEvent(YamlEventType.DocumentStart, true, _line + 1, _column + 1, _line + 1, _column + 1)) { return false; }
 
             if (_pos < _buffer.Length && !IsDocumentEndOrStart())
             {
@@ -194,7 +206,8 @@ internal ref struct YamlEventParser
             }
             else
             {
-                if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                RecordNodeEnd(_line, _column);
+                if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
             }
         }
 
@@ -208,7 +221,7 @@ internal ref struct YamlEventParser
 
         if (IsDocumentEnd())
         {
-            if (!EmitDocumentEvent(YamlEventType.DocumentEnd, false, _line + 1, _column + 1)) { return false; }
+            if (!EmitDocumentEvent(YamlEventType.DocumentEnd, false, _line + 1, _column + 1, _line + 1, _column + 1)) { return false; }
 
             Advance(3);
 
@@ -224,7 +237,7 @@ internal ref struct YamlEventParser
         }
         else
         {
-            if (!EmitDocumentEvent(YamlEventType.DocumentEnd, true, _line + 1, _column + 1)) { return false; }
+            if (!EmitDocumentEvent(YamlEventType.DocumentEnd, true, _line + 1, _column + 1, _line + 1, _column + 1)) { return false; }
         }
 
         return true;
@@ -242,7 +255,8 @@ internal ref struct YamlEventParser
 
         if (_pos >= _buffer.Length)
         {
-            return EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default);
+            RecordNodeEnd(_line, _column);
+            return EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1);
         }
 
         ReadOnlySpan<byte> anchor = default;
@@ -294,7 +308,8 @@ internal ref struct YamlEventParser
         {
             if (_pos >= _buffer.Length)
             {
-                return EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, anchor, tag);
+                RecordNodeEnd(_line, _column);
+                return EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, anchor, tag, _line + 1, _column + 1);
             }
 
             byte c = _buffer[_pos];
@@ -319,14 +334,16 @@ internal ref struct YamlEventParser
                 // Content strictly below parent indent — always an empty scalar
                 if (_column < parentIndent)
                 {
-                    return EmitScalarEvent(propsLine + 1, propsColumn + 1, default, YamlScalarStyle.Plain, anchor, tag);
+                    RecordNodeEnd(propsLine, propsColumn);
+                    return EmitScalarEvent(propsLine + 1, propsColumn + 1, default, YamlScalarStyle.Plain, anchor, tag, propsLine + 1, propsColumn + 1);
                 }
 
                 // Content at parent indent — empty scalar unless it's a block sequence
                 // entry in a non-sequence context (where '-' starts the value collection)
                 if (_column == parentIndent && (isSeqEntry || !IsBlockSequenceEntry()))
                 {
-                    return EmitScalarEvent(propsLine + 1, propsColumn + 1, default, YamlScalarStyle.Plain, anchor, tag);
+                    RecordNodeEnd(propsLine, propsColumn);
+                    return EmitScalarEvent(propsLine + 1, propsColumn + 1, default, YamlScalarStyle.Plain, anchor, tag, propsLine + 1, propsColumn + 1);
                 }
             }
 
@@ -473,8 +490,9 @@ internal ref struct YamlEventParser
             {
                 int sl = _line; int sc = _column;
                 ReadOnlySpan<byte> value = ReadDoubleQuotedScalar(out byte[]? rented, Math.Max(0, parentIndent + 1));
+                RecordNodeEnd(_line, _column);
 
-                try { return EmitScalarEvent(sl + 1, sc + 1, value, YamlScalarStyle.DoubleQuoted, anchor, tag); }
+                try { return EmitScalarEvent(sl + 1, sc + 1, value, YamlScalarStyle.DoubleQuoted, anchor, tag, _line + 1, _column + 1); }
                 finally { if (rented != null) { ArrayPool<byte>.Shared.Return(rented); } }
             }
 
@@ -482,14 +500,16 @@ internal ref struct YamlEventParser
             {
                 int sl = _line; int sc = _column;
                 ReadOnlySpan<byte> value = ReadSingleQuotedScalar(out byte[]? rented, Math.Max(0, parentIndent + 1));
+                RecordNodeEnd(_line, _column);
 
-                try { return EmitScalarEvent(sl + 1, sc + 1, value, YamlScalarStyle.SingleQuoted, anchor, tag); }
+                try { return EmitScalarEvent(sl + 1, sc + 1, value, YamlScalarStyle.SingleQuoted, anchor, tag, _line + 1, _column + 1); }
                 finally { if (rented != null) { ArrayPool<byte>.Shared.Return(rented); } }
             }
 
             if (inFlow && IsFlowEmptyNode())
             {
-                return EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, anchor, tag);
+                RecordNodeEnd(_line, _column);
+                return EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, anchor, tag, _line + 1, _column + 1);
             }
 
             return ParsePlainScalar(parentIndent, inFlow, anchor, tag);
@@ -647,7 +667,8 @@ internal ref struct YamlEventParser
 
         while (_pos < _buffer.Length && !YamlCharacters.IsWhitespaceOrLineBreak(_buffer[_pos]) && !YamlCharacters.IsFlowIndicator(_buffer[_pos])) { Advance(1); }
 
-        return EmitAliasEvent(_buffer.Slice(start, _pos - start), sl + 1, sc + 1);
+        RecordNodeEnd(_line, _column);
+        return EmitAliasEvent(_buffer.Slice(start, _pos - start), sl + 1, sc + 1, _line + 1, _column + 1);
     }
 
     private void EnsureScratchCapacity(int needed)
@@ -666,7 +687,7 @@ internal ref struct YamlEventParser
     {
         if (!EnterDepth()) { return false; }
 
-        if (!EmitCollectionStartEvent(YamlEventType.MappingStart, _line + 1, _column + 1, anchor, tag)) { return false; }
+        if (!EmitCollectionStartEvent(YamlEventType.MappingStart, _line + 1, _column + 1, anchor, tag, _line + 1, _column + 1)) { return false; }
 
         bool first = true;
 
@@ -701,7 +722,8 @@ internal ref struct YamlEventParser
                 }
                 else
                 {
-                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                    RecordNodeEnd(_line, _column);
+                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                 }
 
                 SkipWhitespaceAndComments();
@@ -713,11 +735,13 @@ internal ref struct YamlEventParser
 
                     if (_pos >= _buffer.Length || _column < mappingIndent || IsDocumentEndOrStart())
                     {
-                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                        RecordNodeEnd(_line, _column);
+                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                     }
                     else if (_column == mappingIndent && !IsBlockSequenceEntry())
                     {
-                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                        RecordNodeEnd(_line, _column);
+                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                     }
                     else
                     {
@@ -726,14 +750,16 @@ internal ref struct YamlEventParser
                 }
                 else
                 {
-                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                    RecordNodeEnd(_line, _column);
+                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                 }
             }
             else if (_pendingKeyAnchorLength == 0 && _pendingKeyTagLength == 0
                 && _buffer[_pos] == YamlConstants.Colon && (_pos + 1 >= _buffer.Length || YamlCharacters.IsWhitespaceOrLineBreak(_buffer[_pos + 1])))
             {
                 // Empty key — emit empty scalar for the key, then parse value
-                if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                RecordNodeEnd(_line, _column);
+                if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
 
                 int colonLine = _line;
                 Advance(1);
@@ -741,7 +767,8 @@ internal ref struct YamlEventParser
 
                 if (_pos >= _buffer.Length || IsDocumentEndOrStart())
                 {
-                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                    RecordNodeEnd(_line, _column);
+                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                 }
                 else if (_pos < _buffer.Length && _line == colonLine && !IsComment())
                 {
@@ -749,11 +776,13 @@ internal ref struct YamlEventParser
                 }
                 else if (_column < mappingIndent)
                 {
-                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                    RecordNodeEnd(_line, _column);
+                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                 }
                 else if (_column == mappingIndent && !IsBlockSequenceEntry())
                 {
-                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                    RecordNodeEnd(_line, _column);
+                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                 }
                 else
                 {
@@ -787,15 +816,18 @@ internal ref struct YamlEventParser
                     }
                     else if (_pos >= _buffer.Length || IsDocumentEndOrStart())
                     {
-                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                        RecordNodeEnd(_line, _column);
+                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                     }
                     else if (_column < mappingIndent)
                     {
-                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                        RecordNodeEnd(_line, _column);
+                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                     }
                     else if (_column == mappingIndent && !IsBlockSequenceEntry())
                     {
-                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                        RecordNodeEnd(_line, _column);
+                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                     }
                     else
                     {
@@ -814,7 +846,7 @@ internal ref struct YamlEventParser
             SkipWhitespaceAndComments();
         }
 
-        if (!EmitEvent(YamlEventType.MappingEnd, _line + 1, _column + 1)) { return false; }
+        if (!EmitEvent(YamlEventType.MappingEnd, _line + 1, _column + 1, _line + 1, _column + 1)) { return false; }
 
         _depth--;
         return true;
@@ -826,7 +858,7 @@ internal ref struct YamlEventParser
 
         int seqIndent = _column;
 
-        if (!EmitCollectionStartEvent(YamlEventType.SequenceStart, _line + 1, _column + 1, anchor, tag)) { return false; }
+        if (!EmitCollectionStartEvent(YamlEventType.SequenceStart, _line + 1, _column + 1, anchor, tag, _line + 1, _column + 1)) { return false; }
 
         while (_pos < _buffer.Length)
         {
@@ -849,7 +881,8 @@ internal ref struct YamlEventParser
 
                 if (_pos >= _buffer.Length || _column <= seqIndent || IsDocumentEndOrStart())
                 {
-                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                    RecordNodeEnd(_line, _column);
+                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                 }
                 else
                 {
@@ -862,7 +895,7 @@ internal ref struct YamlEventParser
             }
         }
 
-        if (!EmitEvent(YamlEventType.SequenceEnd, _line + 1, _column + 1)) { return false; }
+        if (!EmitEvent(YamlEventType.SequenceEnd, _line + 1, _column + 1, _line + 1, _column + 1)) { return false; }
 
         _depth--;
         return true;
@@ -874,7 +907,7 @@ internal ref struct YamlEventParser
         int sl = _line; int sc = _column;
         Advance(1);
 
-        if (!EmitCollectionStartEvent(YamlEventType.MappingStart, sl + 1, sc + 1, anchor, tag, isFlowStyle: true)) { return false; }
+        if (!EmitCollectionStartEvent(YamlEventType.MappingStart, sl + 1, sc + 1, anchor, tag, sl + 1, sc + 1, isFlowStyle: true)) { return false; }
 
         SkipWhitespaceAndComments();
         bool needComma = false;
@@ -908,7 +941,7 @@ internal ref struct YamlEventParser
                 }
                 else
                 {
-                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                 }
             }
             else
@@ -918,7 +951,7 @@ internal ref struct YamlEventParser
                     && (_pos + 1 >= _buffer.Length || YamlCharacters.IsWhitespaceOrLineBreak(_buffer[_pos + 1]) || YamlCharacters.IsFlowIndicator(_buffer[_pos + 1])))
                 {
                     // Empty key — emit null scalar, colon will be consumed below
-                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                 }
                 else
                 {
@@ -935,7 +968,7 @@ internal ref struct YamlEventParser
 
                 if (_pos >= _buffer.Length || _buffer[_pos] == YamlConstants.Comma || _buffer[_pos] == YamlConstants.CloseBrace)
                 {
-                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                 }
                 else
                 {
@@ -944,7 +977,7 @@ internal ref struct YamlEventParser
             }
             else
             {
-                if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
             }
 
             SkipWhitespaceAndComments();
@@ -955,7 +988,8 @@ internal ref struct YamlEventParser
 
         Advance(1);
 
-        if (!EmitEvent(YamlEventType.MappingEnd, _line + 1, _column + 1)) { return false; }
+        RecordNodeEnd(_line, _column);
+        if (!EmitEvent(YamlEventType.MappingEnd, _line + 1, _column + 1, _line + 1, _column + 1)) { return false; }
 
         _depth--;
         return true;
@@ -967,7 +1001,7 @@ internal ref struct YamlEventParser
         int sl = _line; int sc = _column;
         Advance(1);
 
-        if (!EmitCollectionStartEvent(YamlEventType.SequenceStart, sl + 1, sc + 1, anchor, tag, isFlowStyle: true)) { return false; }
+        if (!EmitCollectionStartEvent(YamlEventType.SequenceStart, sl + 1, sc + 1, anchor, tag, sl + 1, sc + 1, isFlowStyle: true)) { return false; }
 
         SkipWhitespaceAndComments();
 
@@ -1026,7 +1060,7 @@ internal ref struct YamlEventParser
             if (isImplicitMapping)
             {
                 int ml = _line; int mc = _column;
-                if (!EmitCollectionStartEvent(YamlEventType.MappingStart, ml + 1, mc + 1, default, default, isFlowStyle: true)) { return false; }
+                if (!EmitCollectionStartEvent(YamlEventType.MappingStart, ml + 1, mc + 1, default, default, ml + 1, mc + 1, isFlowStyle: true)) { return false; }
 
                 if (_pos < _buffer.Length && _buffer[_pos] == YamlConstants.QuestionMark && (_pos + 1 >= _buffer.Length || YamlCharacters.IsWhitespaceOrLineBreak(_buffer[_pos + 1])))
                 {
@@ -1039,13 +1073,13 @@ internal ref struct YamlEventParser
                     }
                     else
                     {
-                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                     }
                 }
                 else if (_pos < _buffer.Length && _buffer[_pos] == YamlConstants.Colon)
                 {
                     // Empty key
-                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                 }
                 else
                 {
@@ -1061,7 +1095,7 @@ internal ref struct YamlEventParser
 
                     if (_pos >= _buffer.Length || _buffer[_pos] == YamlConstants.Comma || _buffer[_pos] == YamlConstants.CloseBracket || _buffer[_pos] == YamlConstants.CloseBrace)
                     {
-                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                        if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                     }
                     else
                     {
@@ -1070,10 +1104,11 @@ internal ref struct YamlEventParser
                 }
                 else
                 {
-                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default)) { return false; }
+                    if (!EmitScalarEvent(_line + 1, _column + 1, default, YamlScalarStyle.Plain, default, default, _line + 1, _column + 1)) { return false; }
                 }
 
-                if (!EmitEvent(YamlEventType.MappingEnd, _line + 1, _column + 1)) { return false; }
+                RecordNodeEnd(_line, _column);
+                if (!EmitEvent(YamlEventType.MappingEnd, _line + 1, _column + 1, _line + 1, _column + 1)) { return false; }
             }
             else
             {
@@ -1088,7 +1123,8 @@ internal ref struct YamlEventParser
 
         Advance(1);
 
-        if (!EmitEvent(YamlEventType.SequenceEnd, _line + 1, _column + 1)) { return false; }
+        RecordNodeEnd(_line, _column);
+        if (!EmitEvent(YamlEventType.SequenceEnd, _line + 1, _column + 1, _line + 1, _column + 1)) { return false; }
 
         _depth--;
         return true;
@@ -1100,6 +1136,7 @@ internal ref struct YamlEventParser
         int written = 0;
         Span<byte> output = rentedBuffer;
         int sl = _line; int sc = _column;
+        int el = _line; int ec = _column;
 
         // YAML spec: in flow context, - ? as first char require a following ns-plain-safe char
         // (: is excluded here because it serves as value indicator in flow mappings)
@@ -1211,11 +1248,13 @@ internal ref struct YamlEventParser
                 EnsureOutputCapacity(ref output, ref rentedBuffer, written, 1);
                 output[written++] = c;
                 Advance(1);
+                if (!YamlCharacters.IsWhitespace(c)) { el = _line; ec = _column; }
             }
 
             while (written > 0 && YamlCharacters.IsWhitespace(output[written - 1])) { written--; }
 
-            return EmitScalarEvent(sl + 1, sc + 1, output.Slice(0, written), YamlScalarStyle.Plain, anchor, tag);
+            RecordNodeEnd(el, ec);
+            return EmitScalarEvent(sl + 1, sc + 1, output.Slice(0, written), YamlScalarStyle.Plain, anchor, tag, el + 1, ec + 1);
         }
         finally
         {
@@ -1444,6 +1483,7 @@ internal ref struct YamlEventParser
     {
         byte indicator = _buffer[_pos];
         int sl = _line; int sc = _column;
+        int el = _line; int ec = _column;
         Advance(1);
         bool literal = indicator == YamlConstants.Pipe;
         byte chomping = 0;
@@ -1611,6 +1651,8 @@ internal ref struct YamlEventParser
                     output[written++] = _buffer[_pos];
                     Advance(1);
                 }
+
+                el = _line; ec = _column;
             }
 
             if (chomping == YamlConstants.Plus)
@@ -1627,7 +1669,8 @@ internal ref struct YamlEventParser
             }
 
             YamlScalarStyle style = literal ? YamlScalarStyle.Literal : YamlScalarStyle.Folded;
-            return EmitScalarEvent(sl + 1, sc + 1, output.Slice(0, written), style, anchor, tag);
+            RecordNodeEnd(el, ec);
+            return EmitScalarEvent(sl + 1, sc + 1, output.Slice(0, written), style, anchor, tag, el + 1, ec + 1);
         }
         finally
         {

--- a/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/YamlEvent.cs
+++ b/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/YamlEvent.cs
@@ -26,13 +26,17 @@ public readonly ref struct YamlEvent
     /// Initializes a new instance of the <see cref="YamlEvent"/> struct.
     /// </summary>
     /// <param name="type">The event type.</param>
-    /// <param name="line">The 1-based line number.</param>
-    /// <param name="column">The 1-based column number.</param>
-    internal YamlEvent(YamlEventType type, int line, int column)
+    /// <param name="line">The 1-based start line number.</param>
+    /// <param name="column">The 1-based start column number.</param>
+    /// <param name="endLine">The 1-based end line number.</param>
+    /// <param name="endColumn">The 1-based end column number.</param>
+    internal YamlEvent(YamlEventType type, int line, int column, int endLine, int endColumn)
     {
         this.Type = type;
         this.Line = line;
         this.Column = column;
+        this.EndLine = endLine;
+        this.EndColumn = endColumn;
         this.Value = default;
         this.ScalarStyle = default;
         this.Anchor = default;
@@ -48,13 +52,17 @@ public readonly ref struct YamlEvent
     /// <param name="type">The event type (<see cref="YamlEventType.DocumentStart"/>
     /// or <see cref="YamlEventType.DocumentEnd"/>).</param>
     /// <param name="isImplicit">Whether the document boundary is implicit.</param>
-    /// <param name="line">The 1-based line number.</param>
-    /// <param name="column">The 1-based column number.</param>
-    internal YamlEvent(YamlEventType type, bool isImplicit, int line, int column)
+    /// <param name="line">The 1-based start line number.</param>
+    /// <param name="column">The 1-based start column number.</param>
+    /// <param name="endLine">The 1-based end line number.</param>
+    /// <param name="endColumn">The 1-based end column number.</param>
+    internal YamlEvent(YamlEventType type, bool isImplicit, int line, int column, int endLine, int endColumn)
     {
         this.Type = type;
         this.Line = line;
         this.Column = column;
+        this.EndLine = endLine;
+        this.EndColumn = endColumn;
         this.Value = default;
         this.ScalarStyle = default;
         this.Anchor = default;
@@ -71,19 +79,26 @@ public readonly ref struct YamlEvent
     /// or <see cref="YamlEventType.SequenceStart"/>).</param>
     /// <param name="anchor">The anchor name, if any.</param>
     /// <param name="tag">The tag text, if any.</param>
-    /// <param name="line">The 1-based line number.</param>
-    /// <param name="column">The 1-based column number.</param>
+    /// <param name="isFlowStyle">Whether the collection uses flow style.</param>
+    /// <param name="line">The 1-based start line number.</param>
+    /// <param name="column">The 1-based start column number.</param>
+    /// <param name="endLine">The 1-based end line number.</param>
+    /// <param name="endColumn">The 1-based end column number.</param>
     internal YamlEvent(
         YamlEventType type,
         ReadOnlySpan<byte> anchor,
         ReadOnlySpan<byte> tag,
         bool isFlowStyle,
         int line,
-        int column)
+        int column,
+        int endLine,
+        int endColumn)
     {
         this.Type = type;
         this.Line = line;
         this.Column = column;
+        this.EndLine = endLine;
+        this.EndColumn = endColumn;
         this.Value = default;
         this.ScalarStyle = default;
         this.Anchor = anchor;
@@ -96,21 +111,25 @@ public readonly ref struct YamlEvent
     /// Initializes a new instance of the <see cref="YamlEvent"/> struct for alias events.
     /// </summary>
     /// <param name="aliasName">The anchor name referenced by the alias (without leading <c>*</c>).</param>
-    /// <param name="line">The 1-based line number.</param>
-    /// <param name="column">The 1-based column number.</param>
-    internal static YamlEvent Alias(ReadOnlySpan<byte> aliasName, int line, int column)
+    /// <param name="line">The 1-based start line number.</param>
+    /// <param name="column">The 1-based start column number.</param>
+    /// <param name="endLine">The 1-based end line number.</param>
+    /// <param name="endColumn">The 1-based end column number.</param>
+    internal static YamlEvent Alias(ReadOnlySpan<byte> aliasName, int line, int column, int endLine, int endColumn)
     {
-        return new YamlEvent(aliasName, line, column);
+        return new YamlEvent(aliasName, line, column, endLine, endColumn);
     }
 
     /// <summary>
     /// Initializes a new instance for alias events (private, used by <see cref="Alias"/>).
     /// </summary>
-    private YamlEvent(ReadOnlySpan<byte> aliasName, int line, int column)
+    private YamlEvent(ReadOnlySpan<byte> aliasName, int line, int column, int endLine, int endColumn)
     {
         this.Type = YamlEventType.Alias;
         this.Line = line;
         this.Column = column;
+        this.EndLine = endLine;
+        this.EndColumn = endColumn;
         this.Value = aliasName;
         this.ScalarStyle = default;
         this.Anchor = default;
@@ -158,15 +177,19 @@ public readonly ref struct YamlEvent
     /// <param name="scalarStyle">The scalar style.</param>
     /// <param name="anchor">The anchor name, if any.</param>
     /// <param name="tag">The tag text, if any.</param>
-    /// <param name="line">The 1-based line number.</param>
-    /// <param name="column">The 1-based column number.</param>
+    /// <param name="line">The 1-based start line number.</param>
+    /// <param name="column">The 1-based start column number.</param>
+    /// <param name="endLine">The 1-based end line number.</param>
+    /// <param name="endColumn">The 1-based end column number.</param>
     internal YamlEvent(
         ReadOnlySpan<byte> value,
         YamlScalarStyle scalarStyle,
         ReadOnlySpan<byte> anchor,
         ReadOnlySpan<byte> tag,
         int line,
-        int column)
+        int column,
+        int endLine,
+        int endColumn)
     {
         this.Type = YamlEventType.Scalar;
         this.Value = value;
@@ -175,6 +198,8 @@ public readonly ref struct YamlEvent
         this.Tag = tag;
         this.Line = line;
         this.Column = column;
+        this.EndLine = endLine;
+        this.EndColumn = endColumn;
         this.IsImplicit = false;
         this.IsFlowStyle = false;
     }
@@ -222,6 +247,16 @@ public readonly ref struct YamlEvent
     /// Gets the 1-based column number where this event starts.
     /// </summary>
     public int Column { get; }
+
+    /// <summary>
+    /// Gets the 1-based line number one position past the end of this event's content.
+    /// </summary>
+    public int EndLine { get; }
+
+    /// <summary>
+    /// Gets the 1-based column number one position past the end of this event's content.
+    /// </summary>
+    public int EndColumn { get; }
 
     /// <summary>
     /// Gets a value indicating whether the document start or end is implicit (no explicit

--- a/tests/Corvus.Text.Json.Yaml.Tests/YamlEventSpanTests.cs
+++ b/tests/Corvus.Text.Json.Yaml.Tests/YamlEventSpanTests.cs
@@ -1,0 +1,188 @@
+// <copyright file="YamlEventSpanTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using Corvus.Text.Json.Yaml;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.Yaml.Tests;
+
+/// <summary>
+/// Tests for the <see cref="YamlEvent.Line"/>, <see cref="YamlEvent.Column"/>,
+/// <see cref="YamlEvent.EndLine"/>, and <see cref="YamlEvent.EndColumn"/> span fields.
+/// Each test collects every event's span and extracted text and asserts on the full list.
+/// </summary>
+[TestClass]
+public class YamlEventSpanTests
+{
+    private static string Extract(string yaml, int startLine, int startCol, int endLine, int endCol)
+    {
+        int[] lineStarts = BuildLineStarts();
+        int start = lineStarts[startLine - 1] + startCol - 1;
+        int end = lineStarts[endLine - 1] + endCol - 1;
+        return yaml.Substring(start, end - start);
+
+        int[] BuildLineStarts()
+        {
+            var starts = new List<int> { 0 };
+            for (int i = 0; i < yaml.Length; i++)
+                if (yaml[i] == '\n')
+                    starts.Add(i + 1);
+            return [.. starts];
+        }
+    }
+
+    private static List<(YamlEventType Type, int Line, int Column, int EndLine, int EndColumn, string Text)> AllEventSpans(string yaml)
+    {
+        var result = new List<(YamlEventType, int, int, int, int, string)>();
+        YamlDocument.EnumerateEvents(yaml, (in YamlEvent evt) =>
+        {
+            result.Add((evt.Type, evt.Line, evt.Column, evt.EndLine, evt.EndColumn, Extract(yaml, evt.Line, evt.Column, evt.EndLine, evt.EndColumn)));
+            return true;
+        });
+        return result;
+    }
+
+    [TestMethod]
+    public void PlainScalars_AllEventSpans()
+    {
+        const string yaml = "key: value\n";
+        CollectionAssert.AreEqual(new[]
+        {
+            (YamlEventType.StreamStart,    1, 1, 1, 1, ""),
+            (YamlEventType.DocumentStart,  1, 1, 1, 1, ""),
+            (YamlEventType.MappingStart,   1, 1, 1, 1, ""),
+            (YamlEventType.Scalar,         1, 1, 1, 4, "key"),
+            (YamlEventType.Scalar,         1, 6, 1, 11, "value"),
+            (YamlEventType.MappingEnd,     2, 1, 2, 1, ""),
+            (YamlEventType.DocumentEnd,    2, 1, 2, 1, ""),
+            (YamlEventType.StreamEnd,      2, 1, 2, 1, ""),
+        }, AllEventSpans(yaml));
+    }
+
+    [TestMethod]
+    public void DoubleQuotedScalar_AllEventSpans()
+    {
+        const string yaml = "k: \"hello\"\n";
+        CollectionAssert.AreEqual(new[]
+        {
+            (YamlEventType.StreamStart,    1, 1, 1,  1, ""),
+            (YamlEventType.DocumentStart,  1, 1, 1,  1, ""),
+            (YamlEventType.MappingStart,   1, 1, 1,  1, ""),
+            (YamlEventType.Scalar,         1, 1, 1,  2, "k"),
+            (YamlEventType.Scalar,         1, 4, 1, 11, "\"hello\""),
+            (YamlEventType.MappingEnd,     2, 1, 2,  1, ""),
+            (YamlEventType.DocumentEnd,    2, 1, 2,  1, ""),
+            (YamlEventType.StreamEnd,      2, 1, 2,  1, ""),
+        }, AllEventSpans(yaml));
+    }
+
+    [TestMethod]
+    public void LiteralBlockScalar_AllEventSpans()
+    {
+        const string yaml = "x: |-\n  line1\n  line2\n\n\ny: z\n";
+        CollectionAssert.AreEqual(new[]
+        {
+            (YamlEventType.StreamStart,    1, 1, 1, 1, ""),
+            (YamlEventType.DocumentStart,  1, 1, 1, 1, ""),
+            (YamlEventType.MappingStart,   1, 1, 1, 1, ""),
+            (YamlEventType.Scalar,         1, 1, 1, 2, "x"),
+            (YamlEventType.Scalar,         1, 4, 3, 8, "|-\n  line1\n  line2"),
+            (YamlEventType.Scalar,         6, 1, 6, 2, "y"),
+            (YamlEventType.Scalar,         6, 4, 6, 5, "z"),
+            (YamlEventType.MappingEnd,     7, 1, 7, 1, ""),
+            (YamlEventType.DocumentEnd,    7, 1, 7, 1, ""),
+            (YamlEventType.StreamEnd,      7, 1, 7, 1, ""),
+        }, AllEventSpans(yaml));
+    }
+
+    [TestMethod]
+    public void EmptyNode_AllEventSpans()
+    {
+        const string yaml = "a: 1\nb:\n";
+        CollectionAssert.AreEqual(new[]
+        {
+            (YamlEventType.StreamStart,    1, 1, 1, 1, ""),
+            (YamlEventType.DocumentStart,  1, 1, 1, 1, ""),
+            (YamlEventType.MappingStart,   1, 1, 1, 1, ""),
+            (YamlEventType.Scalar,         1, 1, 1, 2, "a"),
+            (YamlEventType.Scalar,         1, 4, 1, 5, "1"),
+            (YamlEventType.Scalar,         2, 1, 2, 2, "b"),
+            (YamlEventType.Scalar,         3, 1, 3, 1, ""),
+            (YamlEventType.MappingEnd,     3, 1, 3, 1, ""),
+            (YamlEventType.DocumentEnd,    3, 1, 3, 1, ""),
+            (YamlEventType.StreamEnd,      3, 1, 3, 1, ""),
+        }, AllEventSpans(yaml));
+    }
+
+    [TestMethod]
+    public void FlowSequence_AllEventSpans()
+    {
+        const string yaml = "name: foo\ntags: [x, y, z]\n";
+        CollectionAssert.AreEqual(new[]
+        {
+            (YamlEventType.StreamStart,    1,  1, 1,  1, ""),
+            (YamlEventType.DocumentStart,  1,  1, 1,  1, ""),
+            (YamlEventType.MappingStart,   1,  1, 1,  1, ""),
+            (YamlEventType.Scalar,         1,  1, 1,  5, "name"),
+            (YamlEventType.Scalar,         1,  7, 1, 10, "foo"),
+            (YamlEventType.Scalar,         2,  1, 2,  5, "tags"),
+            (YamlEventType.SequenceStart,  2,  7, 2,  7, ""),
+            (YamlEventType.Scalar,         2,  8, 2,  9, "x"),
+            (YamlEventType.Scalar,         2, 11, 2, 12, "y"),
+            (YamlEventType.Scalar,         2, 14, 2, 15, "z"),
+            (YamlEventType.SequenceEnd,    2, 16, 2, 16, ""),
+            (YamlEventType.MappingEnd,     3,  1, 3,  1, ""),
+            (YamlEventType.DocumentEnd,    3,  1, 3,  1, ""),
+            (YamlEventType.StreamEnd,      3,  1, 3,  1, ""),
+        }, AllEventSpans(yaml));
+    }
+
+    [TestMethod]
+    public void FlowMapping_AllEventSpans()
+    {
+        const string yaml = "config: {a: 1, b: 2}\nother: z\n";
+        CollectionAssert.AreEqual(new[]
+        {
+            (YamlEventType.StreamStart,    1,  1, 1,  1, ""),
+            (YamlEventType.DocumentStart,  1,  1, 1,  1, ""),
+            (YamlEventType.MappingStart,   1,  1, 1,  1, ""),
+            (YamlEventType.Scalar,         1,  1, 1,  7, "config"),
+            (YamlEventType.MappingStart,   1,  9, 1,  9, ""),
+            (YamlEventType.Scalar,         1, 10, 1, 11, "a"),
+            (YamlEventType.Scalar,         1, 13, 1, 14, "1"),
+            (YamlEventType.Scalar,         1, 16, 1, 17, "b"),
+            (YamlEventType.Scalar,         1, 19, 1, 20, "2"),
+            (YamlEventType.MappingEnd,     1, 21, 1, 21, ""),
+            (YamlEventType.Scalar,         2,  1, 2,  6, "other"),
+            (YamlEventType.Scalar,         2,  8, 2,  9, "z"),
+            (YamlEventType.MappingEnd,     3,  1, 3,  1, ""),
+            (YamlEventType.DocumentEnd,    3,  1, 3,  1, ""),
+            (YamlEventType.StreamEnd,      3,  1, 3,  1, ""),
+        }, AllEventSpans(yaml));
+    }
+
+    [TestMethod]
+    public void NestedBlockMapping_AllEventSpans()
+    {
+        const string yaml = "outer: x\nmap:\n  a: 1\n  b: 2\n";
+        CollectionAssert.AreEqual(new[]
+        {
+            (YamlEventType.StreamStart,    1, 1, 1, 1, ""),
+            (YamlEventType.DocumentStart,  1, 1, 1, 1, ""),
+            (YamlEventType.MappingStart,   1, 1, 1, 1, ""),
+            (YamlEventType.Scalar,         1, 1, 1, 6, "outer"),
+            (YamlEventType.Scalar,         1, 8, 1, 9, "x"),
+            (YamlEventType.Scalar,         2, 1, 2, 4, "map"),
+            (YamlEventType.MappingStart,   3, 3, 3, 3, ""),
+            (YamlEventType.Scalar,         3, 3, 3, 4, "a"),
+            (YamlEventType.Scalar,         3, 6, 3, 7, "1"),
+            (YamlEventType.Scalar,         4, 3, 4, 4, "b"),
+            (YamlEventType.Scalar,         4, 6, 4, 7, "2"),
+            (YamlEventType.MappingEnd,     5, 1, 5, 1, ""),
+            (YamlEventType.MappingEnd,     5, 1, 5, 1, ""),
+            (YamlEventType.DocumentEnd,    5, 1, 5, 1, ""),
+            (YamlEventType.StreamEnd,      5, 1, 5, 1, ""),
+        }, AllEventSpans(yaml));
+    }
+}


### PR DESCRIPTION
## Summary

- Adds [`EndLine`](https://github.com/OpenByteDev/Corvus.JsonSchema/blob/feat/yaml-event-end-span/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/YamlEvent.cs#L254) and [`EndColumn`](https://github.com/OpenByteDev/Corvus.JsonSchema/blob/feat/yaml-event-end-span/src/Corvus.Text.Json.Yaml/Corvus/Text/Json/Yaml/YamlEvent.cs#L259) properties to `YamlEvent`, giving callers a source span for every event.
- Includes [`YamlEventSpanTests`](https://github.com/OpenByteDev/Corvus.JsonSchema/blob/feat/yaml-event-end-span/tests/Corvus.Text.Json.Yaml.Tests/YamlEventSpanTests.cs) covering all event types (scalars, flow/block collections, literal block scalars, empty nodes).

## Pull request checklist

- [x] Code compiles with no warnings (`TreatWarningsAsErrors=true`)
- [x] Tests pass: `dotnet test --filter "TestCategory!=failing&TestCategory!=outerloop"`
- [x] New public APIs have XML doc comments
- [x] New source files are listed in `.csproj` (no glob includes)
- [x] Exception messages use `SR.*` resource strings
- [x] Follows existing code patterns (partial classes, Common/ linking, etc.)
