### PR TITLE
Fix AsyncAPI 3.0 Channel Parameters Referenced with $ref

### DIFF
--- a/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
+++ b/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
@@ -1032,10 +1032,8 @@ public sealed class AsyncApi30CodeGenerator
         foreach (var paramProp in channel.ParametersValue.EnumerateObject())
         {
             string paramName = paramProp.Name;
-            AsyncApiDocument.Parameter param = paramProp.Value.Match(
-                matchReference: static (in AsyncApiDocument.Reference _) => default,
-                matchParameter: static (in AsyncApiDocument.Parameter p) => p,
-                defaultMatch: static (in AsyncApiDocument.Parameters.AdditionalPropertiesEntity _) => default);
+            JsonElement resolvedParameter = ResolveRef(paramProp.Value, doc, resolver);
+            AsyncApiDocument.Parameter param = resolvedParameter;
 
             if (param.IsUndefined())
             {

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/AsyncApi30CodeGeneratorTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/AsyncApi30CodeGeneratorTests.cs
@@ -2297,6 +2297,22 @@ public class AsyncApi30CodeGeneratorTests
     }
 
     [TestMethod]
+    public void Generate_ParameterizedConsumer_WithReferencedParameter_ComposesTheAddress()
+    {
+        byte[] bytes = File.ReadAllBytes(Path.Combine("TestData", "parameterized-consumer-ref.json"));
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(bytes);
+
+        var generator = new AsyncApi30CodeGenerator("ParameterizedRef", new Dictionary<string, string>());
+        IReadOnlyList<GeneratedFile> files = generator.Generate(doc.RootElement);
+
+        GeneratedFile? consumer = files.FirstOrDefault(f => f.FileName.Contains("SubscribeOrdersConsumer"));
+        Assert.IsNotNull(consumer, "A receive operation should generate a Consumer class");
+
+        StringAssert.Contains(consumer.Content, "public ValueTask StartAsync(string orderId, CancellationToken cancellationToken = default)");
+        StringAssert.Contains(consumer.Content, "written += Encoding.UTF8.GetBytes(orderId, channelUtf8.AsSpan(written));");
+    }
+
+    [TestMethod]
     public void Compile_ConsumerDynamicMultiMessage_GeneratedCodeCompiles()
     {
         byte[] bytes = File.ReadAllBytes(Path.Combine("TestData", "consumer-dynamic-multi.json"));

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/parameterized-consumer-ref.json
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/parameterized-consumer-ref.json
@@ -1,0 +1,43 @@
+{
+  "asyncapi": "3.0.0",
+  "info": {
+    "title": "Parameterized consumer with referenced parameter",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "orders": {
+      "address": "orders.{orderId}.created",
+      "parameters": {
+        "orderId": {
+          "$ref": "#/components/parameters/OrderId"
+        }
+      },
+      "messages": {
+        "OrderCreated": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operations": {
+    "subscribeOrders": {
+      "action": "receive",
+      "channel": { "$ref": "#/channels/orders" },
+      "messages": [
+        { "$ref": "#/channels/orders/messages/OrderCreated" }
+      ]
+    }
+  },
+  "components": {
+    "parameters": {
+      "OrderId": {
+        "description": "The order identifier."
+      }
+    }
+  }
+}


### PR DESCRIPTION
PR #915 implemented generated arguments for templated channel addresses through the common inline-parameter path. However, channel parameters represented with `$ref` were still ignored during code generation.

For example, this worked:

```yaml
channels:
  orders:
    address: orders.{orderId}.created
    parameters:
      orderId:
        description: The order identifier.
```

But this did not generate the `orderId` argument:

```yaml
components:
  parameters:
    OrderId:
      description: The order identifier.

channels:
  orders:
    address: orders.{orderId}.created
    parameters:
      orderId:
        $ref: '#/components/parameters/OrderId'
```

The generator handled the channel reference itself, but did not resolve references for individual entries in `channel.parameters`. As a result, referenced parameters were treated as undefined and the generated consumer used the literal templated address.

This change resolves each channel parameter before extracting its metadata, preserving support for both inline and referenced parameters.

Added regression coverage for the referenced-parameter case while retaining the existing inline-parameter coverage.

All 184 AsyncAPI code-generation tests pass.