### PR TITLE
Fix #924: resolve $ref at every referenceable position in the AsyncAPI generators

### DIFF
--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,17 @@
 # Version History
 
+## V5.3.2
+
+V5.3.2 makes the AsyncAPI generators resolve `$ref` at every referenceable position instead of silently dropping the referenced object, and gives generation a diagnostics channel so nothing the generator skips is ever silent again.
+
+### Bug fixes
+
+- **The AsyncAPI generators resolve `$ref` everywhere the specification allows one** — AsyncAPI 3.0 made nearly every object referenceable, but the generator resolved references at only a few positions and silently discarded the rest. A referenced channel produced a consumer subscribed to the channel *key* rather than its real address; referenced operations and servers vanished from the output; bindings behind references never reached the transport; a chained security scheme reported its type as `unknown`; and a 2.6 parameter expressed as a reference kept its argument name but lost its description, enum, and default. Every site now resolves through the shared reference-resolution chain before matching, with regression coverage for each position including compilation of the generated output. The channel-parameter instance of this class was fixed first by [Levy Barbosa (@Levyks)](https://github.com/Levyks) in [#923](https://github.com/corvus-dotnet/Corvus.JsonSchema/pull/923), with thanks; that fix is included here. See [#924](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/924).
+
+### New features
+
+- **AsyncAPI generation diagnostics and `asyncapi-generate --strict`** — Generation stays deliberately lenient, but anything the generator skips or degrades (for example a `$ref` that does not resolve) is now recorded as a diagnostic carrying its specification location, exposed as a `Diagnostics` property on both generators and via optional parameters on the public inspection helpers. The CLI prints each diagnostic as a warning after generation, and the new `--strict` option fails the run when any were produced. See [#924](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/924).
+
 ## V5.3.1
 
 V5.3.1 closes out the doc-comment emission defects found while reviewing [#916](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/916): the last place specification text reached a generated doc comment unescaped, and the XML doc comments in generated code that had drifted out of step with the signatures they document.

--- a/docs/AsyncApi.md
+++ b/docs/AsyncApi.md
@@ -1296,6 +1296,7 @@ corvusjson asyncapi-generate <specFile> [options]
 | `--exclude-channel` | Glob patterns for channels to exclude | None |
 | `--tag` | Filter by operation tags | All |
 | `--specVersion` | Force spec version (`2.6` or `3.0`); auto-detected if omitted | Auto |
+| `--strict` | Fail the run when generation produces warnings (for example a `$ref` that does not resolve); without it warnings are printed and generation completes | `false` |
 
 Examples:
 

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -675,12 +675,12 @@ main-docs:
       - {index: 58, language: bash, lines: [1257, 1259]}
       - {index: 59, language: csharp, lines: [1261, 1272], category: compilable, verified: false}
       - {index: 60, language: bash, lines: [1282, 1284]}
-      - {index: 61, language: bash, lines: [1302, 1320]}
-      - {index: 62, language: bash, lines: [1324, 1326]}
-      - {index: 63, language: , lines: [1330, 1340]}
-      - {index: 64, language: bash, lines: [1353, 1359]}
-      - {index: 65, language: csharp, lines: [1395, 1400], category: compilable, verified: false}
-      - {index: 66, language: , lines: [1414, 1419]}
+      - {index: 61, language: bash, lines: [1303, 1321]}
+      - {index: 62, language: bash, lines: [1325, 1327]}
+      - {index: 63, language: , lines: [1331, 1341]}
+      - {index: 64, language: bash, lines: [1354, 1360]}
+      - {index: 65, language: csharp, lines: [1396, 1401], category: compilable, verified: false}
+      - {index: 66, language: , lines: [1415, 1420]}
   - path: "docs/AsyncApiMessageResumption.md"
     blocks:
       - {index: 0, language: , lines: [26, 32]}

--- a/src/Corvus.Json.Cli.Core/AsyncApiGenerateCommand.cs
+++ b/src/Corvus.Json.Cli.Core/AsyncApiGenerateCommand.cs
@@ -106,6 +106,8 @@ internal sealed class AsyncApiGenerateCommand : AsyncCommand<AsyncApiGenerateSet
 
         try
         {
+            List<AsyncApiGenerationDiagnostic> generationDiagnostics = [];
+
             // Collect schema pointers from the spec
             string[] pointers;
             if (AsyncApiShowCommand.IsAsyncApi26Version(specVersion))
@@ -114,7 +116,7 @@ internal sealed class AsyncApiGenerateCommand : AsyncCommand<AsyncApiGenerateSet
             }
             else if (AsyncApiShowCommand.IsAsyncApi30Version(specVersion))
             {
-                pointers = AsyncApi30CodeGenerator.CollectSchemaPointers(specRoot, filter, referenceResolver);
+                pointers = AsyncApi30CodeGenerator.CollectSchemaPointers(specRoot, filter, referenceResolver, generationDiagnostics);
             }
             else
             {
@@ -152,6 +154,7 @@ internal sealed class AsyncApiGenerateCommand : AsyncCommand<AsyncApiGenerateSet
                     rootNamespace,
                     schemaTypeMap ?? new Dictionary<string, string>());
                 files = generator.Generate(specRoot, filter, referenceResolver);
+                generationDiagnostics.AddRange(generator.Diagnostics);
             }
             else
             {
@@ -159,6 +162,18 @@ internal sealed class AsyncApiGenerateCommand : AsyncCommand<AsyncApiGenerateSet
                     rootNamespace,
                     schemaTypeMap ?? new Dictionary<string, string>());
                 files = generator.Generate(specRoot, filter, referenceResolver);
+                generationDiagnostics.AddRange(generator.Diagnostics);
+            }
+
+            foreach (AsyncApiGenerationDiagnostic diagnostic in generationDiagnostics)
+            {
+                AnsiConsole.MarkupLineInterpolated($"[yellow]Warning:[/] {diagnostic.Location}: {diagnostic.Message}");
+            }
+
+            if (settings.Strict && generationDiagnostics.Count > 0)
+            {
+                AnsiConsole.MarkupLine($"[red]Generation produced {generationDiagnostics.Count} warning(s) and --strict was specified.[/]");
+                return 1;
             }
 
             // Filter by mode

--- a/src/Corvus.Json.Cli.Core/AsyncApiGenerateSettings.cs
+++ b/src/Corvus.Json.Cli.Core/AsyncApiGenerateSettings.cs
@@ -38,6 +38,10 @@ internal sealed class AsyncApiGenerateSettings : AsyncApiSettings
     [CommandOption("--yaml")]
     [Description("Enable YAML support. When set, the spec file and any external references may be YAML, JSON, or a mixture. Auto-detected from .yaml/.yml extensions if not explicitly set.")]
     public bool? SupportYaml { get; init; }
+
+    [CommandOption("--strict")]
+    [Description("Fail the run when generation produces warnings, such as a $ref that does not resolve. Without this option warnings are printed and generation completes.")]
+    public bool Strict { get; init; }
 }
 
 #endif

--- a/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi26CodeGenerator.cs
+++ b/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi26CodeGenerator.cs
@@ -16,6 +16,7 @@ public sealed class AsyncApi26CodeGenerator
 {
     private readonly AsyncApi30CodeGenerator emitter;
     private readonly IReadOnlyDictionary<string, string> schemaTypeMap;
+    private readonly List<AsyncApiGenerationDiagnostic> diagnostics = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AsyncApi26CodeGenerator"/> class.
@@ -160,11 +161,19 @@ public sealed class AsyncApi26CodeGenerator
         OperationFilter? filter = null,
         IAsyncApiReferenceResolver? referenceResolver = null)
     {
+        this.diagnostics.Clear();
+
         (List<AsyncApi30CodeGenerator.OperationInfo> sendOps, List<AsyncApi30CodeGenerator.OperationInfo> receiveOps) =
             this.CollectOperations(doc, filter, referenceResolver);
 
         return this.emitter.GenerateOperations(sendOps, receiveOps, []);
     }
+
+    /// <summary>
+    /// Gets the problems the most recent <see cref="Generate"/> call encountered and worked
+    /// around, such as references that did not resolve. Empty when generation was clean.
+    /// </summary>
+    public IReadOnlyList<AsyncApiGenerationDiagnostic> Diagnostics => this.diagnostics;
 
     /// <summary>
     /// Describes the document's channel operations with the generated producer/consumer details an Arazzo
@@ -210,7 +219,7 @@ public sealed class AsyncApi26CodeGenerator
             }
 
             List<AsyncApi30CodeGenerator.MessageInfo> messages = this.CollectOperationMessages(operation, doc, referenceResolver);
-            List<AsyncApi30CodeGenerator.ChannelParameter> parameters = CollectChannelParameters(operation.Channel, doc, referenceResolver);
+            List<AsyncApi30CodeGenerator.ChannelParameter> parameters = CollectChannelParameters(operation.Channel, doc, referenceResolver, this.diagnostics, operation.ChannelName);
             AsyncApi30CodeGenerator.ReplyInfo? reply = this.CollectReplyInfo(operation.Operation, doc, referenceResolver);
 
             string? operationBindingsJson = operation.Operation.TryGetProperty("bindings"u8, out JsonElement operationBindings) &&
