### PR TITLE
Fix #901: OpenAPI playground mock routes miss the V5.2.4 base-path prefix

### DIFF
--- a/docs/playground-openapi/src/Corvus.Text.Json.OpenApi.Playground/Services/PlaygroundHttpMessageHandler.cs
+++ b/docs/playground-openapi/src/Corvus.Text.Json.OpenApi.Playground/Services/PlaygroundHttpMessageHandler.cs
@@ -12,6 +12,16 @@ public sealed class PlaygroundHttpMessageHandler : HttpMessageHandler
     protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
     {
         string path = request.RequestUri?.AbsolutePath ?? "/";
+
+        // HttpClientTransport (since V5.2.4) preserves the base address path prefix,
+        // so requests arrive as /v1/pets (basic and Swagger 2.0 samples) or /v2/pets
+        // (advanced sample). Strip the version segment so the route table below stays
+        // sample-neutral.
+        if (path.StartsWith("/v1/", StringComparison.Ordinal) || path.StartsWith("/v2/", StringComparison.Ordinal))
+        {
+            path = path[3..];
+        }
+
         HttpResponseMessage response = (request.Method.Method, path) switch
         {
             ("GET", "/pets") => JsonResponse(HttpStatusCode.OK, AdvancedPetList, ("x-total-count", "2"), ("x-next", "/pets?limit=10&cursor=next")),


### PR DESCRIPTION
Closes #901.

All three OpenAPI playground samples generated and compiled but got `Error 404: No playground response is configured for this request` for every call. `PlaygroundHttpMessageHandler` routes on bare paths (`/pets`, …), which matched the pre-V5.2.4 world where `HttpClient` resolution replaced the base address path. Since V5.2.4 the transport preserves the prefix, so requests arrive at `/v1/pets` (basic and Swagger 2.0 samples) and `/v2/...` (advanced) and nothing matched.

The mock now strips the `/v1`/`/v2` segment before routing, with a comment explaining the V5.2.4 semantics.

**Verification** — a harness compiling the handler source directly probed the 12 real wire paths the three samples produce: all 404 before the fix, all return their configured responses (200/201/202) after. The playground WASM project builds with 0 errors; catalog check passes.

Labeled `no_release`: this is playground demo tooling with no package content, and the playground redeploys with the docs website on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WJ7SSdzvK2SxmYqKEeoX1M