### PR TITLE
Fix #910 and #906: validation message separator space and global-namespace source generation

### DIFF
--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,15 @@
 # Version History
 
+## V5.2.13
+
+V5.2.13 fixes two defects in the schema validation error messages and makes the source generator work for structs declared in the global namespace.
+
+### Bug fixes
+
+- **Integer-valued validation messages restore the space before the quoted value** — Every message family whose expected value is an integer (`minLength`/`maxLength`, `minItems`/`maxItems`, `minContains`/`maxContains`, `minProperties`/`maxProperties`, across all six comparison variants) emitted text like `Expected the item count to be greater than or equal to'3'`. The messages are composed from a resource string that deliberately ends without trailing whitespace plus an appender that writes the quoted expected value; the string-valued appender wrote the separator space but the integer-valued appender did not. The integer appender now writes the same leading space, and exact-format tests pin all 24 affected message providers. See [#910](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/910).
+- **`exclusiveMaximum` failures report the correct comparison direction** — The `JsonSchema_ExpectedLessThan` resource read "The value was expected to be greater than", so a failed less-than comparison reported the opposite direction. Both copies of the resource (the main library and the JsonLogic source generator) now read "less than". See [#910](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/910).
+- **The source generator emits types for structs declared in the global namespace** — A `[JsonSchemaTypeGenerator]` struct declared outside any namespace generated nothing, silently: the generator's syntactic pre-filter required the struct's parent to be a namespace declaration, so a global-namespace target never entered the pipeline and no diagnostic was reported. The filter now accepts a compilation-unit parent, the target namespace maps to the empty string (as the query-language source generators already do), and the C# emission omits the namespace declaration and the leading dot in fully qualified names when the namespace is empty. The default namespace used for shared generated types prefers the first non-empty target namespace, so a global-namespace target cannot capture it. Generated output for namespaced targets is byte-for-byte unchanged. See [#906](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/906).
+
 ## V5.2.12
 
 V5.2.12 adds `MatchEvery()` to generated `anyOf` types in both the V4 and V5 engines: an accumulator-threading counterpart to `Match()` that visits every matching subschema instead of only the first.

--- a/src/Corvus.Text.Json.CodeGeneration/CSharpLanguageProvider.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CSharpLanguageProvider.cs
@@ -477,7 +477,7 @@ public class CSharpLanguageProvider : IHierarchicalLanguageProvider
             name = currentName;
         }
 
-        fullyQualifiedName = $"{options.DefaultNamespace}.{name}";
+        fullyQualifiedName = options.DefaultNamespace.Length == 0 ? name : $"{options.DefaultNamespace}.{name}";
         namedTypes.NamedTypeMap.Add(key, fullyQualifiedName);
 
         if (rootNamespaceGenerator is null)
@@ -497,9 +497,12 @@ public class CSharpLanguageProvider : IHierarchicalLanguageProvider
                     "global::System.Buffers.Text",
                     "global::System.Runtime.CompilerServices",
                     "global::Corvus.Text.Json",
-                    "global::Corvus.Text.Json.Internal")
+                    "global::Corvus.Text.Json.Internal");
 
-                .AppendLineIndent("namespace " + options.DefaultNamespace, ";");
+            if (options.DefaultNamespace.Length != 0)
+            {
+                rootNamespaceGenerator.AppendLineIndent("namespace " + options.DefaultNamespace, ";");
+            }
         }
 
         emitter(rootNamespaceGenerator, name);

--- a/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.cs
@@ -392,11 +392,17 @@ internal static partial class CodeGeneratorExtensions
             return generator;
         }
 
-        return generator
-            .Append("namespace ")
-            .Append(ns)
-            .AppendLine(";")
-            .PushMemberScope(ns, ScopeType.TypeContainer);
+        // An empty namespace means the global namespace: no namespace declaration
+        // is emitted, but the member scope is still pushed so that Begin/End pairing holds.
+        if (ns.Length != 0)
+        {
+            generator
+                .Append("namespace ")
+                .Append(ns)
+                .AppendLine(";");
+        }
+
+        return generator.PushMemberScope(ns, ScopeType.TypeContainer);
     }
 
     /// <summary>

