### PR TITLE
Fix #944: suppress CS0618 at every V5 generated ParseValue call site

### DIFF
--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,13 @@
 # Version History
 
+## V5.4.3
+
+V5.4.3 completes the CS0618 suppression in generated code that V5.4.2 attempted. There are no new features and no breaking changes.
+
+### Bug fixes
+
+- **Generated code no longer warns CS0618 from the V5 source generator.** The V5.4.2 fix wrapped the `DefaultInstance` initializer in a CS0618 suppression in the V4 code generator only, so projects using `Corvus.Text.Json.SourceGenerator` still saw the warning. The V5 generator emits through its own layer, which had three places that call the generated type's obsolete `ParseValue` without a suppression: the `DefaultInstance` initializer for a schema whose `default` is an object or an array, and the static validation constants for object-valued and array-valued `const` and `enum` keywords. All three now wrap the emitted member in a localized CS0618 suppression, so a consumer project without a `NoWarn` for CS0618, including warnings-as-errors builds, compiles generated code cleanly. See [#944](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/944).
+
 ## V5.4.2
 
 V5.4.2 lets generated OpenAPI server stubs stream large multipart uploads, and multipart responses, without loading them into memory, giving the server the property the generated client already had. Streaming is opt-in and the buffered path stays the default indefinitely, so existing generated code is unaffected. The release also hardens the buffered path, adds retry safety for streamed request bodies, fixes two security defects found reviewing the streaming surface, and rolls in an unrelated base64 content validation fix. There are no breaking changes.

--- a/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Validation.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Validation.cs
@@ -952,17 +952,24 @@ internal static partial class CodeGenerationExtensions
 
         string memberName = generator.GetStaticReadOnlyFieldNameInScope(keyword.Keyword, suffix: index?.ToString());
 
+        // The constant is materialised by calling the generated type's own ParseValue, which
+        // is emitted with [Obsolete] to steer consumers towards pooled parsing. This use is
+        // intentional (a process-lifetime static cannot use a pooled parse, and the
+        // ParsedJsonDocument constants only represent scalar values), so suppress the
+        // obsolete diagnostic in the generated code.
         generator
             .AppendLineIndent("/// <summary>")
             .AppendLineIndent("/// A constant for the <c>", keyword.Keyword, "</c> keyword.")
             .AppendLineIndent("/// </summary>")
+            .AppendLineIndent("#pragma warning disable CS0618 // Type or member is obsolete")
             .AppendIndent("public static readonly ", typeDeclaration.DotnetTypeName(), " ")
             .Append(memberName)
             .Append(" = ")
             .Append(typeDeclaration.DotnetTypeName())
             .Append(".ParseValue(")
             .AppendSerializedArrayStringLiteral(value)
-            .AppendLine(");");
+            .AppendLine(");")
+            .AppendLineIndent("#pragma warning restore CS0618");
 
         return generator;
     }
@@ -978,17 +985,24 @@ internal static partial class CodeGenerationExtensions
 
         string memberName = generator.GetStaticReadOnlyFieldNameInScope(keyword.Keyword, suffix: index?.ToString());
 
+        // The constant is materialised by calling the generated type's own ParseValue, which
+        // is emitted with [Obsolete] to steer consumers towards pooled parsing. This use is
+        // intentional (a process-lifetime static cannot use a pooled parse, and the
+        // ParsedJsonDocument constants only represent scalar values), so suppress the
+        // obsolete diagnostic in the generated code.
         generator
             .AppendLineIndent("/// <summary>")
             .AppendLineIndent("/// A constant for the <c>", keyword.Keyword, "</c> keyword.")
             .AppendLineIndent("/// </summary>")
+            .AppendLineIndent("#pragma warning disable CS0618 // Type or member is obsolete")
             .AppendIndent("public static readonly ", typeDeclaration.DotnetTypeName(), " ")
             .Append(memberName)
             .Append(" = ")
             .Append(typeDeclaration.DotnetTypeName())
             .Append(".ParseValue(")
             .AppendSerializedObjectStringLiteral(value)
-            .AppendLine(");");
+            .AppendLine(");")
+            .AppendLineIndent("#pragma warning restore CS0618");
 
         return generator;
     }

--- a/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.cs
@@ -1346,6 +1346,17 @@ internal static partial class CodeGeneratorExtensions
             return generator;
         }
 
+        JsonValueKind defaultValueKind = typeDeclaration.DefaultValue().ValueKind;
+
+        // An object or array default is materialised by calling the generated type's own
+        // ParseValue, which is emitted with [Obsolete] to steer consumers towards pooled
+        // parsing. This use is intentional. A process-lifetime static cannot use the pooled
+        // ParsedJsonDocument<T>.Parse() (the holder would never be disposed), and the
+        // ParsedJsonDocument constants only represent scalar values. Suppress the obsolete
+        // diagnostic so consumers whose own projects do not already suppress CS0618 do not
+        // see a warning from generated code.
+        bool hasParseValueInitializer = defaultValueKind is JsonValueKind.Object or JsonValueKind.Array;
+
         generator
             .ReserveName("DefaultInstance")
             .AppendSeparatorLine()
