### PR TITLE
Add delivery-context support to request/reply responders (SubscribeReplyWithDeliveryContextAsync)

### DIFF
--- a/docs/AsyncApi.md
+++ b/docs/AsyncApi.md
@@ -207,7 +207,7 @@ Message arrives on transport
 
 ## Message Delivery Context
 
-Consumers can opt into transport delivery metadata. For every receive operation that is not a request/reply responder, the generator emits a second handler/consumer pair alongside the legacy one, named by appending `WithDeliveryContext` to the operation name: `I{Operation}WithDeliveryContextHandler` and `{Operation}WithDeliveryContextConsumer`. The handler receives a `MessageDeliveryContext` carrying the subscribed channel (as UTF-8 bytes), the message headers, and the transport-native message when one exists (for example RabbitMQ's `BasicDeliverEventArgs`):
+Consumers can opt into transport delivery metadata. For every receive operation — plain consumers and request/reply responders alike — the generator emits a second handler/consumer pair alongside the legacy one, named by appending `WithDeliveryContext` to the operation name: `I{Operation}WithDeliveryContextHandler` and `{Operation}WithDeliveryContextConsumer`. The handler receives a `MessageDeliveryContext` carrying the subscribed channel (as UTF-8 bytes), the message headers, and the transport-native message when one exists (for example RabbitMQ's `BasicDeliverEventArgs`):
 
 ```csharp
 public sealed class LightMeasuredHandler : IReceiveLightMeasurementWithDeliveryContextHandler
@@ -224,6 +224,8 @@ public sealed class LightMeasuredHandler : IReceiveLightMeasurementWithDeliveryC
 ```
 
 A message that declares a typed headers schema keeps its typed headers parameter: the handler signature becomes `(payload, headers, context, cancellationToken)`.
+
+A request/reply responder's delivery-context handler still returns the reply payload — the same `ValueTask<TReply>` return type its legacy handler has — with `MessageDeliveryContext` added as a parameter, not replacing anything. The generated consumer subscribes through `SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>` rather than `SubscribeReplyAsync`; both are on `IMessageDeliveryContextTransport`, and, like the plain-consumer delivery-context capability, are opt-in per transport (the default implementation throws `NotSupportedException`).
 
 The rules that come with the capability:
 
@@ -1194,7 +1196,7 @@ The transport owns correlation: for each delivered request it reads the request'
 
 **Reply ownership.** `RequestAsync` takes a `JsonWorkspace` and threads it through to the parse of the reply: the returned payload and headers are views over documents that workspace owns, so they stay valid until the workspace is disposed. The generated `SendAndReceive*` requester surfaces the same contract. You pass the workspace that will own the reply, and the reply stays valid until you dispose it. Dispose the workspace once the reply is no longer needed. This mirrors `IApiResponse` on the OpenAPI side, which owns its parsed response body and is itself disposable. (Internally the requester builds the outgoing request in a separate short-lived workspace, disposed when the exchange completes; it never affects the reply's lifetime.)
 
-**Implementation status.** Every transport implements `SubscribeReplyAsync`: the broker transports (NATS, Kafka, AMQP, MQTT, WebSocket, Azure Service Bus) each run a real responder over their native correlation fields, and the in-memory testing transport implements a full in-process round-trip — a `RequestAsync` call delivers the request to a registered responder, whose reply completes the requester's pending call. With no responder registered, the request is delivered to any data subscription on the channel (plain or delivery-context, exactly as a publish would be) and parked for the test helper `CompleteRequest`. A responder subscription occupies its channel's single subscription slot like any other, and the internal reply-channel consumers that serve `RequestAsync` live apart from that registry with the transport's own lifetime, so a cancelled request neither kills request-reply on the channel nor blocks an application subscription on the reply channel.
+**Implementation status.** Every transport implements `SubscribeReplyAsync`, and every transport that implements `IMessageDeliveryContextTransport` also implements `SubscribeReplyWithDeliveryContextAsync`: the broker transports (NATS, Kafka, AMQP, MQTT, WebSocket, Azure Service Bus) each run a real responder over their native correlation fields, and the in-memory testing transport implements a full in-process round-trip — a `RequestAsync` call delivers the request to a registered responder, whose reply completes the requester's pending call. With no responder registered, the request is delivered to any data subscription on the channel (plain or delivery-context, exactly as a publish would be) and parked for the test helper `CompleteRequest`. A responder subscription occupies its channel's single subscription slot like any other, and the internal reply-channel consumers that serve `RequestAsync` live apart from that registry with the transport's own lifetime, so a cancelled request neither kills request-reply on the channel nor blocks an application subscription on the reply channel.
 
 
 ## Bindings

--- a/docs/code-sample-catalog.yaml
+++ b/docs/code-sample-catalog.yaml
@@ -628,61 +628,61 @@ main-docs:
       - {index: 11, language: , lines: [187, 195]}
       - {index: 12, language: , lines: [199, 206]}
       - {index: 13, language: csharp, lines: [212, 224], category: compilable, verified: false}
-      - {index: 14, language: csharp, lines: [254, 269], category: compilable, verified: false}
-      - {index: 15, language: csharp, lines: [275, 281], category: compilable, verified: false}
-      - {index: 16, language: csharp, lines: [307, 317], category: compilable, verified: false}
-      - {index: 17, language: csharp, lines: [323, 352], category: compilable, verified: false}
-      - {index: 18, language: bash, lines: [370, 372]}
-      - {index: 19, language: csharp, lines: [376, 405], category: compilable, verified: false}
-      - {index: 20, language: csharp, lines: [427, 438], category: compilable, verified: false}
-      - {index: 21, language: csharp, lines: [442, 453], category: compilable, verified: false}
-      - {index: 22, language: csharp, lines: [457, 468], category: compilable, verified: false}
-      - {index: 23, language: csharp, lines: [472, 484], category: compilable, verified: false}
-      - {index: 24, language: csharp, lines: [488, 497], category: compilable, verified: false}
-      - {index: 25, language: csharp, lines: [501, 513], category: compilable, verified: false}
-      - {index: 26, language: csharp, lines: [517, 525], category: compilable, verified: false}
-      - {index: 27, language: bash, lines: [533, 535]}
-      - {index: 28, language: csharp, lines: [537, 557], category: compilable, verified: false}
-      - {index: 29, language: powershell, lines: [563, 565]}
-      - {index: 30, language: , lines: [584, 590]}
-      - {index: 31, language: csharp, lines: [608, 640], category: compilable, verified: false}
-      - {index: 32, language: csharp, lines: [644, 670], category: compilable, verified: false}
-      - {index: 33, language: csharp, lines: [678, 696], category: compilable, verified: false}
-      - {index: 34, language: csharp, lines: [704, 719], category: compilable, verified: false}
-      - {index: 35, language: csharp, lines: [723, 745], category: compilable, verified: false}
-      - {index: 36, language: csharp, lines: [751, 779], category: compilable, verified: false}
-      - {index: 37, language: csharp, lines: [785, 802], category: compilable, verified: false}
-      - {index: 38, language: csharp, lines: [808, 830], category: compilable, verified: false}
-      - {index: 39, language: csharp, lines: [836, 859], category: compilable, verified: false}
-      - {index: 40, language: csharp, lines: [865, 882], category: compilable, verified: false}
-      - {index: 41, language: csharp, lines: [886, 908], category: compilable, verified: false}
-      - {index: 42, language: csharp, lines: [916, 922], category: compilable, verified: false}
-      - {index: 43, language: csharp, lines: [930, 935], category: compilable, verified: false}
-      - {index: 44, language: csharp, lines: [939, 941], category: compilable, verified: false}
-      - {index: 45, language: json, lines: [955, 981]}
-      - {index: 46, language: csharp, lines: [987, 995], category: compilable, verified: false}
-      - {index: 47, language: csharp, lines: [1003, 1031], category: compilable, verified: false}
-      - {index: 48, language: csharp, lines: [1037, 1045], category: compilable, verified: false}
-      - {index: 49, language: csharp, lines: [1053, 1066], category: compilable, verified: false}
-      - {index: 50, language: csharp, lines: [1070, 1092], category: compilable, verified: false}
-      - {index: 51, language: csharp, lines: [1115, 1129], category: compilable, verified: false}
-      - {index: 52, language: json, lines: [1135, 1155]}
-      - {index: 53, language: csharp, lines: [1165, 1180], category: compilable, verified: false}
-      - {index: 54, language: csharp, lines: [1184, 1191], category: compilable, verified: false}
-      - {index: 55, language: json, lines: [1210, 1224]}
-      - {index: 56, language: csharp, lines: [1228, 1237], category: compilable, verified: false}
-      - {index: 57, language: csharp, lines: [1247, 1255], category: compilable, verified: false}
-      - {index: 58, language: csharp, lines: [1261, 1270], category: compilable, verified: false}
-      - {index: 59, language: csharp, lines: [1283, 1301], category: compilable, verified: false}
-      - {index: 60, language: bash, lines: [1309, 1311]}
-      - {index: 61, language: csharp, lines: [1313, 1324], category: compilable, verified: false}
-      - {index: 62, language: bash, lines: [1334, 1336]}
-      - {index: 63, language: bash, lines: [1355, 1373]}
-      - {index: 64, language: bash, lines: [1377, 1379]}
-      - {index: 65, language: , lines: [1383, 1393]}
-      - {index: 66, language: bash, lines: [1406, 1412]}
-      - {index: 67, language: csharp, lines: [1448, 1453], category: compilable, verified: false}
-      - {index: 68, language: , lines: [1467, 1472]}
+      - {index: 14, language: csharp, lines: [256, 271], category: compilable, verified: false}
+      - {index: 15, language: csharp, lines: [277, 283], category: compilable, verified: false}
+      - {index: 16, language: csharp, lines: [309, 319], category: compilable, verified: false}
+      - {index: 17, language: csharp, lines: [325, 354], category: compilable, verified: false}
+      - {index: 18, language: bash, lines: [372, 374]}
+      - {index: 19, language: csharp, lines: [378, 407], category: compilable, verified: false}
+      - {index: 20, language: csharp, lines: [429, 440], category: compilable, verified: false}
+      - {index: 21, language: csharp, lines: [444, 455], category: compilable, verified: false}
+      - {index: 22, language: csharp, lines: [459, 470], category: compilable, verified: false}
+      - {index: 23, language: csharp, lines: [474, 486], category: compilable, verified: false}
+      - {index: 24, language: csharp, lines: [490, 499], category: compilable, verified: false}
+      - {index: 25, language: csharp, lines: [503, 515], category: compilable, verified: false}
+      - {index: 26, language: csharp, lines: [519, 527], category: compilable, verified: false}
+      - {index: 27, language: bash, lines: [535, 537]}
+      - {index: 28, language: csharp, lines: [539, 559], category: compilable, verified: false}
+      - {index: 29, language: powershell, lines: [565, 567]}
+      - {index: 30, language: , lines: [586, 592]}
+      - {index: 31, language: csharp, lines: [610, 642], category: compilable, verified: false}
+      - {index: 32, language: csharp, lines: [646, 672], category: compilable, verified: false}
+      - {index: 33, language: csharp, lines: [680, 698], category: compilable, verified: false}
+      - {index: 34, language: csharp, lines: [706, 721], category: compilable, verified: false}
+      - {index: 35, language: csharp, lines: [725, 747], category: compilable, verified: false}
+      - {index: 36, language: csharp, lines: [753, 781], category: compilable, verified: false}
+      - {index: 37, language: csharp, lines: [787, 804], category: compilable, verified: false}
+      - {index: 38, language: csharp, lines: [810, 832], category: compilable, verified: false}
+      - {index: 39, language: csharp, lines: [838, 861], category: compilable, verified: false}
+      - {index: 40, language: csharp, lines: [867, 884], category: compilable, verified: false}
+      - {index: 41, language: csharp, lines: [888, 910], category: compilable, verified: false}
+      - {index: 42, language: csharp, lines: [918, 924], category: compilable, verified: false}
+      - {index: 43, language: csharp, lines: [932, 937], category: compilable, verified: false}
+      - {index: 44, language: csharp, lines: [941, 943], category: compilable, verified: false}
+      - {index: 45, language: json, lines: [957, 983]}
+      - {index: 46, language: csharp, lines: [989, 997], category: compilable, verified: false}
+      - {index: 47, language: csharp, lines: [1005, 1033], category: compilable, verified: false}
+      - {index: 48, language: csharp, lines: [1039, 1047], category: compilable, verified: false}
+      - {index: 49, language: csharp, lines: [1055, 1068], category: compilable, verified: false}
+      - {index: 50, language: csharp, lines: [1072, 1094], category: compilable, verified: false}
+      - {index: 51, language: csharp, lines: [1117, 1131], category: compilable, verified: false}
+      - {index: 52, language: json, lines: [1137, 1157]}
+      - {index: 53, language: csharp, lines: [1167, 1182], category: compilable, verified: false}
+      - {index: 54, language: csharp, lines: [1186, 1193], category: compilable, verified: false}
+      - {index: 55, language: json, lines: [1212, 1226]}
+      - {index: 56, language: csharp, lines: [1230, 1239], category: compilable, verified: false}
+      - {index: 57, language: csharp, lines: [1249, 1257], category: compilable, verified: false}
+      - {index: 58, language: csharp, lines: [1263, 1272], category: compilable, verified: false}
+      - {index: 59, language: csharp, lines: [1285, 1303], category: compilable, verified: false}
+      - {index: 60, language: bash, lines: [1311, 1313]}
+      - {index: 61, language: csharp, lines: [1315, 1326], category: compilable, verified: false}
+      - {index: 62, language: bash, lines: [1336, 1338]}
+      - {index: 63, language: bash, lines: [1357, 1375]}
+      - {index: 64, language: bash, lines: [1379, 1381]}
+      - {index: 65, language: , lines: [1385, 1395]}
+      - {index: 66, language: bash, lines: [1408, 1414]}
+      - {index: 67, language: csharp, lines: [1450, 1455], category: compilable, verified: false}
+      - {index: 68, language: , lines: [1469, 1474]}
   - path: "docs/AsyncApiMessageResumption.md"
     blocks:
       - {index: 0, language: , lines: [26, 32]}

--- a/src/Corvus.Text.Json.AsyncApi.Amqp/AmqpMessageTransport.cs
+++ b/src/Corvus.Text.Json.AsyncApi.Amqp/AmqpMessageTransport.cs
@@ -229,7 +229,22 @@ public sealed class AmqpMessageTransport : IMessageDeliveryContextTransport, IHe
     {
         ObjectDisposedException.ThrowIf(this.disposed, this);
         string channel = Encoding.UTF8.GetString(channelUtf8.Span);
-        return SubscribeReplyCoreAsync(channel, channelUtf8, handler, cancellationToken);
+        return SubscribeReplyCoreAsync(
+            channel, channelUtf8, MessageReplyHandler<TRequest, TReply>.WithoutDeliveryContext(handler), cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+    {
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+        string channel = Encoding.UTF8.GetString(channelUtf8.Span);
+        return SubscribeReplyCoreAsync(
+            channel, channelUtf8, MessageReplyHandler<TRequest, TReply>.WithDeliveryContext(handler), cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -1038,7 +1053,7 @@ public sealed class AmqpMessageTransport : IMessageDeliveryContextTransport, IHe
     private async ValueTask SubscribeReplyCoreAsync<TRequest, TReply>(
         string channel,
         ReadOnlyMemory<byte> channelUtf8,
-        Func<TRequest, JsonElement, CancellationToken, ValueTask<TReply>> handler,
+        MessageReplyHandler<TRequest, TReply> handler,
         CancellationToken cancellationToken)
         where TRequest : struct, IJsonElement<TRequest>
         where TReply : struct, IJsonElement<TReply>
@@ -1205,6 +1220,7 @@ public sealed class AmqpMessageTransport : IMessageDeliveryContextTransport, IHe
                 using (headersDoc)
                 {
                     JsonElement headers = headersDoc?.RootElement ?? default;
+                    object? nativeMessage = handler.UsesDeliveryContext ? args : null;
 
                     try
                     {
@@ -1212,13 +1228,14 @@ public sealed class AmqpMessageTransport : IMessageDeliveryContextTransport, IHe
                         if (this.middleware is not null)
                         {
                             reply = await this.middleware.InvokeAsync(
-                                static (s, ct) => s.handler(s.request, s.headers, ct),
-                                (handler, request, headers),
+                                static (s, ct) => s.handler.InvokeReply(s.request, s.channelUtf8, s.headers, s.nativeMessage, ct),
+                                (handler, request, channelUtf8, headers, nativeMessage),
                                 cts.Token).ConfigureAwait(false);
                         }
                         else
                         {
-                            reply = await handler(request, headers, cts.Token).ConfigureAwait(false);
+                            reply = await handler.InvokeReply(request, channelUtf8, headers, nativeMessage, cts.Token)
+                                .ConfigureAwait(false);
                         }
 
                         // Publish the reply to the request's reply-to routing key, echoing the

--- a/src/Corvus.Text.Json.AsyncApi.AzureServiceBus/AzureServiceBusMessageTransport.cs
+++ b/src/Corvus.Text.Json.AsyncApi.AzureServiceBus/AzureServiceBusMessageTransport.cs
@@ -562,10 +562,29 @@ public sealed class AzureServiceBusMessageTransport : IMessageDeliveryContextTra
     /// <param name="handler">The handler invoked with each request payload and its headers, returning the reply payload.</param>
     /// <param name="cancellationToken">A cancellation token.</param>
     /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
-    public async ValueTask SubscribeReplyAsync<TRequest, TReply>(
+    public ValueTask SubscribeReplyAsync<TRequest, TReply>(
         ReadOnlyMemory<byte> channelUtf8,
         Func<TRequest, JsonElement, CancellationToken, ValueTask<TReply>> handler,
         CancellationToken cancellationToken = default)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+        => this.SubscribeReplyCoreAsync<TRequest, TReply>(
+            channelUtf8, MessageReplyHandler<TRequest, TReply>.WithoutDeliveryContext(handler), cancellationToken);
+
+    /// <inheritdoc/>
+    public ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+        => this.SubscribeReplyCoreAsync<TRequest, TReply>(
+            channelUtf8, MessageReplyHandler<TRequest, TReply>.WithDeliveryContext(handler), cancellationToken);
+
+    private async ValueTask SubscribeReplyCoreAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        MessageReplyHandler<TRequest, TReply> handler,
+        CancellationToken cancellationToken)
         where TRequest : struct, IJsonElement<TRequest>
         where TReply : struct, IJsonElement<TReply>
     {
@@ -656,6 +675,7 @@ public sealed class AzureServiceBusMessageTransport : IMessageDeliveryContextTra
                 JsonElement headersElement = headerWorkspace is not null
                     ? BuildHeadersElement(args.Message.ApplicationProperties, headerWorkspace)
                     : default;
+                object? nativeMessage = handler.UsesDeliveryContext ? args.Message : null;
 
                 try
                 {
@@ -663,13 +683,14 @@ public sealed class AzureServiceBusMessageTransport : IMessageDeliveryContextTra
                     if (this.middleware is not null)
                     {
                         reply = await this.middleware.InvokeAsync(
-                            static (s, ct) => s.handler(s.request, s.headersElement, ct),
-                            (handler, request, headersElement),
+                            static (s, ct) => s.handler.InvokeReply(s.request, s.channelUtf8, s.headersElement, s.nativeMessage, ct),
+                            (handler, request, channelUtf8, headersElement, nativeMessage),
                             cts.Token).ConfigureAwait(false);
                     }
                     else
                     {
-                        reply = await handler(request, headersElement, cts.Token).ConfigureAwait(false);
+                        reply = await handler.InvokeReply(request, channelUtf8, headersElement, nativeMessage, cts.Token)
+                            .ConfigureAwait(false);
                     }
 
                     // Echo the request's reply-to address, session ID and correlation ID so the requester's

--- a/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
+++ b/src/Corvus.Text.Json.AsyncApi.CodeGeneration/AsyncApi30CodeGenerator.cs
@@ -774,10 +774,9 @@ public sealed class AsyncApi30CodeGenerator
             files.Add(EmitConsumerHandler(op, withDeliveryContext: false));
             files.Add(EmitConsumer(op, withDeliveryContext: false));
 
-            // A responder's context never reaches its handler (SubscribeReplyAsync has no
-            // delivery-context form), so the variants would be inert duplicates demanding a
-            // wider transport interface for no benefit.
-            if (!IsResponderOperation(op))
+            // Responders get delivery-context variants too: IMessageDeliveryContextTransport
+            // exposes SubscribeReplyWithDeliveryContextAsync, so a responder's handler can now
+            // receive MessageDeliveryContext exactly as a plain consumer's can.
             {
                 string variantBaseName = ToPascalCase(op.Name) + "WithDeliveryContext";
                 if (receiveOpPascalNames.Contains(variantBaseName))
@@ -2704,7 +2703,10 @@ public sealed class AsyncApi30CodeGenerator
             if (IsResponderOperation(op))
             {
                 string payloadType = op.Messages[0].PayloadTypeName ?? "Corvus.Text.Json.JsonElement";
-                w.WriteLine($"{keyword}this.transport.SubscribeReplyAsync<{payloadType}, {ReplyPayloadTypeNameOf(op)}>({subscribeAddr}, {handlerArg}{contextArg}, cancellationToken){suffix};");
+                string replyPayloadType = ReplyPayloadTypeNameOf(op);
+                w.WriteLine(withDeliveryContext
+                    ? $"{keyword}this.transport.SubscribeReplyWithDeliveryContextAsync<{payloadType}, {replyPayloadType}>({subscribeAddr}, {handlerArg}{contextArg}, cancellationToken){suffix};"
+                    : $"{keyword}this.transport.SubscribeReplyAsync<{payloadType}, {replyPayloadType}>({subscribeAddr}, {handlerArg}{contextArg}, cancellationToken){suffix};");
             }
             else if (op.Messages.Count == 1)
             {
@@ -2903,8 +2905,16 @@ public sealed class AsyncApi30CodeGenerator
             string handlerMethod = $"Handle{ToPascalCase(msg.Name)}Async";
             string replyType = ReplyPayloadTypeNameOf(op);
 
-            w.WriteLine($"private ValueTask<{replyType}> HandleMessageAsync({payloadType} payload, Corvus.Text.Json.JsonElement headers, CancellationToken cancellationToken)");
+            w.WriteLine(withDeliveryContext
+                ? $"private ValueTask<{replyType}> HandleMessageAsync({payloadType} payload, MessageDeliveryContext deliveryContext, CancellationToken cancellationToken)"
+                : $"private ValueTask<{replyType}> HandleMessageAsync({payloadType} payload, Corvus.Text.Json.JsonElement headers, CancellationToken cancellationToken)");
             w.OpenBrace();
+
+            if (withDeliveryContext)
+            {
+                w.WriteLine("Corvus.Text.Json.JsonElement headers = deliveryContext.Headers;");
+            }
+
             w.WriteLine("if (this.validationMode != ValidationMode.None)");
             w.OpenBrace();
             w.WriteLine("ValidatePayload(payload, this.validationMode);");
@@ -2915,7 +2925,15 @@ public sealed class AsyncApi30CodeGenerator
 
             w.CloseBrace();
             w.WriteLine();
-            if (msg.HeadersTypeName is not null)
+            if (withDeliveryContext && msg.HeadersTypeName is not null)
+            {
+                w.WriteLine($"return this.handler.{handlerMethod}(payload, {msg.HeadersTypeName}.From(headers), deliveryContext, cancellationToken);");
+            }
+            else if (withDeliveryContext)
+            {
+                w.WriteLine($"return this.handler.{handlerMethod}(payload, deliveryContext, cancellationToken);");
+            }
+            else if (msg.HeadersTypeName is not null)
             {
                 w.WriteLine($"return this.handler.{handlerMethod}(payload, {msg.HeadersTypeName}.From(headers), cancellationToken);");
             }

--- a/src/Corvus.Text.Json.AsyncApi.Kafka/KafkaMessageTransport.cs
+++ b/src/Corvus.Text.Json.AsyncApi.Kafka/KafkaMessageTransport.cs
@@ -296,10 +296,29 @@ public sealed class KafkaMessageTransport : IMessageDeliveryContextTransport, IH
     }
 
     /// <inheritdoc/>
-    public async ValueTask SubscribeReplyAsync<TRequest, TReply>(
+    public ValueTask SubscribeReplyAsync<TRequest, TReply>(
         ReadOnlyMemory<byte> channelUtf8,
         Func<TRequest, JsonElement, CancellationToken, ValueTask<TReply>> handler,
         CancellationToken cancellationToken = default)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+        => this.SubscribeReplyCoreAsync<TRequest, TReply>(
+            channelUtf8, MessageReplyHandler<TRequest, TReply>.WithoutDeliveryContext(handler), cancellationToken);
+
+    /// <inheritdoc/>
+    public ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+        => this.SubscribeReplyCoreAsync<TRequest, TReply>(
+            channelUtf8, MessageReplyHandler<TRequest, TReply>.WithDeliveryContext(handler), cancellationToken);
+
+    private async ValueTask SubscribeReplyCoreAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        MessageReplyHandler<TRequest, TReply> handler,
+        CancellationToken cancellationToken)
         where TRequest : struct, IJsonElement<TRequest>
         where TReply : struct, IJsonElement<TReply>
     {
@@ -991,7 +1010,7 @@ public sealed class KafkaMessageTransport : IMessageDeliveryContextTransport, IH
         string channel,
         ReadOnlyMemory<byte> channelUtf8,
         IConsumer<Null, byte[]> consumer,
-        Func<TRequest, JsonElement, CancellationToken, ValueTask<TReply>> handler,
+        MessageReplyHandler<TRequest, TReply> handler,
         object marker,
         CancellationToken cancellationToken)
         where TRequest : struct, IJsonElement<TRequest>
@@ -1115,6 +1134,7 @@ public sealed class KafkaMessageTransport : IMessageDeliveryContextTransport, IH
                     using (headersDoc)
                     {
                         JsonElement headers = headersDoc?.RootElement ?? default;
+                        object? nativeMessage = handler.UsesDeliveryContext ? result : null;
 
                         try
                         {
@@ -1122,13 +1142,14 @@ public sealed class KafkaMessageTransport : IMessageDeliveryContextTransport, IH
                             if (this.middleware is not null)
                             {
                                 reply = await this.middleware.InvokeAsync(
-                                    static (s, ct) => s.handler(s.request, s.headers, ct),
-                                    (handler, request, headers),
+                                    static (s, ct) => s.handler.InvokeReply(s.request, s.channelUtf8, s.headers, s.nativeMessage, ct),
+                                    (handler, request, channelUtf8, headers, nativeMessage),
                                     cancellationToken).ConfigureAwait(false);
                             }
                             else
                             {
-                                reply = await handler(request, headers, cancellationToken).ConfigureAwait(false);
+                                reply = await handler.InvokeReply(request, channelUtf8, headers, nativeMessage, cancellationToken)
+                                    .ConfigureAwait(false);
                             }
 
                             // Route the reply back to the requester. The reply-to topic and

--- a/src/Corvus.Text.Json.AsyncApi.Mqtt/MqttMessageTransport.cs
+++ b/src/Corvus.Text.Json.AsyncApi.Mqtt/MqttMessageTransport.cs
@@ -184,7 +184,22 @@ public sealed class MqttMessageTransport : IMessageDeliveryContextTransport
     {
         ObjectDisposedException.ThrowIf(this.disposed, this);
         string channel = Encoding.UTF8.GetString(channelUtf8.Span);
-        return SubscribeReplyCoreAsync(channel, channelUtf8, handler, cancellationToken);
+        return SubscribeReplyCoreAsync(
+            channel, channelUtf8, MessageReplyHandler<TRequest, TReply>.WithoutDeliveryContext(handler), cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+    {
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+        string channel = Encoding.UTF8.GetString(channelUtf8.Span);
+        return SubscribeReplyCoreAsync(
+            channel, channelUtf8, MessageReplyHandler<TRequest, TReply>.WithDeliveryContext(handler), cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -517,7 +532,7 @@ public sealed class MqttMessageTransport : IMessageDeliveryContextTransport
     private async ValueTask SubscribeReplyCoreAsync<TRequest, TReply>(
         string channel,
         ReadOnlyMemory<byte> channelUtf8,
-        Func<TRequest, JsonElement, CancellationToken, ValueTask<TReply>> handler,
+        MessageReplyHandler<TRequest, TReply> handler,
         CancellationToken cancellationToken)
         where TRequest : struct, IJsonElement<TRequest>
         where TReply : struct, IJsonElement<TReply>
@@ -831,7 +846,7 @@ public sealed class MqttMessageTransport : IMessageDeliveryContextTransport
         string channel,
         ReadOnlyMemory<byte> channelUtf8,
         string deadLetterChannel,
-        Func<TRequest, JsonElement, CancellationToken, ValueTask<TReply>> handler,
+        MessageReplyHandler<TRequest, TReply> handler,
         MqttApplicationMessage message,
         CancellationToken cancellationToken)
         where TRequest : struct, IJsonElement<TRequest>
@@ -917,6 +932,7 @@ public sealed class MqttMessageTransport : IMessageDeliveryContextTransport
             using (headersDoc)
             {
                 JsonElement headers = headersDoc?.RootElement ?? default;
+                object? nativeMessage = handler.UsesDeliveryContext ? message : null;
 
                 try
                 {
@@ -924,13 +940,14 @@ public sealed class MqttMessageTransport : IMessageDeliveryContextTransport
                     if (this.middleware is not null)
                     {
                         reply = await this.middleware.InvokeAsync(
-                            static (s, ct) => s.handler(s.request, s.headers, ct),
-                            (handler, request, headers),
+                            static (s, ct) => s.handler.InvokeReply(s.request, s.channelUtf8, s.headers, s.nativeMessage, ct),
+                            (handler, request, channelUtf8, headers, nativeMessage),
                             cancellationToken).ConfigureAwait(false);
                     }
                     else
                     {
-                        reply = await handler(request, headers, cancellationToken).ConfigureAwait(false);
+                        reply = await handler.InvokeReply(request, channelUtf8, headers, nativeMessage, cancellationToken)
+                            .ConfigureAwait(false);
                     }
 
                     // Determine where to send the reply: the requester advertises the reply topic via

--- a/src/Corvus.Text.Json.AsyncApi.Nats/NatsMessageTransport.cs
+++ b/src/Corvus.Text.Json.AsyncApi.Nats/NatsMessageTransport.cs
@@ -375,7 +375,24 @@ public sealed class NatsMessageTransport : IMessageDeliveryContextTransport, IHe
 
         string channel = Encoding.UTF8.GetString(channelUtf8.Span);
         ThrowIfSubscribed(channel);
-        return this.SubscribeReplyToCoreNatsAsync(channel, channelUtf8, handler, cancellationToken);
+        return this.SubscribeReplyToCoreNatsAsync(
+            channel, channelUtf8, MessageReplyHandler<TRequest, TReply>.WithoutDeliveryContext(handler), cancellationToken);
+    }
+
+    /// <inheritdoc/>
+    public ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+    {
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+
+        string channel = Encoding.UTF8.GetString(channelUtf8.Span);
+        ThrowIfSubscribed(channel);
+        return this.SubscribeReplyToCoreNatsAsync(
+            channel, channelUtf8, MessageReplyHandler<TRequest, TReply>.WithDeliveryContext(handler), cancellationToken);
     }
 
     /// <inheritdoc/>
@@ -1225,7 +1242,7 @@ public sealed class NatsMessageTransport : IMessageDeliveryContextTransport, IHe
     private async ValueTask SubscribeReplyToCoreNatsAsync<TRequest, TReply>(
         string channel,
         ReadOnlyMemory<byte> channelUtf8,
-        Func<TRequest, JsonElement, CancellationToken, ValueTask<TReply>> handler,
+        MessageReplyHandler<TRequest, TReply> handler,
         CancellationToken cancellationToken)
         where TRequest : struct, IJsonElement<TRequest>
         where TReply : struct, IJsonElement<TReply>
@@ -1368,18 +1385,20 @@ public sealed class NatsMessageTransport : IMessageDeliveryContextTransport, IHe
                                     using (headersDoc)
                                     {
                                         JsonElement headers = headersDoc?.RootElement ?? default;
+                                        object? nativeMessage = handler.UsesDeliveryContext ? msg : null;
 
                                         TReply reply;
                                         if (this.middleware is not null)
                                         {
                                             reply = await this.middleware.InvokeAsync(
-                                                static (s, ct) => s.handler(s.request, s.headers, ct),
-                                                (handler, request, headers),
+                                                static (s, ct) => s.handler.InvokeReply(s.request, s.channelUtf8, s.headers, s.nativeMessage, ct),
+                                                (handler, request, channelUtf8, headers, nativeMessage),
                                                 cts.Token).ConfigureAwait(false);
                                         }
                                         else
                                         {
-                                            reply = await handler(request, headers, cts.Token).ConfigureAwait(false);
+                                            reply = await handler.InvokeReply(request, channelUtf8, headers, nativeMessage, cts.Token)
+                                                .ConfigureAwait(false);
                                         }
 
                                         // Publish the reply to the request's reply-to subject. NATS correlates

--- a/src/Corvus.Text.Json.AsyncApi.Testing/InMemoryMessageTransport.cs
+++ b/src/Corvus.Text.Json.AsyncApi.Testing/InMemoryMessageTransport.cs
@@ -242,7 +242,7 @@ public sealed class InMemoryMessageTransport : IMessageDeliveryContextTransport,
 
         if (responder is not null)
         {
-            return RespondAsync<TRequest, TReply>(responder, requestBytes, headerBytes, workspace, cancellationToken);
+            return RespondAsync<TRequest, TReply>(responder, requestChannelUtf8, requestBytes, headerBytes, workspace, cancellationToken);
         }
 
         TaskCompletionSource<(byte[] Payload, byte[] Headers)> tcs = new();
@@ -319,10 +319,30 @@ public sealed class InMemoryMessageTransport : IMessageDeliveryContextTransport,
         return ValueTask.CompletedTask;
     }
 
+    /// <inheritdoc/>
+    public ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        string channel = Encoding.UTF8.GetString(channelUtf8.Span);
+
+        this.ClaimChannel(channel, handler);
+
+        return ValueTask.CompletedTask;
+    }
+
     // Parses a delivered request, invokes the responder handler, and returns its reply (the request and
-    // reply documents are GC-backed, matching CompleteRequestAsync's semantics).
+    // reply documents are GC-backed, matching CompleteRequestAsync's semantics). The stored delegate is
+    // either the legacy (request, headers) shape or the delivery-context shape — both are four-arity
+    // Funcs returning ValueTask<TReply>, so a runtime type check picks the right one, matching how
+    // DeliverToSubscriberAsync distinguishes the two plain-subscribe delegate shapes above.
     private static async ValueTask<(TReply Payload, JsonElement Headers)> RespondAsync<TRequest, TReply>(
         Delegate responder,
+        ReadOnlyMemory<byte> requestChannelUtf8,
         byte[] requestBytes,
         byte[] headerBytes,
         JsonWorkspace workspace,
@@ -341,8 +361,24 @@ public sealed class InMemoryMessageTransport : IMessageDeliveryContextTransport,
 
         try
         {
-            var handler = (Func<TRequest, JsonElement, CancellationToken, ValueTask<TReply>>)responder;
-            TReply reply = await handler(requestDoc.RootElement, requestHeaders, cancellationToken).ConfigureAwait(false);
+            TReply reply;
+            if (responder is Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> contextHandler)
+            {
+                // The in-memory transport has no native broker message: the request is already
+                // fully materialized as the parsed document and header bytes this method holds,
+                // exactly as the plain delivery-context subscribe path leaves NativeMessage unset.
+                MessageDeliveryContext context = new()
+                {
+                    ChannelUtf8 = requestChannelUtf8,
+                    Headers = requestHeaders,
+                };
+                reply = await contextHandler(requestDoc.RootElement, context, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                var handler = (Func<TRequest, JsonElement, CancellationToken, ValueTask<TReply>>)responder;
+                reply = await handler(requestDoc.RootElement, requestHeaders, cancellationToken).ConfigureAwait(false);
+            }
 
             // Re-parse the reply into a document owned by the caller's workspace so it outlives this handler.
             byte[] replyBytes = SerializeToOwnedBytes(in reply);

--- a/src/Corvus.Text.Json.AsyncApi.WebSocket/WebSocketMessageTransport.cs
+++ b/src/Corvus.Text.Json.AsyncApi.WebSocket/WebSocketMessageTransport.cs
@@ -169,6 +169,26 @@ public sealed class WebSocketMessageTransport : IMessageDeliveryContextTransport
     }
 
     /// <inheritdoc/>
+    public ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+    {
+        string channel = Encoding.UTF8.GetString(channelUtf8.Span);
+        ObjectDisposedException.ThrowIf(this.disposed, this);
+        return this.SubscribeCoreAsync(
+            channel,
+            new Subscription
+            {
+                ReplyHandler = (payload, headers, replyChannel, correlationId, ct) =>
+                    this.DispatchToReplyContextHandlerAsync(channel, channelUtf8, handler, payload, headers, replyChannel, correlationId, ct),
+            },
+            cancellationToken);
+    }
+
+    /// <inheritdoc/>
     public ValueTask UnsubscribeAsync(ReadOnlyMemory<byte> channelUtf8, CancellationToken cancellationToken = default)
     {
         string channel = Encoding.UTF8.GetString(channelUtf8.Span);
@@ -606,6 +626,93 @@ public sealed class WebSocketMessageTransport : IMessageDeliveryContextTransport
             else
             {
                 reply = await handler(typedRequest, headers, cancellationToken).ConfigureAwait(false);
+            }
+
+            // Without a reply channel there is nowhere to send the response; the request cannot be answered.
+            if (replyChannel is null)
+            {
+                AsyncApiTelemetry.RecordSkip(channel, "websocket", MessageErrorKind.Handler);
+                return;
+            }
+
+            // Send the reply on the reply channel with the request's correlation id so the requester's
+            // RequestAsync (which correlates by that id) receives it.
+            JsonElement replyHeaders = default;
+            (byte[] rented, int length) = BuildPublishEnvelopeRented(replyChannel, in reply, in replyHeaders, correlationId);
+            await this.SendAndReturnAsync(rented, length, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+        {
+            return;
+        }
+        catch (Exception ex)
+        {
+            MessageErrorContext ctx = new(channelUtf8, MessageErrorKind.Handler, payload, headers);
+            MessageErrorAction action = await this.errorPolicy.HandleErrorAsync(ex, ctx, cancellationToken).ConfigureAwait(false);
+            if (action == MessageErrorAction.DeadLetter)
+            {
+                try
+                {
+                    string dlChannel = channel + this.options.DeadLetterSuffix;
+                    (byte[] rented, int length) = BuildDeadLetterEnvelopeRented(dlChannel, channel, in payload, in headers, ex);
+                    await this.SendAndReturnAsync(rented, length, cancellationToken).ConfigureAwait(false);
+                    AsyncApiTelemetry.RecordDeadLetter(dlChannel, channel, "websocket");
+                }
+                catch (Exception dlEx) when (dlEx is not OperationCanceledException)
+                {
+                    AsyncApiTelemetry.RecordDeadLetterFailure(channel + this.options.DeadLetterSuffix, channel, "websocket", dlEx);
+                }
+            }
+            else if (action == MessageErrorAction.Abort)
+            {
+                AsyncApiTelemetry.RecordAbort(channel, "websocket", MessageErrorKind.Handler);
+                await this.UnsubscribeAsync(channelUtf8, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                AsyncApiTelemetry.RecordSkip(channel, "websocket", MessageErrorKind.Handler);
+            }
+        }
+    }
+
+    private async ValueTask DispatchToReplyContextHandlerAsync<TRequest, TReply>(
+        string channel,
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        JsonElement payload,
+        JsonElement headers,
+        string? replyChannel,
+        string? correlationId,
+        CancellationToken cancellationToken)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+    {
+        try
+        {
+            TRequest typedRequest = JsonElementHelpers.Reinterpret<JsonElement, TRequest>(in payload);
+
+            // WebSocket has no native broker message representation — the whole "message" is
+            // already the JSON envelope this transport itself parsed, so NativeMessage is always
+            // null here, exactly as it is for the plain delivery-context subscribe path (see
+            // DispatchToContextHandlerAsync).
+            MessageDeliveryContext context = new()
+            {
+                ChannelUtf8 = channelUtf8,
+                Headers = headers,
+                NativeMessage = null,
+            };
+
+            TReply reply;
+            if (this.middleware is not null)
+            {
+                reply = await this.middleware.InvokeAsync(
+                    static (s, ct) => s.handler(s.typedRequest, s.context, ct),
+                    (handler, typedRequest, context),
+                    cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                reply = await handler(typedRequest, context, cancellationToken).ConfigureAwait(false);
             }
 
             // Without a reply channel there is nowhere to send the response; the request cannot be answered.

--- a/src/Corvus.Text.Json.AsyncApi/IMessageDeliveryContextTransport.cs
+++ b/src/Corvus.Text.Json.AsyncApi/IMessageDeliveryContextTransport.cs
@@ -63,6 +63,78 @@ public interface IMessageDeliveryContextTransport : IMessageTransport
     {
         return SubscribeWithDeliveryContextAsync(channelUtf8, handler, cancellationToken);
     }
+
+    /// <summary>
+    /// Subscribes a responder to a request channel while exposing transport delivery metadata — the
+    /// delivery-context counterpart of
+    /// <see cref="IMessageTransport.SubscribeReplyAsync{TRequest, TReply}(ReadOnlyMemory{byte}, Func{TRequest, JsonElement, CancellationToken, ValueTask{TReply}}, CancellationToken)"/>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// For every request delivered on <paramref name="channelUtf8"/> the transport parses the typed
+    /// request, invokes <paramref name="handler"/> with the request payload and its delivery context to
+    /// obtain the reply payload, and publishes that reply to the request's reply-to address correlated
+    /// to the request — exactly as <c>SubscribeReplyAsync</c> does, except the handler also receives the
+    /// native delivery metadata (headers, channel, and the transport-specific native message) instead of
+    /// just headers.
+    /// </para>
+    /// <para>
+    /// The <see cref="MessageDeliveryContext"/> passed to <paramref name="handler"/> is valid only for
+    /// the duration of that invocation, and the reply the handler returns is published before the
+    /// handler call completes — the same lifetime rule <c>SubscribeWithDeliveryContextAsync</c> applies
+    /// to plain consumers applies here.
+    /// </para>
+    /// <para>
+    /// This is an optional capability layered on an already-optional capability: a transport that
+    /// implements <see cref="IMessageDeliveryContextTransport"/> is not required to also support
+    /// request/reply responders, and one that supports plain responders via
+    /// <c>SubscribeReplyAsync</c> is not required to additionally expose their delivery context. The
+    /// default implementation throws <see cref="NotSupportedException"/>, matching
+    /// <c>SubscribeReplyAsync</c>'s own default.
+    /// </para>
+    /// </remarks>
+    /// <typeparam name="TRequest">The request payload type the responder parses into.</typeparam>
+    /// <typeparam name="TReply">The reply payload type the handler returns.</typeparam>
+    /// <param name="channelUtf8">The request channel address as UTF-8 bytes.</param>
+    /// <param name="handler">The handler invoked with each request payload and its delivery context, returning the reply payload.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
+    ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+        => throw new NotSupportedException(
+            "This transport does not support request/reply responders with delivery context (SubscribeReplyWithDeliveryContextAsync).");
+
+    /// <summary>
+    /// Subscribes a delivery-context-aware responder to a request channel, with protocol-specific metadata.
+    /// </summary>
+    /// <remarks>
+    /// The counterpart of the <see cref="MessageContext"/> overload of <c>SubscribeReplyAsync</c>: a
+    /// delivery-context responder declared with channel or operation bindings is subscribed with them,
+    /// exactly as a plain responder is. The default implementation drops the context and forwards, so a
+    /// transport that has no use for bindings is unaffected and one that already implements the
+    /// delivery-context responder capability keeps working unchanged.
+    /// </remarks>
+    /// <typeparam name="TRequest">The request payload type the responder parses into.</typeparam>
+    /// <typeparam name="TReply">The reply payload type the handler returns.</typeparam>
+    /// <param name="channelUtf8">The request channel address as UTF-8 bytes.</param>
+    /// <param name="handler">The handler invoked with each request payload and its delivery context, returning the reply payload.</param>
+    /// <param name="context">The channel and operation bindings the specification declared.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A <see cref="ValueTask"/> representing the asynchronous operation.</returns>
+    ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        in MessageContext context,
+        CancellationToken cancellationToken = default)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+    {
+        return SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(channelUtf8, handler, cancellationToken);
+    }
 }
 
 // End of file.

--- a/src/Corvus.Text.Json.AsyncApi/InstrumentedMessageTransport.cs
+++ b/src/Corvus.Text.Json.AsyncApi/InstrumentedMessageTransport.cs
@@ -694,6 +694,70 @@ public class InstrumentedMessageTransport : IMessageTransport
         };
     }
 
+    private Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> CreateInstrumentedReplyContextHandler<TRequest, TReply>(
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        string destination)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+    {
+        string processSpanName = "process " + destination;
+        return async (request, context, ct) =>
+        {
+            JsonElement headers = context.Headers;
+            using Activity? activity = StartProcessActivity(in headers, processSpanName, destination);
+            long startTimestamp = Stopwatch.GetTimestamp();
+            try
+            {
+                TReply reply = await handler(request, context, ct).ConfigureAwait(false);
+                RecordProcessed(destination);
+                return reply;
+            }
+            catch (Exception ex)
+            {
+                RecordError(activity, ex);
+                throw;
+            }
+            finally
+            {
+                RecordDuration(AsyncApiTelemetry.ProcessDuration, startTimestamp, "process", destination);
+            }
+        };
+    }
+
+    private ValueTask SubscribeReplyWithDeliveryContextCoreAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        CancellationToken cancellationToken)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+    {
+        // Only the context-capable nested wrappers call this, and Create constructs them only
+        // when the wrapped transport implements the capability, so the cast cannot fail.
+        string destination = Encoding.UTF8.GetString(channelUtf8.Span);
+        return ((IMessageDeliveryContextTransport)this.inner).SubscribeReplyWithDeliveryContextAsync(
+            channelUtf8,
+            CreateInstrumentedReplyContextHandler(handler, destination),
+            cancellationToken);
+    }
+
+    private ValueTask SubscribeReplyWithDeliveryContextCoreAsync<TRequest, TReply>(
+        ReadOnlyMemory<byte> channelUtf8,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+        in MessageContext context,
+        CancellationToken cancellationToken)
+        where TRequest : struct, IJsonElement<TRequest>
+        where TReply : struct, IJsonElement<TReply>
+    {
+        // The binding overload forwards to the wrapped transport's own overload so a transport
+        // that honors bindings still receives them through the instrumentation.
+        string destination = Encoding.UTF8.GetString(channelUtf8.Span);
+        return ((IMessageDeliveryContextTransport)this.inner).SubscribeReplyWithDeliveryContextAsync(
+            channelUtf8,
+            CreateInstrumentedReplyContextHandler(handler, destination),
+            in context,
+            cancellationToken);
+    }
+
     private void SetCommonTags(Activity? activity, string operationName, string destination)
     {
         if (activity is { IsAllDataRequested: true })
@@ -771,6 +835,25 @@ public class InstrumentedMessageTransport : IMessageTransport
             CancellationToken cancellationToken = default)
             where TPayload : struct, IJsonElement<TPayload>
             => this.SubscribeWithDeliveryContextCoreAsync(channelUtf8, handler, in context, cancellationToken);
+
+        /// <inheritdoc/>
+        public ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+            ReadOnlyMemory<byte> channelUtf8,
+            Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+            CancellationToken cancellationToken = default)
+            where TRequest : struct, IJsonElement<TRequest>
+            where TReply : struct, IJsonElement<TReply>
+            => this.SubscribeReplyWithDeliveryContextCoreAsync(channelUtf8, handler, cancellationToken);
+
+        /// <inheritdoc/>
+        public ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+            ReadOnlyMemory<byte> channelUtf8,
+            Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+            in MessageContext context,
+            CancellationToken cancellationToken = default)
+            where TRequest : struct, IJsonElement<TRequest>
+            where TReply : struct, IJsonElement<TReply>
+            => this.SubscribeReplyWithDeliveryContextCoreAsync(channelUtf8, handler, in context, cancellationToken);
     }
 
     /// <summary>
@@ -827,6 +910,25 @@ public class InstrumentedMessageTransport : IMessageTransport
             CancellationToken cancellationToken = default)
             where TPayload : struct, IJsonElement<TPayload>
             => this.SubscribeWithDeliveryContextCoreAsync(channelUtf8, handler, in context, cancellationToken);
+
+        /// <inheritdoc/>
+        public ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+            ReadOnlyMemory<byte> channelUtf8,
+            Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+            CancellationToken cancellationToken = default)
+            where TRequest : struct, IJsonElement<TRequest>
+            where TReply : struct, IJsonElement<TReply>
+            => this.SubscribeReplyWithDeliveryContextCoreAsync(channelUtf8, handler, cancellationToken);
+
+        /// <inheritdoc/>
+        public ValueTask SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>(
+            ReadOnlyMemory<byte> channelUtf8,
+            Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler,
+            in MessageContext context,
+            CancellationToken cancellationToken = default)
+            where TRequest : struct, IJsonElement<TRequest>
+            where TReply : struct, IJsonElement<TReply>
+            => this.SubscribeReplyWithDeliveryContextCoreAsync(channelUtf8, handler, in context, cancellationToken);
 
         /// <inheritdoc/>
         public ValueTask<bool> PingAsync(CancellationToken cancellationToken = default)

--- a/src/Corvus.Text.Json.AsyncApi/Internal/MessageHandler.cs
+++ b/src/Corvus.Text.Json.AsyncApi/Internal/MessageHandler.cs
@@ -103,4 +103,104 @@ public readonly struct MessageHandler<TPayload>
     }
 }
 
+/// <summary>
+/// Stores one responder subscription's legacy or delivery-context-aware callback without an
+/// adapter delegate on the delivery path — the request/reply counterpart of
+/// <see cref="MessageHandler{TPayload}"/>.
+/// </summary>
+/// <typeparam name="TRequest">The deserialized request payload type.</typeparam>
+/// <typeparam name="TReply">The reply payload type the handler returns.</typeparam>
+/// <remarks>
+/// This is infrastructure for <see cref="IMessageTransport"/> implementations.
+/// Application code should not use it directly.
+/// </remarks>
+public readonly struct MessageReplyHandler<TRequest, TReply>
+    where TRequest : struct, IJsonElement<TRequest>
+    where TReply : struct, IJsonElement<TReply>
+{
+    private readonly Func<TRequest, Corvus.Text.Json.JsonElement, CancellationToken, ValueTask<TReply>>? legacyHandler;
+    private readonly Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>>? contextHandler;
+
+    private MessageReplyHandler(
+        Func<TRequest, Corvus.Text.Json.JsonElement, CancellationToken, ValueTask<TReply>>? legacyHandler,
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>>? contextHandler)
+    {
+        this.legacyHandler = legacyHandler;
+        this.contextHandler = contextHandler;
+    }
+
+    /// <summary>
+    /// Gets a value indicating whether the stored callback consumes a
+    /// <see cref="MessageDeliveryContext"/> (and therefore needs the transport's
+    /// native message on delivery).
+    /// </summary>
+    public bool UsesDeliveryContext => this.contextHandler is not null;
+
+    /// <summary>
+    /// Creates a handler wrapping a legacy (request and headers) callback.
+    /// </summary>
+    /// <param name="handler">The legacy callback.</param>
+    /// <returns>The wrapping handler.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="handler"/> is <see langword="null"/>.</exception>
+    public static MessageReplyHandler<TRequest, TReply> WithoutDeliveryContext(
+        Func<TRequest, Corvus.Text.Json.JsonElement, CancellationToken, ValueTask<TReply>> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        return new(handler, null);
+    }
+
+    /// <summary>
+    /// Creates a handler wrapping a delivery-context-aware callback.
+    /// </summary>
+    /// <param name="handler">The delivery-context-aware callback.</param>
+    /// <returns>The wrapping handler.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="handler"/> is <see langword="null"/>.</exception>
+    public static MessageReplyHandler<TRequest, TReply> WithDeliveryContext(
+        Func<TRequest, MessageDeliveryContext, CancellationToken, ValueTask<TReply>> handler)
+    {
+        ArgumentNullException.ThrowIfNull(handler);
+        return new(null, handler);
+    }
+
+    /// <summary>
+    /// Invokes the stored callback for one delivered request, returning the reply payload.
+    /// </summary>
+    /// <param name="request">The deserialized request payload.</param>
+    /// <param name="channelUtf8">The channel the request arrived on, as UTF-8 bytes.</param>
+    /// <param name="headers">The request headers.</param>
+    /// <param name="nativeMessage">The transport's native message representation, when one
+    /// exists; ignored (and safely <see langword="null"/>) when the callback does not consume
+    /// delivery context.</param>
+    /// <param name="cancellationToken">A cancellation token.</param>
+    /// <returns>A task producing the reply payload once the callback has run.</returns>
+    /// <exception cref="InvalidOperationException">This instance is <see langword="default"/> and
+    /// holds no callback. Create instances with <see cref="WithoutDeliveryContext"/> or
+    /// <see cref="WithDeliveryContext"/>.</exception>
+    public ValueTask<TReply> InvokeReply(
+        TRequest request,
+        ReadOnlyMemory<byte> channelUtf8,
+        Corvus.Text.Json.JsonElement headers,
+        object? nativeMessage,
+        CancellationToken cancellationToken)
+    {
+        if (this.contextHandler is null)
+        {
+            if (this.legacyHandler is null)
+            {
+                throw new InvalidOperationException(
+                    "This MessageReplyHandler holds no callback because it was default-constructed. Create instances with WithoutDeliveryContext or WithDeliveryContext.");
+            }
+
+            return this.legacyHandler(request, headers, cancellationToken);
+        }
+
+        return this.contextHandler(request, new MessageDeliveryContext
+        {
+            ChannelUtf8 = channelUtf8,
+            Headers = headers,
+            NativeMessage = nativeMessage,
+        }, cancellationToken);
+    }
+}
+
 // End of file.

--- a/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/AsyncApi30CodeGeneratorTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.CodeGeneration.Tests/AsyncApi30CodeGeneratorTests.cs
@@ -301,7 +301,7 @@ public class AsyncApi30CodeGeneratorTests
     }
 
     [TestMethod]
-    public void Generate_ResponderOperation_DoesNotEmitDeliveryContextVariants()
+    public void Generate_ResponderOperation_EmitsDeliveryContextVariants()
     {
         byte[] bytes = File.ReadAllBytes(Path.Combine("TestData", "receive-request-reply.json"));
         using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(bytes);
@@ -310,9 +310,29 @@ public class AsyncApi30CodeGeneratorTests
         var generator = new AsyncApi30CodeGenerator("Worker", new Dictionary<string, string>());
         IReadOnlyList<GeneratedFile> files = generator.Generate(root);
 
+        // IMessageDeliveryContextTransport exposes SubscribeReplyWithDeliveryContextAsync, so a
+        // responder now gets a delivery-context variant exactly as a plain consumer does.
+        GeneratedFile contextHandler = files.Single(f => f.FileName.Contains("WithDeliveryContextHandler"));
+        GeneratedFile contextConsumer = files.Single(f => f.FileName.Contains("WithDeliveryContextConsumer"));
+
+        StringAssert.Contains(contextHandler.Content, "MessageDeliveryContext context");
+        StringAssert.Contains(
+            contextHandler.Content,
+            "ValueTask<",
+            "A responder's delivery-context handler still returns the reply payload, not void.");
+        StringAssert.Contains(contextConsumer.Content, "IMessageDeliveryContextTransport transport");
+        StringAssert.Contains(contextConsumer.Content, "SubscribeReplyWithDeliveryContextAsync");
+
+        GeneratedFile legacyHandler = files.Single(f => f.FileName.EndsWith("Handler.cs", StringComparison.Ordinal) && !f.FileName.Contains("WithDeliveryContext"));
+        GeneratedFile legacyConsumer = files.Single(f => f.FileName.EndsWith("Consumer.cs", StringComparison.Ordinal) && !f.FileName.Contains("WithDeliveryContext"));
+        Assert.IsFalse(legacyHandler.Content.Contains("MessageDeliveryContext", StringComparison.Ordinal));
+        StringAssert.Contains(
+            legacyConsumer.Content,
+            "SubscribeReplyAsync",
+            "The legacy responder consumer must still call the non-context reply subscribe overload.");
         Assert.IsFalse(
-            files.Any(f => f.FileName.Contains("WithDeliveryContext")),
-            "A responder operation never surfaces a MessageDeliveryContext, so no WithDeliveryContext variants should be emitted for it.");
+            legacyConsumer.Content.Contains("SubscribeReplyWithDeliveryContextAsync", StringComparison.Ordinal),
+            "The legacy responder consumer must not reference the delivery-context subscribe overload.");
     }
 
     [TestMethod]

--- a/tests/Corvus.Text.Json.AsyncApi.Runtime.Tests/InMemoryMessageTransportTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.Runtime.Tests/InMemoryMessageTransportTests.cs
@@ -316,6 +316,38 @@ public class InMemoryMessageTransportTests
     }
 
     [TestMethod]
+    public async Task SubscribeReplyWithDeliveryContextAsync_RespondsToRequestAndProvidesDeliveryMetadata()
+    {
+        using JsonWorkspace workspace = JsonWorkspace.CreateUnrented();
+        await using Testing.InMemoryMessageTransport transport = new();
+
+        string? deliveredChannel = null;
+
+        // Same responder shape as SubscribeReplyAsync_RespondsToRequestInProcess, but registered
+        // with the delivery-context overload: the handler receives MessageDeliveryContext instead
+        // of headers directly, and still produces the reply RequestAsync waits for.
+        await transport.SubscribeReplyWithDeliveryContextAsync<JsonElement, JsonElement>(
+            "rpc/double-context"u8.ToArray(),
+            (request, deliveryContext, _) =>
+            {
+                deliveredChannel = Encoding.UTF8.GetString(deliveryContext.ChannelUtf8.Span);
+                int n = request.GetProperty("n"u8).GetInt32();
+                JsonElement reply = JsonElement.ParseValue(Encoding.UTF8.GetBytes($$"""{"result":{{n * 2}}}"""));
+                return ValueTask.FromResult(reply);
+            });
+
+        JsonElement request = JsonElement.ParseValue("""{"n":21}"""u8);
+        (JsonElement reply, JsonElement _) = await transport.RequestAsync<JsonElement, JsonElement>(
+            "rpc/double-context"u8.ToArray(),
+            "rpc/double-context/replies"u8.ToArray(),
+            request,
+            "corr-rr-context"u8.ToArray(), workspace);
+
+        Assert.AreEqual(42, reply.GetProperty("result"u8).GetInt32());
+        Assert.AreEqual("rpc/double-context", deliveredChannel);
+    }
+
+    [TestMethod]
     public async Task ReceiveOneAndReplyAsync_RepliesToOneRequestThenUnsubscribes()
     {
         using JsonWorkspace workspace = JsonWorkspace.CreateUnrented();

--- a/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/AmqpTransportTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/AmqpTransportTests.cs
@@ -1007,6 +1007,76 @@ public class AmqpTransportTests
     }
 
     [TestMethod]
+    public async Task RequestReplyResponderWithDeliveryContextRoundTrip()
+    {
+        // The delivery-context counterpart of RequestReplyResponderRoundTrip: the responder is
+        // registered with SubscribeReplyWithDeliveryContextAsync instead of SubscribeReplyAsync,
+        // so its handler receives MessageDeliveryContext (channel and native message) alongside
+        // the request, in addition to still producing the reply the requester's RequestAsync waits
+        // for.
+        using JsonWorkspace workspace = JsonWorkspace.CreateUnrented();
+
+        static AmqpTransportOptions Options() => new()
+        {
+            ConnectionUri = AmqpFixture.ConnectionUri,
+            ExchangeName = "corvus.test.responder-context",
+            ExchangeType = "topic",
+            ExchangeDurable = false,
+            ConsumerTagPrefix = "corvus-responder-context",
+        };
+
+        AmqpMessageTransport responder = await AmqpMessageTransport.CreateAsync(Options());
+        AmqpMessageTransport requester = await AmqpMessageTransport.CreateAsync(Options());
+
+        try
+        {
+            ReadOnlyMemory<byte> requestChannel = "amqp.test.responder-context.request"u8.ToArray();
+            ReadOnlyMemory<byte> replyChannel = "amqp.test.responder-context.reply"u8.ToArray();
+            byte[] correlationId = "amqp-responder-context-001"u8.ToArray();
+
+            string? deliveredChannel = null;
+            object? nativeMessage = null;
+
+            await responder.SubscribeReplyWithDeliveryContextAsync<JsonElement, JsonElement>(
+                requestChannel,
+                (request, deliveryContext, ct) =>
+                {
+                    deliveredChannel = Encoding.UTF8.GetString(deliveryContext.ChannelUtf8.Span);
+                    nativeMessage = deliveryContext.NativeMessage;
+
+                    int value = request.GetProperty("value"u8).GetInt32();
+
+                    ParsedJsonDocument<JsonElement> replyDoc = ParsedJsonDocument<JsonElement>.Parse(
+                        Encoding.UTF8.GetBytes($$"""{"doubled":{{value * 2}}}"""));
+                    workspace.TakeOwnership(replyDoc);
+                    return ValueTask.FromResult(replyDoc.RootElement);
+                });
+
+            await Task.Delay(500);
+
+            using ParsedJsonDocument<JsonElement> requestDoc = ParsedJsonDocument<JsonElement>.Parse("""{"value":21}"""u8.ToArray());
+            (JsonElement replyPayload, _) = await requester.RequestAsync<JsonElement, JsonElement>(
+                requestChannel,
+                replyChannel,
+                requestDoc.RootElement,
+                correlationId,
+                workspace);
+
+            Assert.AreEqual(JsonValueKind.Object, replyPayload.ValueKind);
+            Assert.AreEqual(42, replyPayload.GetProperty("doubled"u8).GetInt32());
+            Assert.AreEqual("amqp.test.responder-context.request", deliveredChannel);
+            Assert.IsNotNull(nativeMessage);
+
+            await responder.UnsubscribeAsync(requestChannel);
+        }
+        finally
+        {
+            await responder.DisposeAsync();
+            await requester.DisposeAsync();
+        }
+    }
+
+    [TestMethod]
     public async Task ReceiveOneAndReplyRoundTrip()
     {
         // Owns the reply document the handler builds so it outlives the handler yet is still cleaned up

--- a/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/AzureServiceBusTransportTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/AzureServiceBusTransportTests.cs
@@ -168,6 +168,76 @@ public class AzureServiceBusTransportTests
     }
 
     [TestMethod]
+    public async Task RequestReplyResponderWithDeliveryContextRoundTrip()
+    {
+        // The delivery-context counterpart of RequestReplyResponderRoundTrip: the responder is
+        // registered with SubscribeReplyWithDeliveryContextAsync instead of SubscribeReplyAsync,
+        // so its handler receives MessageDeliveryContext (channel and native message) alongside
+        // the request, in addition to still producing the reply the requester's RequestAsync waits
+        // for.
+        using JsonWorkspace workspace = JsonWorkspace.CreateUnrented();
+
+        AzureServiceBusMessageTransport responderTransport = await AzureServiceBusMessageTransport.CreateAsync(new AzureServiceBusTransportOptions
+        {
+            ConnectionString = AzureServiceBusFixture.ConnectionString,
+            QueueName = "test-queue",
+        });
+
+        AzureServiceBusMessageTransport requesterTransport = await AzureServiceBusMessageTransport.CreateAsync(new AzureServiceBusTransportOptions
+        {
+            ConnectionString = AzureServiceBusFixture.ConnectionString,
+            QueueName = "test-queue",
+        });
+
+        try
+        {
+            ReadOnlyMemory<byte> requestChannel = "test-queue"u8.ToArray();
+            ReadOnlyMemory<byte> replyChannel = "test-reply-queue"u8.ToArray();
+
+            string? deliveredChannel = null;
+            object? nativeMessage = null;
+
+            await responderTransport.SubscribeReplyWithDeliveryContextAsync<JsonElement, JsonElement>(
+                requestChannel,
+                (request, deliveryContext, ct) =>
+                {
+                    deliveredChannel = Encoding.UTF8.GetString(deliveryContext.ChannelUtf8.Span);
+                    nativeMessage = deliveryContext.NativeMessage;
+
+                    int value = request.GetProperty("value"u8).GetInt32();
+                    ParsedJsonDocument<JsonElement> replyDoc = ParsedJsonDocument<JsonElement>.Parse(
+                        Encoding.UTF8.GetBytes($$"""{"result":{{value * 2}}}"""));
+                    workspace.TakeOwnership(replyDoc);
+                    return ValueTask.FromResult(replyDoc.RootElement);
+                });
+
+            await Task.Delay(500);
+
+            byte[] correlationId = "asb-responder-context-roundtrip-001"u8.ToArray();
+            using ParsedJsonDocument<JsonElement> requestDoc = ParsedJsonDocument<JsonElement>.Parse("""{"value":21}"""u8.ToArray());
+
+            (JsonElement replyPayload, JsonElement replyHeaders) = await requesterTransport.RequestAsync<JsonElement, JsonElement>(
+                requestChannel,
+                replyChannel,
+                requestDoc.RootElement,
+                correlationId,
+                workspace);
+
+            Assert.AreEqual(JsonValueKind.Object, replyPayload.ValueKind);
+            Assert.AreEqual(42, replyPayload.GetProperty("result"u8).GetInt32());
+            Assert.AreEqual("test-queue", deliveredChannel);
+            Assert.IsNotNull(nativeMessage);
+
+            await responderTransport.UnsubscribeAsync(requestChannel);
+        }
+        finally
+        {
+            await responderTransport.DisposeAsync();
+            await requesterTransport.DisposeAsync();
+        }
+    }
+
+    [TestMethod]
     public async Task ReceiveOneAndReplyRoundTrip()
     {
         // The reply the handler builds must outlive the handler (the transport serialises it after the handler

--- a/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/KafkaTransportTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/KafkaTransportTests.cs
@@ -924,6 +924,84 @@ public class KafkaTransportTests
     }
 
     [TestMethod]
+    public async Task RequestReplyResponderWithDeliveryContextRoundTrip()
+    {
+        // The delivery-context counterpart of RequestReplyResponderRoundTrip: the responder is
+        // registered with SubscribeReplyWithDeliveryContextAsync instead of SubscribeReplyAsync,
+        // so its handler receives MessageDeliveryContext (channel and native message) alongside
+        // the request, in addition to still producing the reply the requester's RequestAsync waits
+        // for.
+        using JsonWorkspace workspace = JsonWorkspace.CreateUnrented();
+
+        string topicSuffix = Guid.NewGuid().ToString("N")[..8];
+        string requestTopic = $"kafka-resp-ctx-req-{topicSuffix}";
+        string replyTopic = $"kafka-resp-ctx-rep-{topicSuffix}";
+        await KafkaFixture.CreateTopicAsync(requestTopic);
+        await KafkaFixture.CreateTopicAsync(replyTopic);
+
+        ReadOnlyMemory<byte> requestChannel = Encoding.UTF8.GetBytes(requestTopic);
+        ReadOnlyMemory<byte> replyChannel = Encoding.UTF8.GetBytes(replyTopic);
+
+        KafkaMessageTransport responderTransport = new(new KafkaTransportOptions
+        {
+            BootstrapServers = KafkaFixture.BootstrapServers,
+            GroupId = "corvus-responder-context-group-" + topicSuffix,
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            ConsumerConfig = new ConsumerConfig { TopicMetadataRefreshIntervalMs = 1000 },
+        });
+
+        string? deliveredChannel = null;
+        object? nativeMessage = null;
+
+        await responderTransport.SubscribeReplyWithDeliveryContextAsync<JsonElement, JsonElement>(
+            requestChannel,
+            (request, deliveryContext, ct) =>
+            {
+                deliveredChannel = Encoding.UTF8.GetString(deliveryContext.ChannelUtf8.Span);
+                nativeMessage = deliveryContext.NativeMessage;
+
+                int n = request.GetProperty("n"u8).GetInt32();
+                byte[] replyJson = Encoding.UTF8.GetBytes($$"""{"doubled":{{n * 2}}}""");
+
+                ParsedJsonDocument<JsonElement> replyDoc = ParsedJsonDocument<JsonElement>.Parse(replyJson);
+                workspace.TakeOwnership(replyDoc);
+                return ValueTask.FromResult(replyDoc.RootElement);
+            });
+
+        // Give the responder time to start (group coordination + partition assignment).
+        await Task.Delay(5000);
+
+        KafkaMessageTransport clientTransport = new(new KafkaTransportOptions
+        {
+            BootstrapServers = KafkaFixture.BootstrapServers,
+            GroupId = "corvus-responder-context-client-" + topicSuffix,
+            AutoOffsetReset = AutoOffsetReset.Earliest,
+            ConsumerConfig = new ConsumerConfig { TopicMetadataRefreshIntervalMs = 1000 },
+        });
+
+        using ParsedJsonDocument<JsonElement> requestDoc = ParsedJsonDocument<JsonElement>.Parse("""{"n":21}"""u8.ToArray());
+        byte[] correlationId = Guid.NewGuid().ToString("D").Substring(0, 36).Select(c => (byte)c).ToArray();
+
+        using CancellationTokenSource requestCts = new(TimeSpan.FromSeconds(30));
+        (JsonElement replyPayloadElement, JsonElement replyHeaders) = await clientTransport.RequestAsync<JsonElement, JsonElement>(
+            requestChannel,
+            replyChannel,
+            requestDoc.RootElement,
+            correlationId,
+            workspace,
+            cancellationToken: requestCts.Token);
+
+        Assert.AreEqual(JsonValueKind.Object, replyPayloadElement.ValueKind);
+        Assert.AreEqual(42, replyPayloadElement.GetProperty("doubled"u8).GetInt32());
+        Assert.AreEqual(requestTopic, deliveredChannel);
+        Assert.IsNotNull(nativeMessage);
+
+        await responderTransport.UnsubscribeAsync(requestChannel);
+        await responderTransport.DisposeAsync();
+        await clientTransport.DisposeAsync();
+    }
+
+    [TestMethod]
     public async Task ReceiveOneAndReplyRoundTrip()
     {
         // Owns the reply document the handler builds so it outlives the handler yet is still cleaned up

--- a/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/MqttTransportTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/MqttTransportTests.cs
@@ -995,6 +995,73 @@ public class MqttTransportTests
     }
 
     [TestMethod]
+    public async Task RequestReplyResponderWithDeliveryContextRoundTrip()
+    {
+        // The delivery-context counterpart of RequestReplyResponderRoundTrip: the responder is
+        // registered with SubscribeReplyWithDeliveryContextAsync instead of SubscribeReplyAsync,
+        // so its handler receives MessageDeliveryContext (channel and native message) alongside
+        // the request, in addition to still producing the reply the requester's RequestAsync waits
+        // for.
+        using JsonWorkspace workspace = JsonWorkspace.CreateUnrented();
+
+        MqttMessageTransport responderTransport = await MqttMessageTransport.CreateAsync(new MqttTransportOptions
+        {
+            Host = MqttFixture.Host,
+            Port = MqttFixture.Port,
+            ClientId = "corvus-responder-context-" + Guid.NewGuid().ToString("N")[..8],
+        });
+
+        MqttMessageTransport requesterTransport = await MqttMessageTransport.CreateAsync(new MqttTransportOptions
+        {
+            Host = MqttFixture.Host,
+            Port = MqttFixture.Port,
+            ClientId = "corvus-requester-context-" + Guid.NewGuid().ToString("N")[..8],
+        });
+
+        ReadOnlyMemory<byte> requestChannel = "mqtt/test/reqreply-context/request"u8.ToArray();
+        ReadOnlyMemory<byte> replyChannel = "mqtt/test/reqreply-context/reply"u8.ToArray();
+
+        string? deliveredChannel = null;
+        object? nativeMessage = null;
+
+        await responderTransport.SubscribeReplyWithDeliveryContextAsync<JsonElement, JsonElement>(
+            requestChannel,
+            (request, deliveryContext, ct) =>
+            {
+                deliveredChannel = Encoding.UTF8.GetString(deliveryContext.ChannelUtf8.Span);
+                nativeMessage = deliveryContext.NativeMessage;
+
+                int input = request.GetProperty("value"u8).GetInt32();
+                byte[] replyJson = Encoding.UTF8.GetBytes($$"""{"result":{{input * 2}}}""");
+
+                ParsedJsonDocument<JsonElement> replyDoc = ParsedJsonDocument<JsonElement>.Parse(replyJson);
+                workspace.TakeOwnership(replyDoc);
+                return ValueTask.FromResult(replyDoc.RootElement);
+            });
+
+        await Task.Delay(500);
+
+        byte[] correlationId = "mqtt-context-roundtrip-1"u8.ToArray();
+        using ParsedJsonDocument<JsonElement> requestDoc = ParsedJsonDocument<JsonElement>.Parse("""{"value":21}"""u8.ToArray());
+
+        (JsonElement replyPayload, JsonElement replyHeaders) = await requesterTransport.RequestAsync<JsonElement, JsonElement>(
+            requestChannel,
+            replyChannel,
+            requestDoc.RootElement,
+            correlationId,
+            workspace);
+
+        Assert.AreEqual(JsonValueKind.Object, replyPayload.ValueKind);
+        Assert.AreEqual(42, replyPayload.GetProperty("result"u8).GetInt32());
+        Assert.AreEqual("mqtt/test/reqreply-context/request", deliveredChannel);
+        Assert.IsNotNull(nativeMessage);
+
+        await requesterTransport.DisposeAsync();
+        await responderTransport.UnsubscribeAsync(requestChannel);
+        await responderTransport.DisposeAsync();
+    }
+
+    [TestMethod]
     public async Task ReceiveOneAndReplyRoundTrip()
     {
         // Owns the reply document the handler builds so it outlives the handler yet is still cleaned up

--- a/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/NatsTransportTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/NatsTransportTests.cs
@@ -448,6 +448,66 @@ public class NatsTransportTests
     }
 
     [TestMethod]
+    public async Task RequestReplyResponderWithDeliveryContextRoundTrip()
+    {
+        // The delivery-context counterpart of RequestReplyResponderRoundTrip: the responder is
+        // registered with SubscribeReplyWithDeliveryContextAsync instead of SubscribeReplyAsync,
+        // so its handler receives MessageDeliveryContext (channel and native message) alongside
+        // the request, in addition to still producing the reply the requester's RequestAsync waits
+        // for — proving the delivery-context capability actually reaches a real broker responder,
+        // not just the plain-consumer path SubscribeWithDeliveryContextAsync_ProvidesDeliveryMetadata
+        // already covers.
+        using JsonWorkspace workspace = JsonWorkspace.CreateUnrented();
+
+        ReadOnlyMemory<byte> requestChannel = "test.responder-context-roundtrip"u8.ToArray();
+        ReadOnlyMemory<byte> replyChannel = "test.responder-context-roundtrip-reply"u8.ToArray();
+
+        await using NatsMessageTransport responder = await NatsMessageTransport.CreateAsync(new NatsTransportOptions
+        {
+            Url = NatsFixture.ConnectionString,
+        });
+
+        string? deliveredChannel = null;
+        object? nativeMessage = null;
+
+        await responder.SubscribeReplyWithDeliveryContextAsync<JsonElement, JsonElement>(
+            requestChannel,
+            (request, deliveryContext, ct) =>
+            {
+                deliveredChannel = Encoding.UTF8.GetString(deliveryContext.ChannelUtf8.Span);
+                nativeMessage = deliveryContext.NativeMessage;
+
+                int value = request.GetProperty("value"u8).GetInt32();
+                byte[] replyJson = Encoding.UTF8.GetBytes($$"""{"doubled":{{value * 2}}}""");
+
+                // The reply document is handed to the test's workspace so it outlives the handler (the transport
+                // serialises the returned element after the handler returns) and is disposed with the workspace.
+                ParsedJsonDocument<JsonElement> replyDoc = ParsedJsonDocument<JsonElement>.Parse(replyJson);
+                workspace.TakeOwnership(replyDoc);
+                return ValueTask.FromResult(replyDoc.RootElement);
+            });
+
+        await Task.Delay(500);
+
+        using ParsedJsonDocument<JsonElement> requestDoc = ParsedJsonDocument<JsonElement>.Parse("""{"value":21}"""u8.ToArray());
+        byte[] correlationId = "responder-context-corr-001"u8.ToArray();
+
+        (JsonElement replyPayload, JsonElement replyHeaders) = await s_transport.RequestAsync<JsonElement, JsonElement>(
+            requestChannel,
+            replyChannel,
+            requestDoc.RootElement,
+            correlationId,
+            workspace);
+
+        Assert.AreEqual(JsonValueKind.Object, replyPayload.ValueKind);
+        Assert.AreEqual(42, replyPayload.GetProperty("doubled"u8).GetInt32());
+        Assert.AreEqual("test.responder-context-roundtrip", deliveredChannel);
+        Assert.IsNotNull(nativeMessage);
+
+        await responder.UnsubscribeAsync(requestChannel);
+    }
+
+    [TestMethod]
     public async Task ReceiveOneAndReplyRoundTrip()
     {
         // Owns the reply document the handler builds so it outlives the handler yet is still cleaned up

--- a/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/WebSocketTransportTests.cs
+++ b/tests/Corvus.Text.Json.AsyncApi.Transport.IntegrationTests/WebSocketTransportTests.cs
@@ -862,6 +862,73 @@ public class WebSocketTransportTests
     }
 
     [TestMethod]
+    public async Task RequestReplyResponderWithDeliveryContextRoundTrip()
+    {
+        // The delivery-context counterpart of RequestReplyResponderRoundTrip: the responder is
+        // registered with SubscribeReplyWithDeliveryContextAsync instead of SubscribeReplyAsync,
+        // so its handler receives MessageDeliveryContext (channel) alongside the request, in
+        // addition to still producing the reply the requester's RequestAsync waits for.
+        // WebSocket has no native broker message representation — NativeMessage is always null
+        // here, exactly as it is for the plain SubscribeWithDeliveryContextAsync_ProvidesDeliveryMetadata
+        // path above, so this test asserts on the channel only.
+        using JsonWorkspace workspace = JsonWorkspace.CreateUnrented();
+
+        WebSocketMessageTransport responderTransport = await WebSocketMessageTransport.CreateAsync(new WebSocketTransportOptions
+        {
+            ServerUri = WebSocketFixture.ServerUri,
+        });
+
+        WebSocketMessageTransport requesterTransport = await WebSocketMessageTransport.CreateAsync(new WebSocketTransportOptions
+        {
+            ServerUri = WebSocketFixture.ServerUri,
+        });
+
+        ReadOnlyMemory<byte> requestChannel = "ws/test/reqreply-responder-context/request"u8.ToArray();
+        ReadOnlyMemory<byte> replyChannel = "ws/test/reqreply-responder-context/reply"u8.ToArray();
+
+        // The requester must be subscribed to the reply channel so the relay forwards the reply to it
+        // (correlationId match takes priority over the dummy handler).
+        await requesterTransport.SubscribeAsync<JsonElement>(
+            replyChannel,
+            (_, _, _) => ValueTask.CompletedTask);
+
+        string? deliveredChannel = null;
+
+        await responderTransport.SubscribeReplyWithDeliveryContextAsync<JsonElement, JsonElement>(
+            requestChannel,
+            (request, deliveryContext, ct) =>
+            {
+                deliveredChannel = Encoding.UTF8.GetString(deliveryContext.ChannelUtf8.Span);
+
+                int input = request.GetProperty("value"u8).GetInt32();
+                byte[] replyJson = Encoding.UTF8.GetBytes($$"""{"result":{{input + 1}}}""");
+
+                ParsedJsonDocument<JsonElement> replyDoc = ParsedJsonDocument<JsonElement>.Parse(replyJson);
+                workspace.TakeOwnership(replyDoc);
+                return ValueTask.FromResult(replyDoc.RootElement);
+            });
+
+        await Task.Delay(500);
+
+        byte[] correlationId = "ws-responder-context-001"u8.ToArray();
+        using ParsedJsonDocument<JsonElement> requestDoc = ParsedJsonDocument<JsonElement>.Parse("""{"value":41}"""u8.ToArray());
+
+        (JsonElement replyPayload, JsonElement replyHeaders) = await requesterTransport.RequestAsync<JsonElement, JsonElement>(
+            requestChannel,
+            replyChannel,
+            requestDoc.RootElement,
+            correlationId,
+            workspace);
+
+        Assert.AreEqual(JsonValueKind.Object, replyPayload.ValueKind);
+        Assert.AreEqual(42, replyPayload.GetProperty("result"u8).GetInt32());
+        Assert.AreEqual("ws/test/reqreply-responder-context/request", deliveredChannel);
+
+        await responderTransport.DisposeAsync();
+        await requesterTransport.DisposeAsync();
+    }
+
+    [TestMethod]
     public async Task ReceiveOneAndReplyRoundTrip()
     {
         // Owns the reply document the handler builds so it outlives the handler yet is still cleaned up


### PR DESCRIPTION
## Summary

The message-delivery-context feature (5.4.0) covers plain consumers but explicitly excludes
request/reply responders — `IMessageDeliveryContextTransport.SubscribeWithDeliveryContextAsync`
has no counterpart for `IMessageTransport.SubscribeReplyAsync`, so a responder's handler has no
way to see the delivery context (channel, headers, native broker message) that a plain consumer's
does. The code generator explicitly skips emitting `WithDeliveryContext` variants for responder
operations for exactly this reason.

This PR adds that missing piece:

- `IMessageDeliveryContextTransport.SubscribeReplyWithDeliveryContextAsync<TRequest, TReply>` —
  the delivery-context counterpart of `SubscribeReplyAsync`, with the same two-overload shape
  (plain, and `in MessageContext` for binding-aware transports) and the same opt-in-with-throwing-
  default pattern `SubscribeReplyAsync` itself already uses.
- Implemented on every transport that already implements `IMessageDeliveryContextTransport`: NATS,
  Kafka, AMQP, MQTT, WebSocket, Azure Service Bus, and the in-memory testing transport.
- `InstrumentedMessageTransport` forwards the new capability through both context-carrying wrapper
  variants, so tracing/metrics wrapping doesn't silently downgrade a transport's support for it.
- The code generator now emits `WithDeliveryContext` variants for responder operations too — the
  `!IsResponderOperation(op)` guard that skipped them is removed, `EmitConsumer`'s subscribe-call
  and `HandleMessageAsync` emission both branch on `withDeliveryContext` for the responder path the
  same way they already do for plain consumers. `EmitConsumerHandler` needed no changes — it
  already combined the two correctly, it just was never invoked with both flags together before.

## Usage

Given a receive operation that declares a `reply` — the AsyncAPI shape a responder generates from
(`processCalculation` in this example, receiving on `calc/requests` and replying on the channel its
`reply` points to) — the generator now also emits a delivery-context handler interface:

```csharp
// I{Operation}WithDeliveryContextHandler.cs (generated)
public interface IProcessCalculationWithDeliveryContextHandler
{
    /// <summary>
    /// Handles a <c>CalculateRequest</c> message and returns the reply payload.
    /// </summary>
    ValueTask<Corvus.Text.Json.JsonElement> HandleCalculateRequestAsync(
        Corvus.Text.Json.JsonElement payload,
        MessageDeliveryContext context,
        CancellationToken cancellationToken = default);
}
```

Same shape as the existing `IProcessCalculationHandler`, just with `MessageDeliveryContext context`
added and no separate `headers` parameter (it's `context.Headers`). Implement it exactly like a
plain delivery-context handler, except it still returns the reply payload:

```csharp
public sealed class ProcessCalculationHandler : IProcessCalculationWithDeliveryContextHandler
{
    public ValueTask<JsonElement> HandleCalculateRequestAsync(
        JsonElement payload,
        MessageDeliveryContext context,
        CancellationToken cancellationToken = default)
    {
        // context.ChannelUtf8, context.Headers, context.NativeMessage — e.g. cast NativeMessage
        // to the broker's native message type (NatsMsg<T>, BasicDeliverEventArgs, etc.) for
        // anything the AsyncAPI contract doesn't surface, same as a plain consumer would.
        double left = payload.GetProperty("left"u8).GetDouble();
        double right = payload.GetProperty("right"u8).GetDouble();
        return ValueTask.FromResult(BuildReply(left + right));
    }
}
```

The generated consumer wires it up through the new transport method automatically — nothing to
call directly unless you're driving the raw transport API yourself:

```csharp
// ProcessCalculationWithDeliveryContextConsumer.cs (generated) — the relevant line:
await this.transport.SubscribeReplyWithDeliveryContextAsync<JsonElement, JsonElement>(
    ChannelAddressUtf8, this.HandleMessageAsync, cancellationToken).ConfigureAwait(false);
```

And for anyone using a transport's raw API directly instead of generated consumers (`InMemoryMessageTransport`
here, but identical shape on every broker transport):

```csharp
await transport.SubscribeReplyWithDeliveryContextAsync<JsonElement, JsonElement>(
    "rpc/double"u8.ToArray(),
    (request, deliveryContext, ct) =>
    {
        int n = request.GetProperty("n"u8).GetInt32();
        JsonElement reply = JsonElement.ParseValue(
            Encoding.UTF8.GetBytes($$"""{"result":{{n * 2}}}"""));
        return ValueTask.FromResult(reply);
    });
```

## Design notes

- **Allocation discipline preserved.** The plain (non-context) `SubscribeReplyAsync` path is
  untouched — none of these changes touch it. For the shared internal handler-dispatch code (NATS,
  Kafka, AMQP, MQTT), the new `MessageReplyHandler<TRequest, TReply>` mirrors the existing
  `MessageHandler<TPayload>`: a readonly struct holding two delegate fields (only one ever set),
  so there's no adapter-closure allocation on the delivery path. The native message is only boxed
  into `MessageDeliveryContext.NativeMessage` when `handler.UsesDeliveryContext` is true (`object?
  nativeMessage = handler.UsesDeliveryContext ? msg : null;`), exactly matching how the existing
  plain delivery-context path already avoids boxing on its own legacy branch.
- **Scoped to transports that already support delivery context.** No new transport gained the
  base `IMessageDeliveryContextTransport` capability here — this only extends transports that
  already had it, onto the one code path they didn't cover.

## Testing

- `AsyncApi30CodeGeneratorTests`: replaced `Generate_ResponderOperation_DoesNotEmitDeliveryContextVariants`
  with `Generate_ResponderOperation_EmitsDeliveryContextVariants`, asserting the generated handler
  keeps its `ValueTask<TReply>` return type with `MessageDeliveryContext` added, the consumer calls
  `SubscribeReplyWithDeliveryContextAsync`, and the legacy sibling is unaffected.
- `InMemoryMessageTransportTests`: added `SubscribeReplyWithDeliveryContextAsync_RespondsToRequestAndProvidesDeliveryMetadata`,
  a fast in-process round-trip test mirroring the existing `SubscribeReplyAsync_RespondsToRequestInProcess`.
- Every broker transport's Testcontainers integration suite gained a
  `RequestReplyResponderWithDeliveryContextRoundTrip` test, mirroring that file's existing
  `RequestReplyResponderRoundTrip` but asserting the responder actually receives
  `MessageDeliveryContext` (channel, and native message where the transport has one — WebSocket has
  none, so that test asserts on channel only, matching its existing plain-delivery-context test).
  Ran all of them against real containers: `NatsTransportTests` 40/40 pass (full suite, not just the
  new test), and the six new `RequestReplyResponderWithDeliveryContextRoundTrip` tests across NATS,
  AMQP, Azure Service Bus, Kafka, MQTT, and WebSocket all pass against live brokers.