@@ -475,7 +484,9 @@ public sealed class AsyncApi26CodeGenerator
     private static List<AsyncApi30CodeGenerator.ChannelParameter> CollectChannelParameters(
         JsonElement channel,
         JsonElement doc,
-        IAsyncApiReferenceResolver? resolver)
+        IAsyncApiReferenceResolver? resolver,
+        ICollection<AsyncApiGenerationDiagnostic>? diagnostics = null,
+        string? channelName = null)
     {
         List<AsyncApi30CodeGenerator.ChannelParameter> parameters = [];
         if (!channel.TryGetProperty("parameters"u8, out JsonElement parametersElement) ||
@@ -489,6 +500,16 @@ public sealed class AsyncApi26CodeGenerator
             // A parameter entry may be a Reference Object; resolve it (and a referenced
             // schema) so description, enum, and default survive the indirection.
             JsonElement parameter = ResolveRef(parameterProp.Value, doc, resolver);
+            if (diagnostics is not null &&
+                parameter.TryGetProperty("$ref"u8, out JsonElement unresolvedRef) &&
+                unresolvedRef.ValueKind == JsonValueKind.String)
+            {
+                diagnostics.Add(new(
+                    AsyncApiGenerationDiagnosticSeverity.Warning,
+                    $"#/channels/{channelName}/parameters/{parameterProp.Name}",
+                    "The parameter is a $ref that does not resolve; the argument keeps its name but loses description, enum, and default."));
+            }
+
             string? description = GetString(parameter, "description"u8);
             string? defaultValue = null;
             string[]? enumValues = null;

--- a/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi26CodeGenerator.cs
+++ b/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi26CodeGenerator.cs
@@ -210,7 +210,7 @@ public sealed class AsyncApi26CodeGenerator
             }
 
             List<AsyncApi30CodeGenerator.MessageInfo> messages = this.CollectOperationMessages(operation, doc, referenceResolver);
-            List<AsyncApi30CodeGenerator.ChannelParameter> parameters = CollectChannelParameters(operation.Channel);
+            List<AsyncApi30CodeGenerator.ChannelParameter> parameters = CollectChannelParameters(operation.Channel, doc, referenceResolver);
             AsyncApi30CodeGenerator.ReplyInfo? reply = this.CollectReplyInfo(operation.Operation, doc, referenceResolver);
 
             string? operationBindingsJson = operation.Operation.TryGetProperty("bindings"u8, out JsonElement operationBindings) &&
@@ -472,7 +472,10 @@ public sealed class AsyncApi26CodeGenerator
         }
     }
 