@@ -1354,12 +1365,19 @@ internal static partial class CodeGeneratorExtensions
         /// <summary>
         /// Gets the default instance.
         /// </summary>
-        """)
+        """);
+
+        if (hasParseValueInitializer)
+        {
+            generator.AppendLineIndent("#pragma warning disable CS0618 // Type or member is obsolete");
+        }
+
+        generator
             .AppendIndent("public static ")
             .Append(typeDeclaration.DotnetTypeName())
             .Append(" DefaultInstance { get; }");
 
-        return typeDeclaration.DefaultValue().ValueKind switch
+        _ = defaultValueKind switch
         {
             JsonValueKind.Undefined => generator.AppendLine(),
             JsonValueKind.Null => generator
@@ -1389,6 +1407,13 @@ internal static partial class CodeGeneratorExtensions
                     .Append(SymbolDisplay.FormatLiteral(typeDeclaration.DefaultValue().GetRawText(), true))
                     .AppendLine("u8);"),
         };
+
+        if (hasParseValueInitializer)
+        {
+            generator.AppendLineIndent("#pragma warning restore CS0618");
+        }
+
+        return generator;
     }
 
     /// <summary>

--- a/tests/Corvus.Text.Json.CodeGenerator.Tests/InProcessGenerationTests.cs
+++ b/tests/Corvus.Text.Json.CodeGenerator.Tests/InProcessGenerationTests.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Corvus.Json;
 using Corvus.Json.CodeGeneration;
 using Corvus.Text.Json.CodeGeneration;
@@ -1514,6 +1515,146 @@ public class InProcessGenerationTests
                 string.Join(", ", fieldDeclarations.GroupBy(x => x).Where(g => g.Count() > 1).Select(g => g.Key)));
         }
     }
+
+    [TestMethod]
+    public async Task GenerateCode_ObjectDefault_DefaultInstanceIsWrappedInObsoleteSuppression()
+    {
+        // Regression test for issue #944. An object or array valued "default" materialises
+        // DefaultInstance by calling the generated type's own ParseValue, which is emitted with
+        // [Obsolete]. The initializer must sit inside a CS0618 suppression, or consumers whose
+        // projects do not carry a NoWarn for CS0618 see the warning in generated code.
+        string schemaContent = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "options": {
+                  "type": "object",
+                  "properties": {
+                    "name": { "type": "string" }
+                  },
+                  "default": {}
+                }
+              }
+            }
+            """;
+
+        IReadOnlyCollection<GeneratedCodeFile> files = await GenerateInProcessFromContent(schemaContent);
+        string allCode = NormalizeWhitespace(string.Join("\n", files.Select(f => f.FileContent)));
+
+        Assert.IsTrue(
+            Regex.IsMatch(allCode, @"#pragma warning disable CS0618[^#]*DefaultInstance \{ get; \} = \w+\.ParseValue\([^;]*; #pragma warning restore CS0618"),
+            "Expected the DefaultInstance ParseValue initializer to be wrapped in a CS0618 suppression.");
+    }
+
+    [TestMethod]
+    public async Task GenerateCode_ArrayDefault_DefaultInstanceIsWrappedInObsoleteSuppression()
+    {
+        // Regression test for issue #944, array-valued default.
+        string schemaContent = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "tags": {
+                  "type": "array",
+                  "items": { "type": "string" },
+                  "default": []
+                }
+              }
+            }
+            """;
+
+        IReadOnlyCollection<GeneratedCodeFile> files = await GenerateInProcessFromContent(schemaContent);
+        string allCode = NormalizeWhitespace(string.Join("\n", files.Select(f => f.FileContent)));
+
+        Assert.IsTrue(
+            Regex.IsMatch(allCode, @"#pragma warning disable CS0618[^#]*DefaultInstance \{ get; \} = \w+\.ParseValue\([^;]*; #pragma warning restore CS0618"),
+            "Expected the DefaultInstance ParseValue initializer to be wrapped in a CS0618 suppression.");
+    }
+
+    [TestMethod]
+    public async Task GenerateCode_StringDefault_DefaultInstanceUsesNonObsoleteConstant()
+    {
+        // A scalar default uses a ParsedJsonDocument constant, which is not obsolete, so no
+        // suppression is required around it.
+        string schemaContent = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "name": {
+                  "type": "string",
+                  "default": "anonymous"
+                }
+              }
+            }
+            """;
+
+        IReadOnlyCollection<GeneratedCodeFile> files = await GenerateInProcessFromContent(schemaContent);
+        string allCode = NormalizeWhitespace(string.Join("\n", files.Select(f => f.FileContent)));
+
+        Assert.IsTrue(
+            Regex.IsMatch(allCode, @"DefaultInstance \{ get; \} = ParsedJsonDocument<\w+>\.StringConstant\("),
+            "Expected the scalar DefaultInstance initializer to use ParsedJsonDocument.StringConstant.");
+        Assert.IsFalse(
+            Regex.IsMatch(allCode, @"#pragma warning disable CS0618[^#]*DefaultInstance"),
+            "Expected no CS0618 suppression around a scalar DefaultInstance initializer.");
+    }
+
+    [TestMethod]
+    public async Task GenerateCode_ObjectConst_ValidationConstantIsWrappedInObsoleteSuppression()
+    {
+        // Regression test for issue #944. Object-valued validation constants (const, enum)
+        // are materialised via the generated type's own obsolete ParseValue and must sit
+        // inside a CS0618 suppression.
+        string schemaContent = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "fixed": {
+                  "type": "object",
+                  "const": { "kind": "alpha" }
+                }
+              }
+            }
+            """;
+
+        IReadOnlyCollection<GeneratedCodeFile> files = await GenerateInProcessFromContent(schemaContent);
+        string allCode = NormalizeWhitespace(string.Join("\n", files.Select(f => f.FileContent)));
+
+        Assert.IsTrue(
+            Regex.IsMatch(allCode, @"#pragma warning disable CS0618[^#]*public static readonly \w+ \w+ = \w+\.ParseValue\([^;]*; #pragma warning restore CS0618"),
+            "Expected the object validation constant to be wrapped in a CS0618 suppression.");
+    }
+
+    [TestMethod]
+    public async Task GenerateCode_ArrayEnum_ValidationConstantsAreWrappedInObsoleteSuppression()
+    {
+        // Regression test for issue #944, array-valued enum constants.
+        string schemaContent = """
+            {
+              "$schema": "https://json-schema.org/draft/2020-12/schema",
+              "type": "object",
+              "properties": {
+                "pair": {
+                  "type": "array",
+                  "enum": [[1, 2], [3, 4]]
+                }
+              }
+            }
+            """;
+
+        IReadOnlyCollection<GeneratedCodeFile> files = await GenerateInProcessFromContent(schemaContent);
+        string allCode = NormalizeWhitespace(string.Join("\n", files.Select(f => f.FileContent)));
+
+        Assert.IsTrue(
+            Regex.IsMatch(allCode, @"#pragma warning disable CS0618[^#]*public static readonly \w+ \w+ = \w+\.ParseValue\([^;]*; #pragma warning restore CS0618"),
+            "Expected the array validation constants to be wrapped in a CS0618 suppression.");
+    }
+
+    private static string NormalizeWhitespace(string code) => Regex.Replace(code, @"\s+", " ");
 
     private static async Task<IReadOnlyCollection<GeneratedCodeFile>> GenerateInProcessFromContent(
         string schemaContent)


