### PR TITLE
Pass binding context to generated AsyncAPI consumers

### DIFF
--- a/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
+++ b/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
@@ -1967,6 +1967,8 @@ public sealed class AsyncApi30CodeGenerator
             ? "string channel, CancellationToken cancellationToken = default"
             : "CancellationToken cancellationToken = default";
 
+        bool hasBindingContext = op.ChannelBindingsJson is not null || op.OperationBindingsJson is not null;
+
         if (op.SecuritySchemes.Count > 0)
         {
             w.WriteLine($"public async ValueTask StartAsync({startParams})");
@@ -1989,14 +1991,33 @@ public sealed class AsyncApi30CodeGenerator
             w.WriteLine();
 
             string subscribeAddr = op.IsDynamicAddress ? "this.subscribedChannelUtf8" : "ChannelAddressUtf8";
+            if (hasBindingContext)
+            {
+                w.WriteLine("MessageContext context = new()");
+                w.OpenBrace();
+                if (op.ChannelBindingsJson is not null)
+                {
+                    w.WriteLine("ChannelBindingsJson = ChannelBindingsBytes,");
+                }
+
+                if (op.OperationBindingsJson is not null)
+                {
+                    w.WriteLine("OperationBindingsJson = OperationBindingsBytes,");
+                }
+
+                w.CloseBraceWithSemicolon();
+            }
+
             if (op.Messages.Count == 1)
             {
                 string payloadType = op.Messages[0].PayloadTypeName ?? "Corvus.Text.Json.JsonElement";
-                w.WriteLine($"await this.transport.SubscribeAsync<{payloadType}>({subscribeAddr}, this.HandleMessageAsync, cancellationToken).ConfigureAwait(false);");
+                string contextArg = hasBindingContext ? ", context" : string.Empty;
+                w.WriteLine($"await this.transport.SubscribeAsync<{payloadType}>({subscribeAddr}, this.HandleMessageAsync{contextArg}, cancellationToken).ConfigureAwait(false);");
             }
             else
             {
-                w.WriteLine($"await this.transport.SubscribeAsync<Corvus.Text.Json.JsonElement>({subscribeAddr}, this.HandleMessageAsync, cancellationToken).ConfigureAwait(false);");
+                string contextArg = hasBindingContext ? ", context" : string.Empty;
+                w.WriteLine($"await this.transport.SubscribeAsync<Corvus.Text.Json.JsonElement>({subscribeAddr}, this.HandleMessageAsync{contextArg}, cancellationToken).ConfigureAwait(false);");
             }
 
             w.CloseBrace();
@@ -2013,14 +2034,33 @@ public sealed class AsyncApi30CodeGenerator
             }
 
             string subscribeAddr = op.IsDynamicAddress ? "this.subscribedChannelUtf8" : "ChannelAddressUtf8";
+            if (hasBindingContext)
+            {
+                w.WriteLine("MessageContext context = new()");
+                w.OpenBrace();
+                if (op.ChannelBindingsJson is not null)
+                {
+                    w.WriteLine("ChannelBindingsJson = ChannelBindingsBytes,");
+                }
+
+                if (op.OperationBindingsJson is not null)
+                {
+                    w.WriteLine("OperationBindingsJson = OperationBindingsBytes,");
+                }
+
+                w.CloseBraceWithSemicolon();
+            }
+
             if (op.Messages.Count == 1)
             {
                 string payloadType = op.Messages[0].PayloadTypeName ?? "Corvus.Text.Json.JsonElement";
-                w.WriteLine($"return this.transport.SubscribeAsync<{payloadType}>({subscribeAddr}, this.HandleMessageAsync, cancellationToken);");
+                string contextArg = hasBindingContext ? ", context" : string.Empty;
+                w.WriteLine($"return this.transport.SubscribeAsync<{payloadType}>({subscribeAddr}, this.HandleMessageAsync{contextArg}, cancellationToken);");
             }
             else
             {
-                w.WriteLine($"return this.transport.SubscribeAsync<Corvus.Text.Json.JsonElement>({subscribeAddr}, this.HandleMessageAsync, cancellationToken);");
+                string contextArg = hasBindingContext ? ", context" : string.Empty;
+                w.WriteLine($"return this.transport.SubscribeAsync<Corvus.Text.Json.JsonElement>({subscribeAddr}, this.HandleMessageAsync{contextArg}, cancellationToken);");
             }
 
             w.CloseBrace();

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/AsyncApi30CodeGeneratorTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/AsyncApi30CodeGeneratorTests.cs
@@ -2103,6 +2103,23 @@ public class AsyncApi30CodeGeneratorTests
     }
 
     [TestMethod]
+    public void Generate_ConsumerWithOperationBindings_PassesBindingContextToTransport()
+    {
+        byte[] bytes = File.ReadAllBytes(Path.Combine("TestData", "nats-operation-bindings.json"));
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(bytes);
+
+        var generator = new AsyncApi30CodeGenerator("NatsBindings", new Dictionary<string, string>());
+        IReadOnlyList<GeneratedFile> files = generator.Generate(doc.RootElement);
+
+        GeneratedFile? consumer = files.FirstOrDefault(f => f.FileName.Contains("SubscribeOrdersConsumer"));
+        Assert.IsNotNull(consumer, "A receive operation should generate a Consumer class");
+
+        StringAssert.Contains(consumer.Content, "MessageContext context = new()");
+        StringAssert.Contains(consumer.Content, "OperationBindingsJson = OperationBindingsBytes");
+        StringAssert.Contains(consumer.Content, "this.HandleMessageAsync, context, cancellationToken");
+    }
+
+    [TestMethod]
     public void Compile_ConsumerDynamicMultiMessage_GeneratedCodeCompiles()
     {
         byte[] bytes = File.ReadAllBytes(Path.Combine("TestData", "consumer-dynamic-multi.json"));

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/nats-operation-bindings.json
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/nats-operation-bindings.json
@@ -1,0 +1,35 @@
+{
+  "asyncapi": "3.0.0",
+  "info": {
+    "title": "NATS operation bindings",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "orders": {
+      "address": "orders.created",
+      "messages": {
+        "OrderCreated": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operations": {
+    "subscribeOrders": {
+      "action": "receive",
+      "channel": { "$ref": "#/channels/orders" },
+      "bindings": {
+        "nats": {
+          "x-mode": "jetstream",
+          "x-stream": "ORDERS",
+          "x-consumer": "orders-service"
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Description

Generated AsyncAPI consumers currently pass only the channel address and handler to `IMessageTransport.SubscribeAsync`.

This change passes the generated channel and operation binding metadata through `MessageContext` when bindings are present.

That allows transport implementations to inspect protocol-specific extensions, such as NATS Core/JetStream routing and stream/consumer configuration, without reparsing the original AsyncAPI document.

## Compatibility

This remains backward-compatible:

- Existing generated consumers without bindings continue using the existing overload.
- Existing `IMessageTransport` implementations do not need changes.
- The context-aware overload already has a default implementation that delegates to the existing overload.
- Existing generated clients are unaffected until regenerated.

## Tests

Added coverage verifying that generated consumers with operation bindings:

- construct a `MessageContext`;
- populate `OperationBindingsJson`;
- invoke the context-aware `SubscribeAsync` overload.

All 172 AsyncAPI code-generation tests pass on `net10.0`.