--- a/src/Corvus.Text.Json.CodeGeneration/StandaloneEvaluatorGenerator.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/StandaloneEvaluatorGenerator.cs
@@ -4298,8 +4298,12 @@ internal static partial class StandaloneEvaluatorGenerator
 
     private static void EmitNamespaceOpen(GenerationContext ctx, string ns)
     {
-        ctx.AppendLine($"namespace {ns};");
-        ctx.AppendLine();
+        // An empty namespace means the global namespace: no namespace declaration is emitted.
+        if (ns.Length != 0)
+        {
+            ctx.AppendLine($"namespace {ns};");
+            ctx.AppendLine();
+        }
     }
 
     private static void EmitClassOpen(GenerationContext ctx, string className)

--- a/src/Corvus.Text.Json.CodeGeneration/TypeDeclarationExtensions.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/TypeDeclarationExtensions.cs
@@ -446,9 +446,11 @@ public static class TypeDeclarationExtensions
         if (!typeDeclaration.TryGetMetadata(FullyQualifiedDotnetTypeNameKey, out string? fqdntn))
         {
             TypeDeclaration? parent = typeDeclaration.Parent();
-            fqdntn = parent is null
-                ? $"{typeDeclaration.DotnetNamespace()}.{typeDeclaration.DotnetTypeName()}"
-                : $"{parent.FullyQualifiedDotnetTypeName()}.{typeDeclaration.DotnetTypeName()}";
+            fqdntn = parent is not null
+                ? $"{parent.FullyQualifiedDotnetTypeName()}.{typeDeclaration.DotnetTypeName()}"
+                : typeDeclaration.DotnetNamespace() is { Length: > 0 } ns
+                    ? $"{ns}.{typeDeclaration.DotnetTypeName()}"
+                    : typeDeclaration.DotnetTypeName();
 
             typeDeclaration.SetMetadata(FullyQualifiedDotnetTypeNameKey, fqdntn);
         }

--- a/src/Corvus.Text.Json.JsonLogic.SourceGenerator/Resources/Strings.Designer.cs
+++ b/src/Corvus.Text.Json.JsonLogic.SourceGenerator/Resources/Strings.Designer.cs
@@ -386,8 +386,8 @@ namespace Resources
         /// <summary>The value was expected to be greater than or equal to</summary>
         public static string @JsonSchema_ExpectedGreaterThanOrEquals => GetResourceString("JsonSchema_ExpectedGreaterThanOrEquals", @"The value was expected to be greater than or equal to");
 
-        /// <summary>The value was expected to be greater than</summary>
-        public static string @JsonSchema_ExpectedLessThan => GetResourceString("JsonSchema_ExpectedLessThan", @"The value was expected to be greater than");
+        /// <summary>The value was expected to be less than</summary>
+        public static string @JsonSchema_ExpectedLessThan => GetResourceString("JsonSchema_ExpectedLessThan", @"The value was expected to be less than");
 
         /// <summary>The value was expected to be less than or equal to</summary>
         public static string @JsonSchema_ExpectedLessThanOrEquals => GetResourceString("JsonSchema_ExpectedLessThanOrEquals", @"The value was expected to be less than or equal to");

--- a/src/Corvus.Text.Json.JsonLogic.SourceGenerator/Resources/Strings.resx
+++ b/src/Corvus.Text.Json.JsonLogic.SourceGenerator/Resources/Strings.resx
@@ -495,7 +495,7 @@
     <value>The value was expected to be greater than or equal to</value>
   </data>
   <data name="JsonSchema_ExpectedLessThan" xml:space="preserve">
-    <value>The value was expected to be greater than</value>
+    <value>The value was expected to be less than</value>
   </data>
   <data name="JsonSchema_ExpectedLessThanOrEquals" xml:space="preserve">
     <value>The value was expected to be less than or equal to</value>

--- a/src/Corvus.Text.Json.SourceGenerator/IncrementalSourceGenerator.cs
+++ b/src/Corvus.Text.Json.SourceGenerator/IncrementalSourceGenerator.cs
@@ -91,7 +91,11 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
             }
         }
 