-    private static List<AsyncApi30CodeGenerator.ChannelParameter> CollectChannelParameters(JsonElement channel)
+    private static List<AsyncApi30CodeGenerator.ChannelParameter> CollectChannelParameters(
+        JsonElement channel,
+        JsonElement doc,
+        IAsyncApiReferenceResolver? resolver)
     {
         List<AsyncApi30CodeGenerator.ChannelParameter> parameters = [];
         if (!channel.TryGetProperty("parameters"u8, out JsonElement parametersElement) ||
@@ -483,13 +486,18 @@ public sealed class AsyncApi26CodeGenerator
 
         foreach (var parameterProp in parametersElement.EnumerateObject())
         {
-            JsonElement parameter = parameterProp.Value;
+            // A parameter entry may be a Reference Object; resolve it (and a referenced
+            // schema) so description, enum, and default survive the indirection.
+            JsonElement parameter = ResolveRef(parameterProp.Value, doc, resolver);
             string? description = GetString(parameter, "description"u8);
             string? defaultValue = null;
             string[]? enumValues = null;
 
-            if (parameter.TryGetProperty("schema"u8, out JsonElement schema) &&
-                schema.ValueKind == JsonValueKind.Object)
+            JsonElement schema = parameter.TryGetProperty("schema"u8, out JsonElement schemaRef)
+                ? ResolveRef(schemaRef, doc, resolver)
+                : default;
+
+            if (schema.ValueKind == JsonValueKind.Object)
             {
                 defaultValue = GetString(schema, "default"u8);
                 if (schema.TryGetProperty("enum"u8, out JsonElement enumElement) &&

--- a/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
+++ b/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
@@ -24,6 +24,7 @@ public sealed class AsyncApi30CodeGenerator
 {
     private readonly string rootNamespace;
     private readonly IReadOnlyDictionary<string, string> schemaTypeMap;
+    private readonly List<AsyncApiGenerationDiagnostic> diagnostics = [];
 
     /// <summary>
     /// Initializes a new instance of the <see cref="AsyncApi30CodeGenerator"/> class.
@@ -43,6 +44,12 @@ public sealed class AsyncApi30CodeGenerator
     }
 
     /// <summary>
+    /// Gets the problems the most recent <see cref="Generate"/> call encountered and worked
+    /// around, such as references that did not resolve. Empty when generation was clean.
+    /// </summary>
+    public IReadOnlyList<AsyncApiGenerationDiagnostic> Diagnostics => this.diagnostics;
+
+    /// <summary>
     /// Walks the AsyncAPI 3.0 specification and collects all schema
     /// JSON Pointer strings reachable from the selected operations.
     /// </summary>
@@ -52,11 +59,15 @@ public sealed class AsyncApi30CodeGenerator
     /// Optional external reference resolver. When provided, external <c>$ref</c> pointers
     /// are resolved to absolute paths via <see cref="IAsyncApiReferenceResolver.ResolveToAbsolute(string)"/>.
     /// </param>
+    /// <param name="diagnostics">
+    /// Optional collection receiving a diagnostic for every entry that was skipped or degraded.
+    /// </param>
     /// <returns>An array of schema pointer strings.</returns>
     public static string[] CollectSchemaPointers(
         AsyncApiDocument doc,
         OperationFilter? filter = null,
-        IAsyncApiReferenceResolver? referenceResolver = null)
+        IAsyncApiReferenceResolver? referenceResolver = null,
+        ICollection<AsyncApiGenerationDiagnostic>? diagnostics = null)
     {
         List<string> pointers = [];
 
@@ -72,6 +83,10 @@ public sealed class AsyncApi30CodeGenerator
 
             if (!TryResolveEntry(channelProp.Value, doc, referenceResolver, out JsonElement resolvedChannel))
             {
+                diagnostics?.Add(new(
+                    AsyncApiGenerationDiagnosticSeverity.Warning,
+                    $"#/channels/{channelName}",
+                    "The channel entry is a $ref that does not resolve; its message schemas were skipped."));
                 continue;
             }
 
@@ -136,11 +151,15 @@ public sealed class AsyncApi30CodeGenerator
     /// <param name="referenceResolver">
     /// Optional external reference resolver for <c>$ref</c> values pointing outside the document.
     /// </param>
+    /// <param name="diagnostics">
+    /// Optional collection receiving a diagnostic for every entry that was skipped or degraded.
+    /// </param>
     /// <returns>An array of <see cref="AsyncApiOperationSummary"/> records.</returns>
     public static AsyncApiOperationSummary[] ListOperations(
         AsyncApiDocument doc,
         OperationFilter? filter = null,
-        IAsyncApiReferenceResolver? referenceResolver = null)
+        IAsyncApiReferenceResolver? referenceResolver = null,
+        ICollection<AsyncApiGenerationDiagnostic>? diagnostics = null)
     {
         List<AsyncApiOperationSummary> result = [];
 
@@ -153,6 +172,10 @@ public sealed class AsyncApi30CodeGenerator
         {
             if (!TryResolveEntry(operationProp.Value, doc, referenceResolver, out JsonElement resolvedOperation))
             {
+                diagnostics?.Add(new(
+                    AsyncApiGenerationDiagnosticSeverity.Warning,
+                    $"#/operations/{operationProp.Name}",
+                    "The operation entry is a $ref that does not resolve; the operation was skipped."));
                 continue;
             }
 
@@ -174,7 +197,7 @@ public sealed class AsyncApi30CodeGenerator
                 : OperationAction.Receive;
 
             // Resolve channel reference to get address
-            string channelAddress = ResolveChannelAddress(operation, doc, referenceResolver);
+            string channelAddress = ResolveChannelAddress(operation, doc, referenceResolver, diagnostics);
 
             if (filter?.Matches(channelAddress) == false)
             {
@@ -244,8 +267,11 @@ public sealed class AsyncApi30CodeGenerator
     /// <param name="referenceResolver">
     /// Optional external reference resolver for <c>$ref</c> values pointing outside the document.
     /// </param>
+    /// <param name="diagnostics">
+    /// Optional collection receiving a diagnostic for every entry that was skipped or degraded.
+    /// </param>
     /// <returns>An array of <see cref="ServerInfo"/> records.</returns>
-    public static ServerInfo[] ListServers(AsyncApiDocument doc, IAsyncApiReferenceResolver? referenceResolver = null)
+    public static ServerInfo[] ListServers(AsyncApiDocument doc, IAsyncApiReferenceResolver? referenceResolver = null, ICollection<AsyncApiGenerationDiagnostic>? diagnostics = null)
     {
         List<ServerInfo> result = [];
 
@@ -260,6 +286,10 @@ public sealed class AsyncApi30CodeGenerator
 
             if (!TryResolveEntry(serverProp.Value, doc, referenceResolver, out JsonElement resolvedServer))
             {
+                diagnostics?.Add(new(
+                    AsyncApiGenerationDiagnosticSeverity.Warning,
+                    $"#/servers/{name}",
+                    "The server entry is a $ref that does not resolve; the server was skipped."));
                 continue;
             }
 
@@ -283,6 +313,10 @@ public sealed class AsyncApi30CodeGenerator
 
                     if (!TryResolveEntry(varProp.Value, doc, referenceResolver, out JsonElement resolvedVariable))
                     {
+                        diagnostics?.Add(new(
+                            AsyncApiGenerationDiagnosticSeverity.Warning,
+                            $"#/servers/{name}/variables/{varName}",
+                            "The server variable is a $ref that does not resolve; the variable was skipped."));
                         continue;
                     }
 
@@ -331,7 +365,7 @@ public sealed class AsyncApi30CodeGenerator
 
                     if (schemeName is not null)
                     {
-                        string schemeType = ResolveSecuritySchemeType(doc, schemeName, referenceResolver);
+                        string schemeType = ResolveSecuritySchemeType(doc, schemeName, referenceResolver, diagnostics);
                         securitySchemes.Add(new SecuritySchemeInfo(schemeName, schemeType));
                     }
                 }
@@ -351,12 +385,16 @@ public sealed class AsyncApi30CodeGenerator
     /// <param name="resolver">
     /// Optional external reference resolver for <c>$ref</c> values pointing outside the document.
     /// </param>
+    /// <param name="diagnostics">
+    /// Optional collection receiving a diagnostic for every entry that was skipped or degraded.
+    /// </param>
     /// <returns>A <see cref="ChannelBindingInfo"/> containing the resolved bindings.</returns>
     public static ChannelBindingInfo GetBindings(
         AsyncApiDocument doc,
         string channelName,
         string? messageName = null,
-        IAsyncApiReferenceResolver? resolver = null)
+        IAsyncApiReferenceResolver? resolver = null,
+        ICollection<AsyncApiGenerationDiagnostic>? diagnostics = null)
     {
         AsyncApiDocument.ChannelBindingsObject channelBindings = default;
         AsyncApiDocument.OperationBindingsObject operationBindings = default;
@@ -366,9 +404,18 @@ public sealed class AsyncApi30CodeGenerator
         if (doc.ChannelsValue.IsNotUndefined() &&
             doc.ChannelsValue.TryGetProperty(channelName, out var channelEntity))
         {
-            AsyncApiDocument.Channel channel = TryResolveEntry(channelEntity, doc, resolver, out JsonElement resolvedChannel)
-                ? (AsyncApiDocument.Channel)resolvedChannel
-                : default;
+            AsyncApiDocument.Channel channel = default;
+            if (TryResolveEntry(channelEntity, doc, resolver, out JsonElement resolvedChannel))
+            {
+                channel = resolvedChannel;
+            }
+            else
+            {
+                diagnostics?.Add(new(
+                    AsyncApiGenerationDiagnosticSeverity.Warning,
+                    $"#/channels/{channelName}",
+                    "The channel entry is a $ref that does not resolve; its bindings were skipped."));
+            }
 
             if (channel.IsNotUndefined() && channel.Bindings.IsNotUndefined())
             {
@@ -397,6 +444,10 @@ public sealed class AsyncApi30CodeGenerator
             {
                 if (!TryResolveEntry(opProp.Value, doc, resolver, out JsonElement resolvedOperation))
                 {
+                    diagnostics?.Add(new(
+                        AsyncApiGenerationDiagnosticSeverity.Warning,
+                        $"#/operations/{opProp.Name}",
+                        "The operation entry is a $ref that does not resolve; its bindings were skipped."));
                     continue;
                 }
 
@@ -439,17 +490,28 @@ public sealed class AsyncApi30CodeGenerator
             doc.ChannelsValue.IsNotUndefined() &&
             doc.ChannelsValue.TryGetProperty(channelName, out var chEntityForMsg))
         {
-            AsyncApiDocument.Channel channelForMsg = TryResolveEntry(chEntityForMsg, doc, resolver, out JsonElement resolvedChannelForMsg)
-                ? (AsyncApiDocument.Channel)resolvedChannelForMsg
-                : default;
+            AsyncApiDocument.Channel channelForMsg = default;
+            if (TryResolveEntry(chEntityForMsg, doc, resolver, out JsonElement resolvedChannelForMsg))
+            {
+                channelForMsg = resolvedChannelForMsg;
+            }
 
             if (channelForMsg.IsNotUndefined() && channelForMsg.Messages.IsNotUndefined())
             {
                 if (channelForMsg.Messages.TryGetProperty(messageName, out var msgEntity))
                 {
-                    AsyncApiDocument.MessageObject msg = TryResolveEntry(msgEntity, doc, resolver, out JsonElement resolvedMsg)
-                        ? (AsyncApiDocument.MessageObject)resolvedMsg
-                        : default;
+                    AsyncApiDocument.MessageObject msg = default;
+                    if (TryResolveEntry(msgEntity, doc, resolver, out JsonElement resolvedMsg))
+                    {
+                        msg = resolvedMsg;
+                    }
+                    else
+                    {
+                        diagnostics?.Add(new(
+                            AsyncApiGenerationDiagnosticSeverity.Warning,
+                            $"#/channels/{channelName}/messages/{messageName}",
+                            "The message entry is a $ref that does not resolve; its bindings were skipped."));
+                    }
 
                     if (msg.IsNotUndefined() && msg.Bindings.IsNotUndefined())
                     {
@@ -484,6 +546,8 @@ public sealed class AsyncApi30CodeGenerator
         OperationFilter? filter = null,
         IAsyncApiReferenceResolver? referenceResolver = null)
     {
+        this.diagnostics.Clear();
+
         List<GeneratedFile> files = [];
 
         if (doc.OperationsValue.IsUndefined())
@@ -491,9 +555,9 @@ public sealed class AsyncApi30CodeGenerator
             return files;
         }
 
-        (List<OperationInfo> sendOps, List<OperationInfo> receiveOps) = CollectOperations(doc, filter, referenceResolver);
+        (List<OperationInfo> sendOps, List<OperationInfo> receiveOps) = this.CollectOperations(doc, filter, referenceResolver);
 
-        files.AddRange(this.GenerateOperations(sendOps, receiveOps, ListServers(doc)));
+        files.AddRange(this.GenerateOperations(sendOps, receiveOps, ListServers(doc, referenceResolver, this.diagnostics)));
 
         return files;
     }
@@ -520,6 +584,10 @@ public sealed class AsyncApi30CodeGenerator
         {
             if (!TryResolveEntry(operationProp.Value, doc, referenceResolver, out JsonElement resolvedOperation))
             {
+                this.diagnostics.Add(new(
+                    AsyncApiGenerationDiagnosticSeverity.Warning,
+                    $"#/operations/{operationProp.Name}",
+                    "The operation entry is a $ref that does not resolve; the operation was skipped."));
                 continue;
             }
 
@@ -539,7 +607,7 @@ public sealed class AsyncApi30CodeGenerator
                 ? OperationAction.Send
                 : OperationAction.Receive;
 
-            (string channelAddress, bool isDynamicAddress) = ResolveChannelAddressInfo(operation, doc, referenceResolver);
+            (string channelAddress, bool isDynamicAddress) = ResolveChannelAddressInfo(operation, doc, referenceResolver, this.diagnostics);
 
             if (filter?.Matches(channelAddress) == false)
             {
@@ -548,13 +616,13 @@ public sealed class AsyncApi30CodeGenerator
 
             string operationName = operationProp.Name;
             List<MessageInfo> messages = CollectOperationMessages(operation, doc, referenceResolver);
-            List<ChannelParameter> parameters = CollectChannelParameters(operation, doc, referenceResolver);
+            List<ChannelParameter> parameters = CollectChannelParameters(operation, doc, referenceResolver, this.diagnostics);
             ReplyInfo? reply = CollectReplyInfo(operation, doc, referenceResolver);
 
             // Extract channel name and allowed servers
             string? channelName = ExtractChannelName(operation, doc);
             IReadOnlyList<string>? allowedServers = channelName is not null
-                ? GetChannelAllowedServers(doc, channelName, referenceResolver)
+                ? GetChannelAllowedServers(doc, channelName, referenceResolver, this.diagnostics)
                 : null;
 
             // Collect security schemes from the servers this operation is allowed to use
@@ -829,12 +897,12 @@ public sealed class AsyncApi30CodeGenerator
         return GetChannelAddressInfo(channel, channelName).Address;
     }
 
-    private static string ResolveChannelAddress(JsonElement operation, AsyncApiDocument doc, IAsyncApiReferenceResolver? resolver = null)
+    private static string ResolveChannelAddress(JsonElement operation, AsyncApiDocument doc, IAsyncApiReferenceResolver? resolver = null, ICollection<AsyncApiGenerationDiagnostic>? diagnostics = null)
     {
-        return ResolveChannelAddressInfo(operation, doc, resolver).Address;
+        return ResolveChannelAddressInfo(operation, doc, resolver, diagnostics).Address;
     }
 
-    private static (string Address, bool IsDynamic) ResolveChannelAddressInfo(JsonElement operation, AsyncApiDocument doc, IAsyncApiReferenceResolver? resolver = null)
+    private static (string Address, bool IsDynamic) ResolveChannelAddressInfo(JsonElement operation, AsyncApiDocument doc, IAsyncApiReferenceResolver? resolver = null, ICollection<AsyncApiGenerationDiagnostic>? diagnostics = null)
     {
         // Check operation traits for channel property fallback
         if (!TryGetPropertyWithTraits(operation, "channel"u8, doc, null, out JsonElement channelRef))
@@ -857,9 +925,18 @@ public sealed class AsyncApi30CodeGenerator
             if (channels.IsNotUndefined() &&
                 channels.TryGetProperty(channelName, out AsyncApiDocument.Channels.AdditionalPropertiesEntity channelEntity))
             {
-                AsyncApiDocument.Channel channel = TryResolveEntry(channelEntity, doc, resolver, out JsonElement resolvedChannel)
-                    ? (AsyncApiDocument.Channel)resolvedChannel
-                    : default;
+                AsyncApiDocument.Channel channel = default;
+                if (TryResolveEntry(channelEntity, doc, resolver, out JsonElement resolvedChannel))
+                {
+                    channel = resolvedChannel;
+                }
+                else
+                {
+                    diagnostics?.Add(new(
+                        AsyncApiGenerationDiagnosticSeverity.Warning,
+                        $"#/channels/{channelName}",
+                        "The channel entry is a $ref that does not resolve; the channel key was used as the address."));
+                }
 
                 if (channel.IsNotUndefined())
                 {
@@ -891,7 +968,7 @@ public sealed class AsyncApi30CodeGenerator
         return null;
     }
 
-    private static IReadOnlyList<string>? GetChannelAllowedServers(AsyncApiDocument doc, string channelName, IAsyncApiReferenceResolver? resolver = null)
+    private static IReadOnlyList<string>? GetChannelAllowedServers(AsyncApiDocument doc, string channelName, IAsyncApiReferenceResolver? resolver = null, ICollection<AsyncApiGenerationDiagnostic>? diagnostics = null)
     {
         if (doc.ChannelsValue.IsUndefined())
         {
@@ -903,9 +980,18 @@ public sealed class AsyncApi30CodeGenerator
             return null;
         }
 
-        AsyncApiDocument.Channel channel = TryResolveEntry(channelEntity, doc, resolver, out JsonElement resolvedChannel)
-            ? (AsyncApiDocument.Channel)resolvedChannel
-            : default;
+        AsyncApiDocument.Channel channel = default;
+        if (TryResolveEntry(channelEntity, doc, resolver, out JsonElement resolvedChannel))
+        {
+            channel = resolvedChannel;
+        }
+        else
+        {
+            diagnostics?.Add(new(
+                AsyncApiGenerationDiagnosticSeverity.Warning,
+                $"#/channels/{channelName}",
+                "The channel entry is a $ref that does not resolve; its server restriction was skipped."));
+        }
 
         if (channel.IsUndefined() || channel.Servers.IsUndefined())
         {
@@ -1023,7 +1109,7 @@ public sealed class AsyncApi30CodeGenerator
         return messages;
     }
 
-    private static List<ChannelParameter> CollectChannelParameters(JsonElement operation, AsyncApiDocument doc, IAsyncApiReferenceResolver? resolver = null)
+    private static List<ChannelParameter> CollectChannelParameters(JsonElement operation, AsyncApiDocument doc, IAsyncApiReferenceResolver? resolver = null, ICollection<AsyncApiGenerationDiagnostic>? diagnostics = null)
     {
         List<ChannelParameter> parameters = [];
 
@@ -1032,6 +1118,9 @@ public sealed class AsyncApi30CodeGenerator
         {
             return parameters;
         }
+
+        AsyncApiDocument.Reference channelAsRef = channelRef;
+        string channelLocation = channelAsRef.Ref.IsNotUndefined() ? channelAsRef.Ref.GetString()! : "#/channels/(inline)";
 
         JsonElement channelElement = ResolveRef(channelRef, doc, resolver);
         if (channelElement.ValueKind != JsonValueKind.Object)
@@ -1048,7 +1137,14 @@ public sealed class AsyncApi30CodeGenerator
         foreach (var paramProp in channel.ParametersValue.EnumerateObject())
         {
             string paramName = paramProp.Name;
-            JsonElement resolvedParameter = ResolveRef(paramProp.Value, doc, resolver);
+            if (!TryResolveEntry(paramProp.Value, doc, resolver, out JsonElement resolvedParameter))
+            {
+                diagnostics?.Add(new(
+                    AsyncApiGenerationDiagnosticSeverity.Warning,
+                    $"{channelLocation}/parameters/{paramName}",
+                    "The parameter is a $ref that does not resolve; the argument keeps its name but loses description, enum, and default."));
+            }
+
             AsyncApiDocument.Parameter param = resolvedParameter;
 
             if (param.IsUndefined())
@@ -3137,13 +3233,23 @@ public sealed class AsyncApi30CodeGenerator
         return result;
     }
 
-    private static string ResolveSecuritySchemeType(AsyncApiDocument doc, string schemeName, IAsyncApiReferenceResolver? resolver = null)
+    private static string ResolveSecuritySchemeType(AsyncApiDocument doc, string schemeName, IAsyncApiReferenceResolver? resolver = null, ICollection<AsyncApiGenerationDiagnostic>? diagnostics = null)
     {
         if (doc.ComponentsValue.IsNotUndefined() && doc.ComponentsValue.SecuritySchemes.IsNotUndefined())
         {
             if (doc.ComponentsValue.SecuritySchemes.TryGetProperty(schemeName, out var element) && element.IsNotUndefined())
             {
-                var schemeEntity = AsyncApiDocument.Components.AnObjectToHoldReusableSecuritySchemeObjects.WDEntity.From(ResolveRef(element, doc, resolver));
+                JsonElement resolvedScheme = ResolveRef(element, doc, resolver);
+                AsyncApiDocument.Reference schemeAsRef = resolvedScheme;
+                if (schemeAsRef.Ref.IsNotUndefined())
+                {
+                    diagnostics?.Add(new(
+                        AsyncApiGenerationDiagnosticSeverity.Warning,
+                        $"#/components/securitySchemes/{schemeName}",
+                        "The security scheme is a $ref that does not resolve; its type was reported as 'unknown'."));
+                }
+
+                var schemeEntity = AsyncApiDocument.Components.AnObjectToHoldReusableSecuritySchemeObjects.WDEntity.From(resolvedScheme);
                 return schemeEntity.Match<string>(
                     matchReference: static (in AsyncApiDocument.Reference _) => "unknown",
                     matchSecurityScheme: static (in AsyncApiDocument.SecurityScheme scheme) =>

--- a/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
+++ b/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
@@ -70,10 +70,12 @@ public sealed class AsyncApi30CodeGenerator
         {
             string channelName = channelProp.Name;
 
-            AsyncApiDocument.Channel channel = channelProp.Value.Match(
-                matchReference: static (in AsyncApiDocument.Reference _) => default,
-                matchChannel: static (in AsyncApiDocument.Channel ch) => ch,
-                defaultMatch: static (in AsyncApiDocument.Channels.AdditionalPropertiesEntity _) => default);
+            if (!TryResolveEntry(channelProp.Value, doc, referenceResolver, out JsonElement resolvedChannel))
+            {
+                continue;
+            }
+
+            AsyncApiDocument.Channel channel = resolvedChannel;
 
             if (channel.IsUndefined())
             {
@@ -131,10 +133,14 @@ public sealed class AsyncApi30CodeGenerator
     /// </summary>
     /// <param name="doc">The parsed AsyncAPI document.</param>
     /// <param name="filter">Optional operation filter (filters by channel address).</param>
+    /// <param name="referenceResolver">
+    /// Optional external reference resolver for <c>$ref</c> values pointing outside the document.
+    /// </param>
     /// <returns>An array of <see cref="AsyncApiOperationSummary"/> records.</returns>
     public static AsyncApiOperationSummary[] ListOperations(
         AsyncApiDocument doc,
-        OperationFilter? filter = null)
+        OperationFilter? filter = null,
+        IAsyncApiReferenceResolver? referenceResolver = null)
     {
         List<AsyncApiOperationSummary> result = [];
 
@@ -145,10 +151,12 @@ public sealed class AsyncApi30CodeGenerator
 
         foreach (var operationProp in doc.OperationsValue.EnumerateObject())
         {
-            AsyncApiDocument.Type300Operation operation = operationProp.Value.Match(
-                matchReference: static (in AsyncApiDocument.Reference _) => default,
-                matchType300Operation: static (in AsyncApiDocument.Type300Operation op) => op,
-                defaultMatch: static (in AsyncApiDocument.Operations.AdditionalPropertiesEntity _) => default);
+            if (!TryResolveEntry(operationProp.Value, doc, referenceResolver, out JsonElement resolvedOperation))
+            {
+                continue;
+            }
+
+            AsyncApiDocument.Type300Operation operation = resolvedOperation;
 
             if (operation.IsUndefined())
             {
@@ -166,7 +174,7 @@ public sealed class AsyncApi30CodeGenerator
                 : OperationAction.Receive;
 
             // Resolve channel reference to get address
-            string channelAddress = ResolveChannelAddress(operation, doc);
+            string channelAddress = ResolveChannelAddress(operation, doc, referenceResolver);
 
             if (filter?.Matches(channelAddress) == false)
             {
@@ -233,8 +241,11 @@ public sealed class AsyncApi30CodeGenerator
     /// Lists all servers defined in the AsyncAPI 3.0 specification.
     /// </summary>
     /// <param name="doc">The parsed AsyncAPI document.</param>
+    /// <param name="referenceResolver">
+    /// Optional external reference resolver for <c>$ref</c> values pointing outside the document.
+    /// </param>
     /// <returns>An array of <see cref="ServerInfo"/> records.</returns>
-    public static ServerInfo[] ListServers(AsyncApiDocument doc)
+    public static ServerInfo[] ListServers(AsyncApiDocument doc, IAsyncApiReferenceResolver? referenceResolver = null)
     {
         List<ServerInfo> result = [];
 
@@ -246,10 +257,13 @@ public sealed class AsyncApi30CodeGenerator
         foreach (var serverProp in doc.ServersValue.EnumerateObject())
         {
             string name = serverProp.Name;
-            AsyncApiDocument.Type300Server server = serverProp.Value.Match(
-                matchReference: static (in AsyncApiDocument.Reference _) => default,
-                matchType300Server: static (in AsyncApiDocument.Type300Server s) => s,
-                defaultMatch: static (in AsyncApiDocument.Servers.AdditionalPropertiesEntity _) => default);
+
+            if (!TryResolveEntry(serverProp.Value, doc, referenceResolver, out JsonElement resolvedServer))
+            {
+                continue;
+            }
+
+            AsyncApiDocument.Type300Server server = resolvedServer;
 
             if (server.IsUndefined())
             {
@@ -266,10 +280,13 @@ public sealed class AsyncApi30CodeGenerator
                 foreach (var varProp in server.Variables.EnumerateObject())
                 {
                     string varName = varProp.Name;
-                    AsyncApiDocument.ServerVariable variable = varProp.Value.Match(
-                        matchReference: static (in AsyncApiDocument.Reference _) => default,
-                        matchServerVariable: static (in AsyncApiDocument.ServerVariable v) => v,
-                        defaultMatch: static (in AsyncApiDocument.ServerVariables.AdditionalPropertiesEntity _) => default);
+
+                    if (!TryResolveEntry(varProp.Value, doc, referenceResolver, out JsonElement resolvedVariable))
+                    {
+                        continue;
+                    }
+
+                    AsyncApiDocument.ServerVariable variable = resolvedVariable;
 
                     if (variable.IsUndefined())
                     {
@@ -314,7 +331,7 @@ public sealed class AsyncApi30CodeGenerator
 
                     if (schemeName is not null)
                     {
-                        string schemeType = ResolveSecuritySchemeType(doc, schemeName);
+                        string schemeType = ResolveSecuritySchemeType(doc, schemeName, referenceResolver);
                         securitySchemes.Add(new SecuritySchemeInfo(schemeName, schemeType));
                     }
                 }
@@ -349,10 +366,9 @@ public sealed class AsyncApi30CodeGenerator
         if (doc.ChannelsValue.IsNotUndefined() &&
             doc.ChannelsValue.TryGetProperty(channelName, out var channelEntity))
         {
-            AsyncApiDocument.Channel channel = channelEntity.Match(
-                matchReference: static (in AsyncApiDocument.Reference _) => default,
-                matchChannel: static (in AsyncApiDocument.Channel ch) => ch,
-                defaultMatch: static (in AsyncApiDocument.Channels.AdditionalPropertiesEntity _) => default);
+            AsyncApiDocument.Channel channel = TryResolveEntry(channelEntity, doc, resolver, out JsonElement resolvedChannel)
+                ? (AsyncApiDocument.Channel)resolvedChannel
+                : default;
 
             if (channel.IsNotUndefined() && channel.Bindings.IsNotUndefined())
             {
@@ -379,10 +395,12 @@ public sealed class AsyncApi30CodeGenerator
             string channelRef = $"#/channels/{channelName}";
             foreach (var opProp in doc.OperationsValue.EnumerateObject())
             {
-                AsyncApiDocument.Type300Operation operation = opProp.Value.Match(
-                    matchReference: static (in AsyncApiDocument.Reference _) => default,
-                    matchType300Operation: static (in AsyncApiDocument.Type300Operation op) => op,
-                    defaultMatch: static (in AsyncApiDocument.Operations.AdditionalPropertiesEntity _) => default);
+                if (!TryResolveEntry(opProp.Value, doc, resolver, out JsonElement resolvedOperation))
+                {
+                    continue;
+                }
+
+                AsyncApiDocument.Type300Operation operation = resolvedOperation;
 
                 if (operation.IsUndefined())
                 {
@@ -421,26 +439,21 @@ public sealed class AsyncApi30CodeGenerator
             doc.ChannelsValue.IsNotUndefined() &&
             doc.ChannelsValue.TryGetProperty(channelName, out var chEntityForMsg))
         {
-            AsyncApiDocument.Channel channelForMsg = chEntityForMsg.Match(
-                matchReference: static (in AsyncApiDocument.Reference _) => default,
-                matchChannel: static (in AsyncApiDocument.Channel ch) => ch,
-                defaultMatch: static (in AsyncApiDocument.Channels.AdditionalPropertiesEntity _) => default);
+            AsyncApiDocument.Channel channelForMsg = TryResolveEntry(chEntityForMsg, doc, resolver, out JsonElement resolvedChannelForMsg)
+                ? (AsyncApiDocument.Channel)resolvedChannelForMsg
+                : default;
 
             if (channelForMsg.IsNotUndefined() && channelForMsg.Messages.IsNotUndefined())
             {
                 if (channelForMsg.Messages.TryGetProperty(messageName, out var msgEntity))
                 {
-                    AsyncApiDocument.MessageObject msg = msgEntity.Match(
-                        matchReference: static (in AsyncApiDocument.Reference _) => default,
-                        matchMessageObject: static (in AsyncApiDocument.MessageObject m) => m,
-                        defaultMatch: static (in AsyncApiDocument.ChannelMessages.AdditionalPropertiesEntity _) => default);
+                    AsyncApiDocument.MessageObject msg = TryResolveEntry(msgEntity, doc, resolver, out JsonElement resolvedMsg)
+                        ? (AsyncApiDocument.MessageObject)resolvedMsg
+                        : default;
 
                     if (msg.IsNotUndefined() && msg.Bindings.IsNotUndefined())
                     {
-                        messageBindings = msg.Bindings.Match(
-                            matchReference: static (in AsyncApiDocument.Reference _) => default,
-                            matchMessageBindingsObject: static (in AsyncApiDocument.MessageBindingsObject b) => b,
-                            defaultMatch: static (in AsyncApiDocument.MessageObject.BindingsEntity _) => default);
+                        messageBindings = AsyncApiDocument.MessageBindingsObject.From(ResolveRef(msg.Bindings, doc, resolver));
                     }
                 }
             }
@@ -505,10 +518,12 @@ public sealed class AsyncApi30CodeGenerator
 
         foreach (var operationProp in doc.OperationsValue.EnumerateObject())
         {
-            AsyncApiDocument.Type300Operation operation = operationProp.Value.Match(
-                matchReference: static (in AsyncApiDocument.Reference _) => default,
-                matchType300Operation: static (in AsyncApiDocument.Type300Operation op) => op,
-                defaultMatch: static (in AsyncApiDocument.Operations.AdditionalPropertiesEntity _) => default);
+            if (!TryResolveEntry(operationProp.Value, doc, referenceResolver, out JsonElement resolvedOperation))
+            {
+                continue;
+            }
+
+            AsyncApiDocument.Type300Operation operation = resolvedOperation;
 
             if (operation.IsUndefined())
             {
@@ -524,7 +539,7 @@ public sealed class AsyncApi30CodeGenerator
                 ? OperationAction.Send
                 : OperationAction.Receive;
 
-            (string channelAddress, bool isDynamicAddress) = ResolveChannelAddressInfo(operation, doc);
+            (string channelAddress, bool isDynamicAddress) = ResolveChannelAddressInfo(operation, doc, referenceResolver);
 
             if (filter?.Matches(channelAddress) == false)
             {
@@ -539,7 +554,7 @@ public sealed class AsyncApi30CodeGenerator
             // Extract channel name and allowed servers
             string? channelName = ExtractChannelName(operation, doc);
             IReadOnlyList<string>? allowedServers = channelName is not null
-                ? GetChannelAllowedServers(doc, channelName)
+                ? GetChannelAllowedServers(doc, channelName, referenceResolver)
                 : null;
 
             // Collect security schemes from the servers this operation is allowed to use
@@ -762,7 +777,10 @@ public sealed class AsyncApi30CodeGenerator
         {
             foreach (var msgProp in channel.Messages.EnumerateObject())
             {
-                // Match discriminates references (collected separately) from inline messages
+                // Match deliberately leaves references alone here: a channel message that is a
+                // $ref into components.messages gets its schema pointers from the separate
+                // components.Messages pass in CollectSchemaPointers, so resolving it here
+                // would collect the same payload twice.
                 AsyncApiDocument.MessageObject msg = msgProp.Value.Match(
                     matchReference: static (in AsyncApiDocument.Reference _) => default,
                     matchMessageObject: static (in AsyncApiDocument.MessageObject m) => m,
@@ -811,12 +829,12 @@ public sealed class AsyncApi30CodeGenerator
         return GetChannelAddressInfo(channel, channelName).Address;
     }
 
-    private static string ResolveChannelAddress(JsonElement operation, AsyncApiDocument doc)
+    private static string ResolveChannelAddress(JsonElement operation, AsyncApiDocument doc, IAsyncApiReferenceResolver? resolver = null)
     {
-        return ResolveChannelAddressInfo(operation, doc).Address;
+        return ResolveChannelAddressInfo(operation, doc, resolver).Address;
     }
 
-    private static (string Address, bool IsDynamic) ResolveChannelAddressInfo(JsonElement operation, AsyncApiDocument doc)
+    private static (string Address, bool IsDynamic) ResolveChannelAddressInfo(JsonElement operation, AsyncApiDocument doc, IAsyncApiReferenceResolver? resolver = null)
     {
         // Check operation traits for channel property fallback
         if (!TryGetPropertyWithTraits(operation, "channel"u8, doc, null, out JsonElement channelRef))
@@ -839,10 +857,9 @@ public sealed class AsyncApi30CodeGenerator
             if (channels.IsNotUndefined() &&
                 channels.TryGetProperty(channelName, out AsyncApiDocument.Channels.AdditionalPropertiesEntity channelEntity))
             {
-                AsyncApiDocument.Channel channel = channelEntity.Match(
-                    matchReference: static (in AsyncApiDocument.Reference _) => default,
-                    matchChannel: static (in AsyncApiDocument.Channel ch) => ch,
-                    defaultMatch: static (in AsyncApiDocument.Channels.AdditionalPropertiesEntity _) => default);
+                AsyncApiDocument.Channel channel = TryResolveEntry(channelEntity, doc, resolver, out JsonElement resolvedChannel)
+                    ? (AsyncApiDocument.Channel)resolvedChannel
+                    : default;
 
                 if (channel.IsNotUndefined())
                 {
@@ -874,7 +891,7 @@ public sealed class AsyncApi30CodeGenerator
         return null;
     }
 
-    private static IReadOnlyList<string>? GetChannelAllowedServers(AsyncApiDocument doc, string channelName)
+    private static IReadOnlyList<string>? GetChannelAllowedServers(AsyncApiDocument doc, string channelName, IAsyncApiReferenceResolver? resolver = null)
     {
         if (doc.ChannelsValue.IsUndefined())
         {
@@ -886,10 +903,9 @@ public sealed class AsyncApi30CodeGenerator
             return null;
         }
 
-        AsyncApiDocument.Channel channel = channelEntity.Match(
-            matchReference: static (in AsyncApiDocument.Reference _) => default,
-            matchChannel: static (in AsyncApiDocument.Channel ch) => ch,
-            defaultMatch: static (in AsyncApiDocument.Channels.AdditionalPropertiesEntity _) => default);
+        AsyncApiDocument.Channel channel = TryResolveEntry(channelEntity, doc, resolver, out JsonElement resolvedChannel)
+            ? (AsyncApiDocument.Channel)resolvedChannel
+            : default;
 
         if (channel.IsUndefined() || channel.Servers.IsUndefined())
         {
@@ -1313,6 +1329,21 @@ public sealed class AsyncApi30CodeGenerator
     private static JsonElement ResolveRef(JsonElement element, AsyncApiDocument doc, IAsyncApiReferenceResolver? resolver = null)
     {
         return ResolveRef(element, doc, resolver, out _);
+    }
+
+    // Resolves a map entry that may be a Reference Object (in AsyncAPI 3.0 nearly every
+    // object is referenceable). Returns false when the element is a reference that cannot
+    // be resolved (dangling, or external with no resolver), so the caller can skip it the
+    // same way it skips a malformed entry.
+    private static bool TryResolveEntry(
+        JsonElement element,
+        AsyncApiDocument doc,
+        IAsyncApiReferenceResolver? resolver,
+        out JsonElement resolved)
+    {
+        resolved = ResolveRef(element, doc, resolver);
+        AsyncApiDocument.Reference asRef = resolved;
+        return !asRef.Ref.IsNotUndefined();
     }
 
     // Extracts a message's AsyncAPI Correlation ID as (name, location). The message's `correlationId` is
@@ -3106,13 +3137,13 @@ public sealed class AsyncApi30CodeGenerator
         return result;
     }
 
-    private static string ResolveSecuritySchemeType(AsyncApiDocument doc, string schemeName)
+    private static string ResolveSecuritySchemeType(AsyncApiDocument doc, string schemeName, IAsyncApiReferenceResolver? resolver = null)
     {
         if (doc.ComponentsValue.IsNotUndefined() && doc.ComponentsValue.SecuritySchemes.IsNotUndefined())
         {
             if (doc.ComponentsValue.SecuritySchemes.TryGetProperty(schemeName, out var element) && element.IsNotUndefined())
             {
-                var schemeEntity = AsyncApiDocument.Components.AnObjectToHoldReusableSecuritySchemeObjects.WDEntity.From(element);
+                var schemeEntity = AsyncApiDocument.Components.AnObjectToHoldReusableSecuritySchemeObjects.WDEntity.From(ResolveRef(element, doc, resolver));
                 return schemeEntity.Match<string>(
                     matchReference: static (in AsyncApiDocument.Reference _) => "unknown",
                     matchSecurityScheme: static (in AsyncApiDocument.SecurityScheme scheme) =>

--- a/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
+++ b/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
@@ -1032,10 +1032,8 @@ public sealed class AsyncApi30CodeGenerator
         foreach (var paramProp in channel.ParametersValue.EnumerateObject())
         {
             string paramName = paramProp.Name;
-            AsyncApiDocument.Parameter param = paramProp.Value.Match(
-                matchReference: static (in AsyncApiDocument.Reference _) => default,
-                matchParameter: static (in AsyncApiDocument.Parameter p) => p,
-                defaultMatch: static (in AsyncApiDocument.Parameters.AdditionalPropertiesEntity _) => default);
+            JsonElement resolvedParameter = ResolveRef(paramProp.Value, doc, resolver);
+            AsyncApiDocument.Parameter param = resolvedParameter;
 
             if (param.IsUndefined())
             {

--- a/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApiGenerationDiagnostic.cs
+++ b/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApiGenerationDiagnostic.cs
@@ -1,0 +1,33 @@
+// <copyright file="AsyncApiGenerationDiagnostic.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Text.Json.AsyncApi.CodeGeneration;
+
+/// <summary>
+/// A problem the generator encountered and worked around while walking the specification.
+/// </summary>
+/// <remarks>
+/// Generation is deliberately lenient: an entry the generator cannot use (for example a
+/// <c>$ref</c> that does not resolve) is skipped rather than failing the run, and the skip
+/// is recorded as a diagnostic so it is never silent. Callers decide whether diagnostics
+/// are fatal; the CLI prints them as warnings and fails the run under <c>--strict</c>.
+/// </remarks>
+/// <param name="Severity">The severity of the diagnostic.</param>
+/// <param name="Location">The specification location, as a JSON-pointer-style path (e.g. <c>#/channels/orders</c>).</param>
+/// <param name="Message">The human-readable description of the problem and what the generator did about it.</param>
+public readonly record struct AsyncApiGenerationDiagnostic(
+    AsyncApiGenerationDiagnosticSeverity Severity,
+    string Location,
+    string Message);
+
+/// <summary>
+/// The severity of an <see cref="AsyncApiGenerationDiagnostic"/>.
+/// </summary>
+public enum AsyncApiGenerationDiagnosticSeverity
+{
+    /// <summary>
+    /// The generator skipped or degraded something; the output omits the affected member.
+    /// </summary>
+    Warning,
+}

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/AsyncApi26CodeGeneratorTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/AsyncApi26CodeGeneratorTests.cs
@@ -154,6 +154,28 @@ public class AsyncApi26CodeGeneratorTests
         Assert.AreEqual("Streetlights.LightMeasuredPayload", receive.Messages.Single().PayloadTypeName);
     }
 
+    [TestMethod]
+    public void Generate_ParameterizedConsumer_WithReferencedParameter_CarriesParameterMetadata()
+    {
+        byte[] bytes = File.ReadAllBytes(Path.Combine("TestData", "parameterized-consumer-ref-2.6.json"));
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(bytes);
+
+        var generator = new AsyncApi26CodeGenerator("ParameterizedRef26", new Dictionary<string, string>());
+        IReadOnlyList<GeneratedFile> files = generator.Generate(doc.RootElement);
+
+        GeneratedFile? consumer = files.FirstOrDefault(f => f.FileName.Contains("OnOrderCreatedConsumer"));
+        Assert.IsNotNull(consumer, "The publish operation should generate a consumer class");
+
+        StringAssert.Contains(
+            consumer.Content,
+            "The order identifier.",
+            "The referenced parameter's description should reach the generated doc comment");
+        StringAssert.Contains(
+            consumer.Content,
+            "orderId = \"standard\"",
+            "The referenced parameter's schema default should become the argument default");
+    }
+
     private static Dictionary<string, string> CreateRequestReplySchemaTypeMap()
     {
         return new()

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/AsyncApi30CodeGeneratorTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/AsyncApi30CodeGeneratorTests.cs
@@ -2297,6 +2297,22 @@ public class AsyncApi30CodeGeneratorTests
     }
 
     [TestMethod]
+    public void Generate_ParameterizedConsumer_WithReferencedParameter_ComposesTheAddress()
+    {
+        byte[] bytes = File.ReadAllBytes(Path.Combine("TestData", "parameterized-consumer-ref.json"));
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(bytes);
+
+        var generator = new AsyncApi30CodeGenerator("ParameterizedRef", new Dictionary<string, string>());
+        IReadOnlyList<GeneratedFile> files = generator.Generate(doc.RootElement);
+
+        GeneratedFile? consumer = files.FirstOrDefault(f => f.FileName.Contains("SubscribeOrdersConsumer"));
+        Assert.IsNotNull(consumer, "A receive operation should generate a Consumer class");
+
+        StringAssert.Contains(consumer.Content, "public ValueTask StartAsync(string orderId, CancellationToken cancellationToken = default)");
+        StringAssert.Contains(consumer.Content, "written += Encoding.UTF8.GetBytes(orderId, channelUtf8.AsSpan(written));");
+    }
+
+    [TestMethod]
     public void Compile_ConsumerDynamicMultiMessage_GeneratedCodeCompiles()
     {
         byte[] bytes = File.ReadAllBytes(Path.Combine("TestData", "consumer-dynamic-multi.json"));

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/ReferencedComponentsTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/ReferencedComponentsTests.cs
@@ -1,0 +1,158 @@
+// <copyright file="ReferencedComponentsTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using Corvus.Text.Json;
+using Corvus.Text.Json.AsyncApi.CodeGeneration;
+
+namespace Corvus.Text.Json.AsyncApi.CodeGeneration.Tests;
+
+/// <summary>
+/// Verifies that the AsyncAPI 3.0 generator resolves <c>$ref</c> at every referenceable
+/// position rather than silently dropping the referenced object: top-level channels,
+/// operations, and servers, server variables, channel parameters, bindings at every
+/// level, and security schemes. Guards the defect class of issue #924.
+/// </summary>
+[TestClass]
+public class ReferencedComponentsTests
+{
+    private static JsonElement root;
+
+    [ClassInitialize]
+    public static void ClassInit(TestContext _)
+    {
+        byte[] bytes = File.ReadAllBytes(Path.Combine("TestData", "referenced-components-3.0.json"));
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(bytes);
+        root = doc.RootElement.Clone();
+    }
+
+    [TestMethod]
+    public void ListServers_ReferencedServer_IsListed()
+    {
+        ServerInfo[] servers = AsyncApi30CodeGenerator.ListServers(root);
+
+        Assert.AreEqual(1, servers.Length, "The referenced server should be listed");
+        Assert.AreEqual("production", servers[0].Name);
+        Assert.AreEqual("broker.example.com", servers[0].Host);
+        Assert.AreEqual("kafka", servers[0].Protocol);
+    }
+
+    [TestMethod]
+    public void ListServers_ReferencedServerVariable_IsListed()
+    {
+        ServerInfo[] servers = AsyncApi30CodeGenerator.ListServers(root);
+
+        Assert.AreEqual(1, servers.Length, "The referenced server should be listed");
+        Assert.AreEqual(1, servers[0].Variables.Count, "The referenced server variable should be listed");
+        Assert.AreEqual("region", servers[0].Variables[0].Name);
+        Assert.AreEqual("eu-west-1", servers[0].Variables[0].DefaultValue);
+    }
+
+    [TestMethod]
+    public void ListServers_ChainedSecuritySchemeReference_ResolvesType()
+    {
+        ServerInfo[] servers = AsyncApi30CodeGenerator.ListServers(root);
+
+        Assert.AreEqual(1, servers.Length, "The referenced server should be listed");
+        Assert.AreEqual(1, servers[0].SecuritySchemes.Count, "The server security scheme should be listed");
+        Assert.AreEqual("sasl", servers[0].SecuritySchemes[0].Type, "The chained scheme reference should resolve to the concrete scheme type");
+    }
+
+    [TestMethod]
+    public void ListOperations_ReferencedOperation_IsListed()
+    {
+        AsyncApiOperationSummary[] ops = AsyncApi30CodeGenerator.ListOperations(root);
+
+        Assert.AreEqual(1, ops.Length, "The referenced operation should be listed");
+        Assert.AreEqual("subscribeOrders", ops[0].OperationId);
+        Assert.AreEqual("orders.{orderId}.created", ops[0].ChannelAddress, "The address should come from the referenced channel, not the channel key");
+    }
+
+    [TestMethod]
+    public void CollectSchemaPointers_InlineMessageInReferencedChannel_IsCollected()
+    {
+        string[] pointers = AsyncApi30CodeGenerator.CollectSchemaPointers(root);
+
+        Assert.IsTrue(
+            pointers.Any(p => p.Contains("OrderShipped", StringComparison.Ordinal)),
+            $"The inline message in the referenced channel should contribute a schema pointer. Got: {string.Join(", ", pointers)}");
+    }
+
+    [TestMethod]
+    public void GetBindings_ReferencedChannel_ResolvesChannelBindings()
+    {
+        ChannelBindingInfo bindings = AsyncApi30CodeGenerator.GetBindings(root, "orders");
+
+        Assert.IsTrue(
+            bindings.ChannelBindings.IsNotUndefined(),
+            "Channel bindings declared on the referenced channel should resolve");
+        Assert.IsTrue(bindings.ChannelBindings.Kafka.IsNotUndefined(), "The kafka channel binding should be present");
+    }
+
+    [TestMethod]
+    public void GetBindings_ReferencedOperation_ResolvesOperationBindings()
+    {
+        ChannelBindingInfo bindings = AsyncApi30CodeGenerator.GetBindings(root, "orders");
+
+        Assert.IsTrue(
+            bindings.OperationBindings.IsNotUndefined(),
+            "Operation bindings declared on the referenced operation should resolve");
+        Assert.IsTrue(bindings.OperationBindings.Kafka.IsNotUndefined(), "The kafka operation binding should be present");
+    }
+
+    [TestMethod]
+    public void GetBindings_ReferencedMessage_ResolvesMessageBindings()
+    {
+        ChannelBindingInfo bindings = AsyncApi30CodeGenerator.GetBindings(root, "orders", "OrderCreated");
+
+        Assert.IsTrue(
+            bindings.MessageBindings.IsNotUndefined(),
+            "Message bindings declared behind the referenced message (and themselves a reference) should resolve");
+        Assert.IsTrue(bindings.MessageBindings.Kafka.IsNotUndefined(), "The kafka message binding should be present");
+    }
+
+    [TestMethod]
+    public void Generate_ReferencedChannel_ComposesTheRealAddress()
+    {
+        var generator = new AsyncApi30CodeGenerator("ReferencedComponents", new Dictionary<string, string>());
+        IReadOnlyList<GeneratedFile> files = generator.Generate(root);
+
+        GeneratedFile? consumer = files.FirstOrDefault(f => f.FileName.Contains("SubscribeOrdersConsumer"));
+        Assert.IsNotNull(consumer, "The referenced receive operation should generate a consumer");
+
+        StringAssert.Contains(
+            consumer.Content,
+            "public ValueTask StartAsync(string orderId, CancellationToken cancellationToken = default)",
+            "The referenced parameter behind the referenced channel should become a StartAsync argument");
+        StringAssert.Contains(
+            consumer.Content,
+            "orders.",
+            "The composed address should come from the referenced channel's template, not the channel key");
+    }
+
+    [TestMethod]
+    public void Generate_ReferencedChannel_EmitsAllowedServers()
+    {
+        var generator = new AsyncApi30CodeGenerator("ReferencedComponents", new Dictionary<string, string>());
+        IReadOnlyList<GeneratedFile> files = generator.Generate(root);
+
+        GeneratedFile? consumer = files.FirstOrDefault(f => f.FileName.Contains("SubscribeOrdersConsumer"));
+        Assert.IsNotNull(consumer, "The referenced receive operation should generate a consumer");
+
+        StringAssert.Contains(
+            consumer.Content,
+            "AllowedServers",
+            "The referenced channel's server restriction should reach the generated consumer");
+        StringAssert.Contains(consumer.Content, "\"production\"");
+    }
+
+    [TestMethod]
+    public void Generate_ReferencedEverything_Compiles()
+    {
+        var generator = new AsyncApi30CodeGenerator("ReferencedComponents", new Dictionary<string, string>());
+        IReadOnlyList<GeneratedFile> files = generator.Generate(root);
+
+        Assert.IsTrue(files.Count > 0, "Generation should produce files");
+        DynamicCompiler.AssertCompiles(files, "ReferencedComponents.Generated");
+    }
+}

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/ReferencedComponentsTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/ReferencedComponentsTests.cs
@@ -147,6 +147,32 @@ public class ReferencedComponentsTests
     }
 
     [TestMethod]
+    public void Generate_DanglingReference_RecordsDiagnosticAndCompletes()
+    {
+        byte[] bytes = File.ReadAllBytes(Path.Combine("TestData", "dangling-ref-3.0.json"));
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(bytes);
+
+        var generator = new AsyncApi30CodeGenerator("DanglingRef", new Dictionary<string, string>());
+        IReadOnlyList<GeneratedFile> files = generator.Generate(doc.RootElement);
+
+        Assert.IsTrue(
+            files.Any(f => f.FileName.Contains("SubscribeOrdersConsumer")),
+            "The intact operation should still generate");
+        Assert.AreEqual(1, generator.Diagnostics.Count, "The dangling operation reference should record exactly one diagnostic");
+        Assert.AreEqual("#/operations/brokenOp", generator.Diagnostics[0].Location);
+        Assert.AreEqual(AsyncApiGenerationDiagnosticSeverity.Warning, generator.Diagnostics[0].Severity);
+    }
+
+    [TestMethod]
+    public void Generate_CleanSpec_RecordsNoDiagnostics()
+    {
+        var generator = new AsyncApi30CodeGenerator("ReferencedComponents", new Dictionary<string, string>());
+        generator.Generate(root);
+
+        Assert.AreEqual(0, generator.Diagnostics.Count, "A fully resolvable spec should generate without diagnostics");
+    }
+
+    [TestMethod]
     public void Generate_ReferencedEverything_Compiles()
     {
         var generator = new AsyncApi30CodeGenerator("ReferencedComponents", new Dictionary<string, string>());

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/dangling-ref-3.0.json
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/dangling-ref-3.0.json
@@ -1,0 +1,32 @@
+{
+  "asyncapi": "3.0.0",
+  "info": {
+    "title": "Dangling reference",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "orders": {
+      "address": "orders.created",
+      "messages": {
+        "OrderCreated": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operations": {
+    "subscribeOrders": {
+      "action": "receive",
+      "channel": { "$ref": "#/channels/orders" },
+      "messages": [
+        { "$ref": "#/channels/orders/messages/OrderCreated" }
+      ]
+    },
+    "brokenOp": { "$ref": "#/components/operations/Missing" }
+  }
+}

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/parameterized-consumer-ref-2.6.json
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/parameterized-consumer-ref-2.6.json
@@ -1,0 +1,37 @@
+{
+  "asyncapi": "2.6.0",
+  "info": {
+    "title": "Parameterized consumer with referenced parameter (2.6)",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "orders/{orderId}/created": {
+      "parameters": {
+        "orderId": { "$ref": "#/components/parameters/OrderId" }
+      },
+      "publish": {
+        "operationId": "onOrderCreated",
+        "message": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "parameters": {
+      "OrderId": {
+        "description": "The order identifier.",
+        "schema": {
+          "type": "string",
+          "enum": ["standard", "priority"],
+          "default": "standard"
+        }
+      }
+    }
+  }
+}

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/parameterized-consumer-ref.json
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/parameterized-consumer-ref.json
@@ -1,0 +1,43 @@
+{
+  "asyncapi": "3.0.0",
+  "info": {
+    "title": "Parameterized consumer with referenced parameter",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "orders": {
+      "address": "orders.{orderId}.created",
+      "parameters": {
+        "orderId": {
+          "$ref": "#/components/parameters/OrderId"
+        }
+      },
+      "messages": {
+        "OrderCreated": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operations": {
+    "subscribeOrders": {
+      "action": "receive",
+      "channel": { "$ref": "#/channels/orders" },
+      "messages": [
+        { "$ref": "#/channels/orders/messages/OrderCreated" }
+      ]
+    }
+  },
+  "components": {
+    "parameters": {
+      "OrderId": {
+        "description": "The order identifier."
+      }
+    }
+  }
+}

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/referenced-components-3.0.json
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/TestData/referenced-components-3.0.json
@@ -1,0 +1,114 @@
+{
+  "asyncapi": "3.0.0",
+  "info": {
+    "title": "Referenced components coverage",
+    "version": "1.0.0"
+  },
+  "servers": {
+    "production": { "$ref": "#/components/servers/Production" }
+  },
+  "channels": {
+    "orders": { "$ref": "#/components/channels/Orders" }
+  },
+  "operations": {
+    "subscribeOrders": { "$ref": "#/components/operations/SubscribeOrders" }
+  },
+  "components": {
+    "servers": {
+      "Production": {
+        "host": "broker.example.com",
+        "protocol": "kafka",
+        "variables": {
+          "region": { "$ref": "#/components/serverVariables/Region" }
+        },
+        "security": [
+          { "$ref": "#/components/securitySchemes/Sasl" }
+        ]
+      }
+    },
+    "serverVariables": {
+      "Region": {
+        "default": "eu-west-1",
+        "enum": ["eu-west-1", "us-east-1"],
+        "description": "Deployment region."
+      }
+    },
+    "securitySchemes": {
+      "Sasl": { "$ref": "#/components/securitySchemes/ScramSha256" },
+      "ScramSha256": {
+        "type": "scramSha256",
+        "description": "SASL SCRAM authentication."
+      }
+    },
+    "channels": {
+      "Orders": {
+        "address": "orders.{orderId}.created",
+        "servers": [
+          { "$ref": "#/servers/production" }
+        ],
+        "parameters": {
+          "orderId": { "$ref": "#/components/parameters/OrderId" }
+        },
+        "messages": {
+          "OrderCreated": { "$ref": "#/components/messages/OrderCreated" },
+          "OrderShipped": {
+            "payload": {
+              "type": "object",
+              "properties": {
+                "shippedAt": { "type": "string" }
+              }
+            }
+          }
+        },
+        "bindings": { "$ref": "#/components/channelBindings/OrdersChannel" }
+      }
+    },
+    "messages": {
+      "OrderCreated": {
+        "payload": {
+          "type": "object",
+          "properties": {
+            "id": { "type": "string" }
+          }
+        },
+        "bindings": { "$ref": "#/components/messageBindings/OrderCreatedMessage" }
+      }
+    },
+    "parameters": {
+      "OrderId": {
+        "description": "The order identifier."
+      }
+    },
+    "channelBindings": {
+      "OrdersChannel": {
+        "kafka": { "bindingVersion": "0.5.0" }
+      }
+    },
+    "operationBindings": {
+      "SubscribeOrdersOperation": {
+        "kafka": {
+          "groupId": { "type": "string", "enum": ["orders-group"] },
+          "bindingVersion": "0.5.0"
+        }
+      }
+    },
+    "messageBindings": {
+      "OrderCreatedMessage": {
+        "kafka": {
+          "key": { "type": "string" },
+          "bindingVersion": "0.5.0"
+        }
+      }
+    },
+    "operations": {
+      "SubscribeOrders": {
+        "action": "receive",
+        "channel": { "$ref": "#/channels/orders" },
+        "messages": [
+          { "$ref": "#/channels/orders/messages/OrderCreated" }
+        ],
+        "bindings": { "$ref": "#/components/operationBindings/SubscribeOrdersOperation" }
+      }
+    }
+  }
+}

--- a/tests/Corvus.Text.Json.CodeGenerator.Tests/AsyncApiDiagnosticsTests.cs
+++ b/tests/Corvus.Text.Json.CodeGenerator.Tests/AsyncApiDiagnosticsTests.cs
@@ -1,0 +1,54 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.CodeGenerator.Tests;
+
+/// <summary>
+/// Verifies the asyncapi-generate diagnostics surface: a reference the generator cannot
+/// resolve is reported as a warning, generation still completes, and <c>--strict</c>
+/// turns the warnings into a failed run.
+/// </summary>
+[TestClass]
+public class AsyncApiDiagnosticsTests
+{
+    private string _outputDir;
+
+    [TestInitialize]
+    public void Initialize()
+    {
+        _outputDir = CodeGeneratorRunner.CreateTempOutputDirectory();
+    }
+
+    [TestCleanup]
+    public void Cleanup()
+    {
+        CodeGeneratorRunner.CleanupTempDirectory(_outputDir);
+    }
+
+    [TestMethod]
+    public async Task AsyncApiGenerate_DanglingReference_WarnsAndSucceeds()
+    {
+        string spec = CodeGeneratorRunner.GetFixturePath("Specs", "dangling-ref-3.0.json");
+
+        ProcessResult result = await CodeGeneratorRunner.RunAsync(
+            $"asyncapi-generate \"{spec}\" --rootNamespace TestGenerated --outputPath \"{_outputDir}\" --force");
+
+        Assert.AreEqual(0, result.ExitCode, $"Generation should succeed without --strict. Stdout: {result.StandardOutput} Stderr: {result.StandardError}");
+        StringAssert.Contains(result.StandardOutput, "Warning:", "The dangling reference should be reported");
+        StringAssert.Contains(result.StandardOutput, "#/operations/brokenOp", "The warning should carry the specification location");
+        Assert.IsTrue(
+            Directory.GetFiles(_outputDir, "*.cs", SearchOption.AllDirectories).Length > 0,
+            "The intact operation should still generate files");
+    }
+
+    [TestMethod]
+    public async Task AsyncApiGenerate_DanglingReferenceWithStrict_Fails()
+    {
+        string spec = CodeGeneratorRunner.GetFixturePath("Specs", "dangling-ref-3.0.json");
+
+        ProcessResult result = await CodeGeneratorRunner.RunAsync(
+            $"asyncapi-generate \"{spec}\" --rootNamespace TestGenerated --outputPath \"{_outputDir}\" --force --strict");
+
+        Assert.AreEqual(1, result.ExitCode, $"--strict should fail the run when generation produced warnings. Stdout: {result.StandardOutput} Stderr: {result.StandardError}");
+        StringAssert.Contains(result.StandardOutput, "--strict", "The failure should say --strict caused it");
+    }
+}

--- a/tests/Corvus.Text.Json.CodeGenerator.Tests/TestFixtures/Specs/dangling-ref-3.0.json
+++ b/tests/Corvus.Text.Json.CodeGenerator.Tests/TestFixtures/Specs/dangling-ref-3.0.json
@@ -1,0 +1,32 @@
+{
+  "asyncapi": "3.0.0",
+  "info": {
+    "title": "Dangling reference",
+    "version": "1.0.0"
+  },
+  "channels": {
+    "orders": {
+      "address": "orders.created",
+      "messages": {
+        "OrderCreated": {
+          "payload": {
+            "type": "object",
+            "properties": {
+              "id": { "type": "string" }
+            }
+          }
+        }
+      }
+    }
+  },
+  "operations": {
+    "subscribeOrders": {
+      "action": "receive",
+      "channel": { "$ref": "#/channels/orders" },
+      "messages": [
+        { "$ref": "#/channels/orders/messages/OrderCreated" }
+      ]
+    },
+    "brokenOp": { "$ref": "#/components/operations/Missing" }
+  }
+}


### PR DESCRIPTION
Closes #924. Incorporates #923 (Levy Barbosa's channel-parameter fix, cherry-picked with authorship preserved), which this supersedes and which can be closed when this merges.

## What changed

**The sweep.** AsyncAPI 3.0 made nearly every object referenceable, but the generator resolved `$ref` at only a few positions and silently discarded the rest. Every silent-drop site now resolves through the shared `ResolveRef` chain first, via a `TryResolveEntry` helper that treats a still-unresolved reference like a malformed entry:

- top-level `channels`, `operations`, and `servers` entries (referenced channels previously produced a consumer subscribed to the channel *key* rather than its real address; referenced operations and servers vanished from the output);
- server variables, and chained security schemes (previously reported as type `unknown`);
- the channel, operation, and message entities in `GetBindings`, plus message bindings expressed as a reference;
- the AsyncAPI 2.6 parameter path, where a referenced parameter kept its argument name but lost description, enum, and default (building on the 3.0 parameter fix from #923).

`ListOperations` and `ListServers` gain an optional reference resolver parameter, matching `CollectSchemaPointers` and `GetBindings`. The one deliberately non-resolving site (channel messages in `CollectSchemaPointers`, collected separately from `components.Messages`) now has a comment saying so.

**Diagnostics.** Generation stays deliberately lenient, but a skip is never silent: every swept site records an `AsyncApiGenerationDiagnostic` (severity, specification location, what the generator did instead), exposed as a `Diagnostics` property on both generators and via optional parameters on the public static helpers. The CLI prints each as a warning after generation, and the new `asyncapi-generate --strict` option fails the run when any were produced. `docs/AsyncApi.md` documents the option.

## Tests

- `referenced-components-3.0.json` exercises every swept position (including a chained scheme reference and an inline message inside a referenced channel) and drives twelve regression tests, ending in `DynamicCompiler.AssertCompiles` on the full generated output. All twelve were run against the unfixed generator first and failed with the silent-drop behavior.
- A 2.6 fixture pins that a referenced parameter's description and schema default reach the generated consumer.
- A dangling-reference fixture proves the intact operation still generates, exactly one diagnostic is recorded with its location, and a clean specification records none. CLI-level tests pin exit 0 with the warning printed, and exit 1 under `--strict`.

## Verification

- Full solution builds with 0 warnings; the AsyncAPI codegen suite (198) and the full CLI suite (1827) are green.
- Example-recipes and AsyncAPI-benchmark regeneration with the changed generator are content no-ops (none of the checked-in specifications use references at the affected positions), so no regenerated output rides along.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0157Tdszg6wzgWeKgGYRBNKV