### PR DESCRIPTION
Fixes #944.

## Root cause

The #941 fix for #939 wrapped the `DefaultInstance` initializer in a CS0618 suppression in the V4 emission layer (`src-v4/Corvus.Json.CodeGeneration.CSharp`) only. `Corvus.Text.Json.SourceGenerator` emits through its own parallel layer in `src/Corvus.Text.Json.CodeGeneration/`, which still had three sites calling the generated type's obsolete `ParseValue` with no suppression:

1. the `DefaultInstance` fallback for object and array `default` values (`CodeGeneratorExtensions.cs`; scalar defaults use the non-obsolete `ParsedJsonDocument<T>` constants),
2. the array validation constant fields (`CodeGeneratorExtensions.Validation.cs`),
3. the object validation constant fields (`CodeGeneratorExtensions.Validation.cs`).

In-repo builds never see the warning because `src/Directory.Build.props` adds a repo-wide `NoWarn` for CS0618. External consumers without that `NoWarn` get CS0618 in generated files, which is build-breaking under warnings-as-errors. That is exactly what the reporter sees in 5.4.2.

## The fix

All three sites now wrap the emitted member in a localized `#pragma warning disable CS0618` / `restore` pair, mirroring the V4 fix. `ParseValue` remains the right call for these process-lifetime statics. A pooled `ParsedJsonDocument<T>.Parse()` would need disposal, and the `ParsedJsonDocument` constants only represent scalar values.

## Tests and verification

- Five string-emission regression tests in `tests/Corvus.Text.Json.CodeGenerator.Tests/InProcessGenerationTests.cs` (object default, array default, object const, array enum, and a negative test asserting scalar defaults need no suppression). Red-verified against the unfixed generator (4 failed), all pass with the fix. String-level assertions are required because the in-repo `NoWarn` masks any compile-based test.
- A consumer-style repro mirroring the reporter's setup (source generator as analyzer, `TreatWarningsAsErrors`, no `NoWarn`, schema with an object default, an object const, and an array enum) fails on the old generator and now compiles with 0 warnings, with all four obsolete initializers pragma-wrapped in the emitted files.
- Full solution build with 0 warnings; full filtered test suite 94,411 passed, 0 failed.
- Example recipes regeneration is a content no-op (no recipe schema exercises the affected patterns). The tracked benchmark generated output contains none of the affected patterns.

## Not included

The checked-in `src/Corvus.Text.Json.AsyncApi26|30/Generated` directories were last generated at 5.1 and drift substantially from the current generator (2,150 of 2,752 files differ on a scratch regeneration), so they are deliberately not regenerated here. They ship as compiled packages, so consumers see no CS0618 from them. They need a separate baseline refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fMWB9opbgcQ2JGzqxVYZA