-        return new(context.TargetSymbol.ContainingNamespace.ToDisplayString(), location, rebaseToRootPath, context.TargetSymbol.Name, GetAccessibility(context.TargetSymbol.DeclaredAccessibility), emitEvaluator);
+        string ns = context.TargetSymbol.ContainingNamespace.IsGlobalNamespace
+            ? string.Empty
+            : context.TargetSymbol.ContainingNamespace.ToDisplayString();
+
+        return new(ns, location, rebaseToRootPath, context.TargetSymbol.Name, GetAccessibility(context.TargetSymbol.DeclaredAccessibility), emitEvaluator);
     }
 
     private static SourceGeneratorTools.GeneratedTypeAccessibility GetAccessibility(Accessibility accessibility)
@@ -280,7 +284,7 @@ public class IncrementalSourceGenerator : IIncrementalGenerator
                structDeclarationSyntax
                    .Modifiers
                    .Any(m => m.IsKind(SyntaxKind.PartialKeyword)) &&
-               structDeclarationSyntax.Parent is (FileScopedNamespaceDeclarationSyntax or NamespaceDeclarationSyntax);
+               structDeclarationSyntax.Parent is (FileScopedNamespaceDeclarationSyntax or NamespaceDeclarationSyntax or CompilationUnitSyntax);
     }
 
     private class GlobalOptions(

--- a/src/Corvus.Text.Json.SourceGenerator/SourceGeneratorHelpers.cs
+++ b/src/Corvus.Text.Json.SourceGenerator/SourceGeneratorHelpers.cs
@@ -103,7 +103,12 @@ public static class SourceGeneratorHelpers
                 evaluatorRootTypes.Add(rootType);
             }
 
-            defaultNamespace ??= spec.Namespace;
+            // Prefer the first non-empty namespace: an empty namespace (a global-namespace
+            // target) must not capture the default used for shared generated types.
+            if (string.IsNullOrEmpty(defaultNamespace))
+            {
+                defaultNamespace = spec.Namespace;
+            }
 
             // Only add the named type if the spec.TypeName is not null or empty.
             if (!string.IsNullOrEmpty(spec.TypeName))

--- a/src/Corvus.Text.Json/Corvus/Text/Json/JsonSchema/Internal/JsonSchemaEvaluation.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/JsonSchema/Internal/JsonSchemaEvaluation.cs
@@ -243,12 +243,13 @@ public static partial class JsonSchemaEvaluation
 
     private static bool AppendQuotedInteger(int value, Span<byte> buffer, ref int written)
     {
-        if (buffer.Length < 3)
+        if (buffer.Length - written < 4)
         {
             written = 0;
             return false;
         }
 
+        buffer[written++] = (byte)' ';
         buffer[written++] = (byte)'\'';
         if (!Utf8Formatter.TryFormat(value, buffer.Slice(written), out int bytesWritten))
         {

--- a/src/Corvus.Text.Json/Resources/Strings.resx
+++ b/src/Corvus.Text.Json/Resources/Strings.resx
@@ -507,7 +507,7 @@
     <value>The value was expected to be greater than or equal to</value>
   </data>
   <data name="JsonSchema_ExpectedLessThan" xml:space="preserve">
-    <value>The value was expected to be greater than</value>
+    <value>The value was expected to be less than</value>
   </data>
   <data name="JsonSchema_ExpectedLessThanOrEquals" xml:space="preserve">
     <value>The value was expected to be less than or equal to</value>

--- a/tests/Corvus.Text.Json.Tests.GeneratedModels/Corvus.Text.Json.Tests.GeneratedModels.csproj
+++ b/tests/Corvus.Text.Json.Tests.GeneratedModels/Corvus.Text.Json.Tests.GeneratedModels.csproj
@@ -60,6 +60,7 @@
     <AdditionalFiles Include="case-insensitive-enum-2020-12.json" />
     <AdditionalFiles Include="reserved-property-names-2020-12.json" />
     <AdditionalFiles Include="string-maxlength-enum-2020-12.json" />
+    <AdditionalFiles Include="global-namespace-model-2020-12.json" />
     <AdditionalFiles Include="simple-object-2020-12.yaml" />
     <AdditionalFiles Include="app-config-2020-12.yaml" />
   </ItemGroup>

--- a/tests/Corvus.Text.Json.Tests.GeneratedModels/GlobalNamespaceModel.cs
+++ b/tests/Corvus.Text.Json.Tests.GeneratedModels/GlobalNamespaceModel.cs
@@ -1,0 +1,4 @@
+using Corvus.Text.Json;
+
+[JsonSchemaTypeGenerator("./global-namespace-model-2020-12.json")]
+public readonly partial struct GlobalNamespaceModel;

--- a/tests/Corvus.Text.Json.Tests.GeneratedModels/global-namespace-model-2020-12.json
+++ b/tests/Corvus.Text.Json.Tests.GeneratedModels/global-namespace-model-2020-12.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "oneOf": [
+        { "type": "string" },
+        {
+            "type": "object",
+            "properties": {
+                "expression": { "type": "string" }
+            },
+            "required": ["expression"]
+        }
+    ]
+}

--- a/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
+++ b/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
@@ -169,6 +169,7 @@
     <Compile Include="GeneratedMixedCompositionTests.cs" />
     <Compile Include="GeneratedNullableOptionalTests.cs" />
     <Compile Include="GeneratedNonNullDefaultedTests.cs" />
+    <Compile Include="GlobalNamespaceModelTests.cs" />
     <Compile Include="DiscriminatedUnionConversionTests.cs" />
     <Compile Include="GeneratedV4NonNullDefaultedTests.cs" />
     <Compile Include="GeneratedTupleArrayTests.cs" />

--- a/tests/Corvus.Text.Json.Tests/GlobalNamespaceModelTests.cs
+++ b/tests/Corvus.Text.Json.Tests/GlobalNamespaceModelTests.cs
@@ -1,0 +1,54 @@
+// <copyright file="GlobalNamespaceModelTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.Tests;
+
+/// <summary>
+/// Tests for source generation targeting a struct declared in the global namespace
+/// (see https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/906).
+/// <see cref="GlobalNamespaceModel"/> is declared without a namespace in the
+/// GeneratedModels project; these tests prove that the generator produced a working
+/// type for it. A regression to silent non-generation fails this file at compile time.
+/// </summary>
+[TestClass]
+public class GlobalNamespaceModelTests
+{
+    [TestMethod]
+    public void GlobalNamespaceModel_StringForm_EvaluatesSchemaValid()
+    {
+        using ParsedJsonDocument<GlobalNamespaceModel> doc =
+            ParsedJsonDocument<GlobalNamespaceModel>.Parse("\"just a string\"");
+
+        Assert.IsTrue(doc.RootElement.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void GlobalNamespaceModel_ObjectForm_EvaluatesSchemaValid()
+    {
+        using ParsedJsonDocument<GlobalNamespaceModel> doc =
+            ParsedJsonDocument<GlobalNamespaceModel>.Parse("""{"expression": "a + b"}""");
+
+        Assert.IsTrue(doc.RootElement.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void GlobalNamespaceModel_ObjectFormMissingRequiredProperty_EvaluatesSchemaInvalid()
+    {
+        using ParsedJsonDocument<GlobalNamespaceModel> doc =
+            ParsedJsonDocument<GlobalNamespaceModel>.Parse("""{"other": 1}""");
+
+        Assert.IsFalse(doc.RootElement.EvaluateSchema());
+    }
+
+    [TestMethod]
+    public void GlobalNamespaceModel_NumberForm_EvaluatesSchemaInvalid()
+    {
+        using ParsedJsonDocument<GlobalNamespaceModel> doc =
+            ParsedJsonDocument<GlobalNamespaceModel>.Parse("42");
+
+        Assert.IsFalse(doc.RootElement.EvaluateSchema());
+    }
+}

--- a/tests/Corvus.Text.Json.Tests/JsonSchemaEvaluationMessageTests.cs
+++ b/tests/Corvus.Text.Json.Tests/JsonSchemaEvaluationMessageTests.cs
@@ -1397,12 +1397,12 @@ public class JsonSchemaEvaluationMessageTests
         Span<byte> largeBuffer = stackalloc byte[512];
         JsonSchemaEvaluation.ExpectedItemCountEqualsValue(5, largeBuffer, out int fullWritten);
 
-        // Buffer = prefix + 1: room for opening quote but not for the integer digit
-        // AppendQuotedInteger: after writing opening quote, TryFormat has 0 bytes → fails (lines 252-255)
+        // Buffer with room for the space and opening quote but not for the integer digit
+        // AppendQuotedInteger: after writing space + opening quote, TryFormat has 0 bytes → fails
         Span<byte> buffer = stackalloc byte[512];
 
-        // The full message is: "prefix'5'" — prefix + opening quote (1) + digit (1) + closing quote (1) = prefix + 3
-        // Use prefix + 1 to allow only the opening quote
+        // The full message is: "prefix '5'" — space (1) + opening quote (1) + digit (1) + closing quote (1)
+        // Trim the digit and closing quote to allow only the space and opening quote
         int prefixPlusQuote = fullWritten - 2; // minus digit and closing quote
         buffer = buffer.Slice(0, prefixPlusQuote);
 
@@ -1484,6 +1484,66 @@ public class JsonSchemaEvaluationMessageTests
 
     #endregion
 
+    #region Exact message format (issue #910)
+
+    [TestMethod]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedItemCountEquals), "Expected the item count to equal '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedItemCountNotEquals), "Expected the item count not to equal '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedItemCountGreaterThan), "Expected the item count to be greater than '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedItemCountGreaterThanOrEquals), "Expected the item count to be greater than or equal to '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedItemCountLessThan), "Expected the item count to be less than '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedItemCountLessThanOrEquals), "Expected the item count to be less than or equal to '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedContainsCountEquals), "Expected the contains count to equal '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedContainsCountNotEquals), "Expected the contains count not to equal '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedContainsCountGreaterThan), "Expected the contains count to be greater than '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedContainsCountGreaterThanOrEquals), "Expected the contains count to be greater than or equal to '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedContainsCountLessThan), "Expected the contains count to be less than '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedContainsCountLessThanOrEquals), "Expected the contains count to be less than or equal to '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedPropertyCountEquals), "Expected the property count to equal '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedPropertyCountNotEquals), "Expected the property count not to equal '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedPropertyCountGreaterThan), "Expected the property count to be greater than '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedPropertyCountGreaterThanOrEquals), "Expected the property count to be greater than or equal to '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedPropertyCountLessThan), "Expected the property count to be less than '3'")]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedPropertyCountLessThanOrEquals), "Expected the property count to be less than or equal to '3'")]
+    [DataRow("ExpectedStringLengthEquals", "Expected the length of the value to equal '3'")]
+    [DataRow("ExpectedStringLengthNotEquals", "Expected the length of the value not to equal '3'")]
+    [DataRow("ExpectedStringLengthGreaterThan", "Expected the length of the value to be greater than '3'")]
+    [DataRow("ExpectedStringLengthGreaterThanOrEquals", "Expected the length of the value to be greater than or equal to '3'")]
+    [DataRow("ExpectedStringLengthLessThan", "Expected the length of the value to be less than '3'")]
+    [DataRow("ExpectedStringLengthLessThanOrEquals", "Expected the length of the value to be less than or equal to '3'")]
+    public void IntMessageProvider_WritesSpaceSeparatedQuotedValue(string fieldName, string expected)
+    {
+        JsonSchemaMessageProvider<int> provider = GetIntProvider(fieldName);
+        Span<byte> buffer = stackalloc byte[256];
+
+        bool result = provider(3, buffer, out int written);
+
+        Assert.IsTrue(result);
+        string output = Encoding.UTF8.GetString(buffer.Slice(0, written).ToArray());
+        Assert.AreEqual(expected, output);
+    }
+
+    [TestMethod]
+    [DataRow(nameof(JsonSchemaEvaluation.ExpectedEquals), "The value was expected to be equal to '10'")]
+    [DataRow("ExpectedNotEquals", "The value was expected to be not equal to '10'")]
+    [DataRow("ExpectedGreaterThan", "The value was expected to be greater than '10'")]
+    [DataRow("ExpectedGreaterThanOrEquals", "The value was expected to be greater than or equal to '10'")]
+    [DataRow("ExpectedLessThan", "The value was expected to be less than '10'")]
+    [DataRow("ExpectedLessThanOrEquals", "The value was expected to be less than or equal to '10'")]
+    public void NumberComparisonMessageProvider_WritesExpectedMessage(string fieldName, string expected)
+    {
+        JsonSchemaMessageProvider<string> provider = GetStringProvider(fieldName);
+        Span<byte> buffer = stackalloc byte[256];
+
+        bool result = provider("10", buffer, out int written);
+
+        Assert.IsTrue(result);
+        string output = Encoding.UTF8.GetString(buffer.Slice(0, written).ToArray());
+        Assert.AreEqual(expected, output);
+    }
+
+    #endregion
+
     #region Helper methods
 
     private static JsonSchemaMessageProvider GetParameterlessProvider(string fieldName)
@@ -1495,9 +1555,16 @@ public class JsonSchemaEvaluationMessageTests
 
     private static JsonSchemaMessageProvider<int> GetIntProvider(string fieldName)
     {
-        System.Reflection.FieldInfo field = typeof(JsonSchemaEvaluation).GetField(fieldName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Static)
+        System.Reflection.FieldInfo field = typeof(JsonSchemaEvaluation).GetField(fieldName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
             ?? throw new InvalidOperationException($"Field '{fieldName}' not found on JsonSchemaEvaluation");
         return (JsonSchemaMessageProvider<int>)(field.GetValue(null) ?? throw new InvalidOperationException($"Field '{fieldName}' value is null"));
+    }
+
+    private static JsonSchemaMessageProvider<string> GetStringProvider(string fieldName)
+    {
+        System.Reflection.FieldInfo field = typeof(JsonSchemaEvaluation).GetField(fieldName, System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)
+            ?? throw new InvalidOperationException($"Field '{fieldName}' not found on JsonSchemaEvaluation");
+        return (JsonSchemaMessageProvider<string>)(field.GetValue(null) ?? throw new InvalidOperationException($"Field '{fieldName}' value is null"));
     }
 
     #endregion


### PR DESCRIPTION
Fixes #910. Fixes #906.

Two layered fixes, each root-caused and planned in its issue thread before implementation ([#910 plan](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/910#issuecomment-5152859439), [#906 plan](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/906#issuecomment-5156198090)).

## #910 — validation message whitespace (`db886368a0a`)

Validation messages are composed from a resource string that deliberately ends without trailing whitespace plus an appender that writes the quoted expected value. `AppendSingleQuotedValue` writes the separator space; `AppendQuotedInteger` did not, so every integer-valued message family (`minLength`/`maxLength`, `minItems`/`maxItems`, `minContains`/`maxContains`, `minProperties`/`maxProperties`, six comparison variants each) emitted `...greater than or equal to'3'`. The integer appender now writes the same leading space.

The scan the issue asked for also found `JsonSchema_ExpectedLessThan` reading "The value was expected to be **greater** than" in both resource copies (main library and the JsonLogic source generator), so `exclusiveMaximum` failures reported the opposite direction. Both copies now read "less than".

Test-first: 25 new exact-format assertions failed before the fix and pass after, pinning all 24 integer-valued message providers and the six number-comparison messages.

## #906 — global-namespace source generation (`3c683101791`)

The generator's syntactic pre-filter required the attributed struct's parent to be a namespace declaration, so a global-namespace struct (parent `CompilationUnitSyntax`) was silently dropped with no diagnostic. Behind the filter, `ContainingNamespace.ToDisplayString()` yields the literal `<global namespace>` string, and four emission sites assumed a non-empty namespace (`namespace ...;` lines and `{ns}.{name}` fully qualified names).

The fix relaxes the filter, maps the global namespace to the empty string (matching the JMESPath/Jsonata/JsonLogic/JsonPath generators), and handles the empty namespace at the four emission sites. The default namespace used for shared generated types now prefers the first non-empty target namespace, so a global-namespace target cannot capture it regardless of spec collection order.

A `GlobalNamespaceModel` struct in the GeneratedModels project guards the regression through the real build on every TFM: silent non-generation now fails compilation, and four tests parse and schema-evaluate the `oneOf` shapes from the issue.

## Verification

- Warning-free `Corvus.Text.Json.slnx` builds after each fix.
- Full filtered test suite on all TFMs: green after #910 (94,095 tests); 94,098/94,099 after #906, with the single AsyncApi telemetry failure passing standalone and unrelated to these changes.
- Generator-change gate: regenerated all example recipes and a benchmark `C/` directory — output is byte-for-byte identical for namespaced inputs (only lock-file timestamp churn, reverted).
- `VERSIONHISTORY.md` gains the V5.2.13 entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EZZMVqcEwHxGUmVYGY8Rte
