### PR TITLE
Fix #942 and #937: JSON Pointer locations and direct numeric casts (5.5.0)

### DIFF
--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -20,4 +20,4 @@ branches:
     - feature
     - support
     - hotfix
-next-version: "5.4"
+next-version: "5.5"

--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,19 @@
 # Version History
 
+## V5.5.0
+
+V5.5.0 adds retrieval of an element's location as an RFC 6901 JSON Pointer, and completes the numeric conversion surface of generated types with direct casts to every numeric CLR type. The new cast operators change the failure mode of lossy numeric casts, which is a breaking change.
+
+### New features
+
+- **Retrieve an element's location as a JSON Pointer.** `JsonElement` (and every generated type, via `IJsonElement<T>` extension methods) can now report its location relative to its document root as an [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901) JSON Pointer. The zero-allocation `TryGetJsonPointer` overloads write UTF-8 bytes or UTF-16 characters into a caller-supplied buffer and return the written length; the `GetJsonPointer()` convenience method returns a string. The pointer is derived on demand by walking the document's metadata database from the element back to its ancestors, so parsing carries no extra bookkeeping. Property names are unescaped and then pointer-escaped (`~` as `~0`, `/` as `~1`), and the root element produces the empty pointer. This makes it straightforward to turn JSONPath query results into JSON Patch targets. See [#942](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/942).
+
+- **Direct casts from generated numeric types to every numeric CLR type.** Generated numeric types now emit explicit conversion operators for `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `ulong`, and `float` (plus `Int128`, `UInt128`, and `Half` on .NET), alongside the existing implicit `long`, `double`, and format-specific conversions. A cast such as `(ushort)value` previously routed through the implicit conversion to `long`, which tripped the IDE0221 analyzer; some casts, such as `(ulong)` on a plain integer type, were ambiguous and did not compile, and the .NET-only numeric types could not be cast to at all. Every numeric cast now binds a user-defined operator directly. See [#937](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/937).
+
+### Breaking changes
+
+- **Lossy numeric casts now throw `FormatException` instead of silently truncating.** Because casts to narrower types previously converted through `long`, an out-of-range value was silently wrapped: `(byte)` applied to a value of 300 produced 44. The new direct operators are range-checked, so an out-of-range or non-integral value now throws `FormatException`, matching the V4 behavior. Code that relied on silent truncation should cast to `(long)` explicitly and narrow with standard numeric casts. See [#937](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/937).
+
 ## V5.4.3
 
 V5.4.3 completes the CS0618 suppression in generated code that V5.4.2 attempted. There are no new features and no breaking changes.

--- a/benchmarks/Corvus.Text.Json.Benchmarks/JsonPointerBenchmarks/BenchmarkGetJsonPointer.cs
+++ b/benchmarks/Corvus.Text.Json.Benchmarks/JsonPointerBenchmarks/BenchmarkGetJsonPointer.cs
@@ -1,0 +1,57 @@
+// Derived from code licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licensed this code under the MIT license.
+
+using BenchmarkDotNet.Attributes;
+using Corvus.Text.Json;
+
+#pragma warning disable IDE0130 // Namespace does not match folder structure
+
+namespace JsonPointerBenchmarks;
+#pragma warning restore IDE0130 // Namespace does not match folder structure
+
+/// <summary>
+/// Measures deriving the JSON Pointer of an element relative to its document root by walking
+/// the metadata database to its ancestors. The span overloads must report 0 B allocated; the
+/// string overload allocates only the returned string.
+/// </summary>
+[MemoryDiagnoser]
+public class BenchmarkGetJsonPointer
+{
+    private static readonly byte[] Utf8Buffer = new byte[128];
+    private static readonly char[] CharBuffer = new char[128];
+
+    private ParsedJsonDocument<JsonElement>? document;
+    private JsonElement element;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        this.document = ParsedJsonDocument<JsonElement>.Parse(
+            """{"store":{"book":[{"title":"A","price":10},{"title":"B","price":5},{"title":"C","price":7},{"m~n":{"x/y":true},"title":"D","price":9}]}}""");
+        this.element = this.document.RootElement["store"u8]["book"u8][3]["m~n"]["x/y"];
+    }
+
+    [GlobalCleanup]
+    public void Cleanup()
+    {
+        this.document?.Dispose();
+    }
+
+    [Benchmark(Baseline = true)]
+    public bool TryGetJsonPointerUtf8()
+    {
+        return this.element.TryGetJsonPointer(Utf8Buffer, out _);
+    }
+
+    [Benchmark]
+    public bool TryGetJsonPointerChars()
+    {
+        return this.element.TryGetJsonPointer(CharBuffer, out _);
+    }
+
+    [Benchmark]
+    public string GetJsonPointerString()
+    {
+        return this.element.GetJsonPointer();
+    }
+}

--- a/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/GetPetsLimit.Mutable.cs
+++ b/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/GetPetsLimit.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct GetPetsLimit
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/GetPetsLimit.cs
+++ b/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/GetPetsLimit.cs
@@ -82,6 +82,42 @@ public readonly partial struct GetPetsLimit
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/JsonInt32.Mutable.cs
+++ b/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/JsonInt32.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct JsonInt32
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/JsonInt32.cs
+++ b/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/JsonInt32.cs
@@ -82,6 +82,42 @@ public readonly partial struct JsonInt32
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt32 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt32 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt32 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt32 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/JsonInt64.Mutable.cs
+++ b/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/JsonInt64.Mutable.cs
@@ -74,6 +74,45 @@ public readonly partial struct JsonInt64
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/JsonInt64.cs
+++ b/docs/ExampleRecipes/029-OpenApiClient/Generated/Models/JsonInt64.cs
@@ -79,6 +79,45 @@ public readonly partial struct JsonInt64
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt64 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt64 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator int(JsonInt64 value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt64 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt64 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/029-OpenApiClient/Generated/corvusjson-openapi.lock
+++ b/docs/ExampleRecipes/029-OpenApiClient/Generated/corvusjson-openapi.lock
@@ -1,6 +1,6 @@
 {
   "excludePaths": [],
-  "generatedAt": "2026-08-18T17:46:27.7754480\u002B00:00",
+  "generatedAt": "2026-08-27T13:13:24.9824471\u002B00:00",
   "generatedFiles": [
     "ListPetsRequest.cs",
     "ListPetsResponse.cs",
@@ -36,7 +36,7 @@
     "Models/GetPetsLimit.JsonSchema.cs",
     "Models/Corvus__GlobalDeclarations.cs"
   ],
-  "generatorVersion": "1.0.0\u002Ba58eb326f479e3c0b4939480be9299a319ddaf94",
+  "generatorVersion": "1.0.0\u002B68617b47ad47aa32242fdd24a3435adf50cbb969",
   "includePaths": [],
   "rootNamespace": "Petstore.Client",
   "specFileHash": "199092ff57f7e5d812b7164055f1065eb27cdc0a7be4303bea5e4edc070217d8",

--- a/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/GetPetsLimit.Mutable.cs
+++ b/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/GetPetsLimit.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct GetPetsLimit
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/GetPetsLimit.cs
+++ b/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/GetPetsLimit.cs
@@ -82,6 +82,42 @@ public readonly partial struct GetPetsLimit
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/JsonInt32.Mutable.cs
+++ b/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/JsonInt32.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct JsonInt32
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/JsonInt32.cs
+++ b/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/JsonInt32.cs
@@ -82,6 +82,42 @@ public readonly partial struct JsonInt32
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt32 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt32 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt32 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt32 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/JsonInt64.Mutable.cs
+++ b/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/JsonInt64.Mutable.cs
@@ -74,6 +74,45 @@ public readonly partial struct JsonInt64
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/JsonInt64.cs
+++ b/docs/ExampleRecipes/030-OpenApiServer/Generated/Models/JsonInt64.cs
@@ -79,6 +79,45 @@ public readonly partial struct JsonInt64
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt64 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt64 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator int(JsonInt64 value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt64 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt64 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/GetPetsLimit.Mutable.cs
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/GetPetsLimit.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct GetPetsLimit
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/GetPetsLimit.cs
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/GetPetsLimit.cs
@@ -82,6 +82,42 @@ public readonly partial struct GetPetsLimit
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInt32.Mutable.cs
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInt32.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct JsonInt32
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInt32.cs
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInt32.cs
@@ -82,6 +82,42 @@ public readonly partial struct JsonInt32
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt32 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt32 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt32 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt32 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInt64.Mutable.cs
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInt64.Mutable.cs
@@ -74,6 +74,45 @@ public readonly partial struct JsonInt64
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInt64.cs
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInt64.cs
@@ -79,6 +79,45 @@ public readonly partial struct JsonInt64
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt64 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt64 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator int(JsonInt64 value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt64 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt64 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInteger.Mutable.cs
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInteger.Mutable.cs
@@ -74,6 +74,45 @@ public readonly partial struct JsonInteger
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInteger.cs
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/Models/JsonInteger.cs
@@ -130,6 +130,45 @@ public readonly partial struct JsonInteger
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInteger value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInteger value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInteger value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInteger value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInteger value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator int(JsonInteger value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInteger value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInteger value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInteger value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInteger value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInteger value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInteger value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/corvusjson-openapi.lock
+++ b/docs/ExampleRecipes/031-OpenApiAdvancedClient/Generated/corvusjson-openapi.lock
@@ -1,6 +1,6 @@
 {
   "excludePaths": [],
-  "generatedAt": "2026-08-18T17:46:30.8983641\u002B00:00",
+  "generatedAt": "2026-08-27T13:13:33.2808444\u002B00:00",
   "generatedFiles": [
     "ListPetsRequest.cs",
     "ListPetsResponse.cs",
@@ -135,7 +135,7 @@
     "Models/PostPetsByPetIdPhotosBody.JsonSchema.cs",
     "Models/Corvus__GlobalDeclarations.cs"
   ],
-  "generatorVersion": "1.0.0\u002Ba58eb326f479e3c0b4939480be9299a319ddaf94",
+  "generatorVersion": "1.0.0\u002B68617b47ad47aa32242fdd24a3435adf50cbb969",
   "includePaths": [],
   "rootNamespace": "Petstore.Extended",
   "specFileHash": "27f81b7eb15fe66d4e3b2ffb3572a80fe7e0c6b564966f8b785c7496c1631ff8",

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/GetPetsLimit.Mutable.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/GetPetsLimit.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct GetPetsLimit
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/GetPetsLimit.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/GetPetsLimit.cs
@@ -82,6 +82,42 @@ public readonly partial struct GetPetsLimit
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInt32.Mutable.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInt32.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct JsonInt32
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInt32.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInt32.cs
@@ -82,6 +82,42 @@ public readonly partial struct JsonInt32
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt32 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt32 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt32 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt32 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInt64.Mutable.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInt64.Mutable.cs
@@ -74,6 +74,45 @@ public readonly partial struct JsonInt64
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInt64.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInt64.cs
@@ -79,6 +79,45 @@ public readonly partial struct JsonInt64
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt64 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt64 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator int(JsonInt64 value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt64 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt64 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInteger.Mutable.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInteger.Mutable.cs
@@ -74,6 +74,45 @@ public readonly partial struct JsonInteger
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInteger.cs
+++ b/docs/ExampleRecipes/032-OpenApiAdvancedServer/Generated/Models/JsonInteger.cs
@@ -130,6 +130,45 @@ public readonly partial struct JsonInteger
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInteger value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInteger value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInteger value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInteger value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInteger value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator int(JsonInteger value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInteger value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInteger value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInteger value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInteger value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInteger value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInteger value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/GetPetsLimit.Mutable.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/GetPetsLimit.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct GetPetsLimit
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/GetPetsLimit.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/GetPetsLimit.cs
@@ -82,6 +82,42 @@ public readonly partial struct GetPetsLimit
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInt32.Mutable.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInt32.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct JsonInt32
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInt32.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInt32.cs
@@ -82,6 +82,42 @@ public readonly partial struct JsonInt32
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt32 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt32 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt32 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt32 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInt64.Mutable.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInt64.Mutable.cs
@@ -74,6 +74,45 @@ public readonly partial struct JsonInt64
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInt64.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInt64.cs
@@ -79,6 +79,45 @@ public readonly partial struct JsonInt64
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt64 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt64 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator int(JsonInt64 value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt64 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt64 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInteger.Mutable.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInteger.Mutable.cs
@@ -74,6 +74,45 @@ public readonly partial struct JsonInteger
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInteger.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/Models/JsonInteger.cs
@@ -130,6 +130,45 @@ public readonly partial struct JsonInteger
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInteger value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInteger value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInteger value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInteger value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInteger value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator int(JsonInteger value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInteger value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInteger value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInteger value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInteger value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInteger value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInteger value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/corvusjson-openapi.lock
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Client/corvusjson-openapi.lock
@@ -1,6 +1,6 @@
 {
   "excludePaths": [],
-  "generatedAt": "2026-08-18T17:46:35.2813571\u002B00:00",
+  "generatedAt": "2026-08-27T13:13:48.8689455\u002B00:00",
   "generatedFiles": [
     "ListPetsRequest.cs",
     "ListPetsResponse.cs",
@@ -135,7 +135,7 @@
     "Models/PostPetsByPetIdPhotosBody.JsonSchema.cs",
     "Models/Corvus__GlobalDeclarations.cs"
   ],
-  "generatorVersion": "1.0.0\u002Ba58eb326f479e3c0b4939480be9299a319ddaf94",
+  "generatorVersion": "1.0.0\u002B68617b47ad47aa32242fdd24a3435adf50cbb969",
   "includePaths": [],
   "rootNamespace": "Petstore.EndToEnd.Client",
   "specFileHash": "27f81b7eb15fe66d4e3b2ffb3572a80fe7e0c6b564966f8b785c7496c1631ff8",

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/GetPetsLimit.Mutable.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/GetPetsLimit.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct GetPetsLimit
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/GetPetsLimit.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/GetPetsLimit.cs
@@ -82,6 +82,42 @@ public readonly partial struct GetPetsLimit
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInt32.Mutable.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInt32.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct JsonInt32
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInt32.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInt32.cs
@@ -82,6 +82,42 @@ public readonly partial struct JsonInt32
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt32 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt32 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt32 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt32 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInt64.Mutable.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInt64.Mutable.cs
@@ -74,6 +74,45 @@ public readonly partial struct JsonInt64
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInt64.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInt64.cs
@@ -79,6 +79,45 @@ public readonly partial struct JsonInt64
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt64 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt64 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator int(JsonInt64 value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt64 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt64 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInteger.Mutable.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInteger.Mutable.cs
@@ -74,6 +74,45 @@ public readonly partial struct JsonInteger
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInteger.cs
+++ b/docs/ExampleRecipes/033-OpenApiEndToEnd/Generated/Server/Models/JsonInteger.cs
@@ -130,6 +130,45 @@ public readonly partial struct JsonInteger
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInteger value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInteger value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInteger value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInteger value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInteger value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator int(JsonInteger value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInteger value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInteger value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInteger value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInteger value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInteger value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInteger value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/036-AsyncApiProducer/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.Mutable.cs
+++ b/docs/ExampleRecipes/036-AsyncApiProducer/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.Mutable.cs
@@ -85,6 +85,45 @@ public readonly partial struct LightMeasuredPayload
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
             /// <summary>
             /// Operator ==.
             /// </summary>

--- a/docs/ExampleRecipes/036-AsyncApiProducer/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.cs
+++ b/docs/ExampleRecipes/036-AsyncApiProducer/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.cs
@@ -141,6 +141,45 @@ public readonly partial struct LightMeasuredPayload
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/036-AsyncApiProducer/Generated/corvusjson-asyncapi.lock
+++ b/docs/ExampleRecipes/036-AsyncApiProducer/Generated/corvusjson-asyncapi.lock
@@ -1,6 +1,6 @@
 {
   "excludeChannels": [],
-  "generatedAt": "2026-08-18T17:46:40.5769066\u002B00:00",
+  "generatedAt": "2026-08-27T13:14:10.8854495\u002B00:00",
   "generatedFiles": [
     "TurnOnProducer.cs",
     "IReceiveLightMeasurementHandler.cs",
@@ -26,7 +26,7 @@
     "Models/TurnOnOffPayload.WhetherToTurnOnOrOffTheLight.JsonSchema.cs",
     "Models/Corvus__GlobalDeclarations.cs"
   ],
-  "generatorVersion": "1.0.0\u002Ba58eb326f479e3c0b4939480be9299a319ddaf94",
+  "generatorVersion": "1.0.0\u002B68617b47ad47aa32242fdd24a3435adf50cbb969",
   "includeChannels": [],
   "mode": "both",
   "rootNamespace": "Streetlights.Client",

--- a/docs/ExampleRecipes/037-AsyncApiConsumer/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.Mutable.cs
+++ b/docs/ExampleRecipes/037-AsyncApiConsumer/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.Mutable.cs
@@ -85,6 +85,45 @@ public readonly partial struct LightMeasuredPayload
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
             /// <summary>
             /// Operator ==.
             /// </summary>

--- a/docs/ExampleRecipes/037-AsyncApiConsumer/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.cs
+++ b/docs/ExampleRecipes/037-AsyncApiConsumer/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.cs
@@ -141,6 +141,45 @@ public readonly partial struct LightMeasuredPayload
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/037-AsyncApiConsumer/Generated/corvusjson-asyncapi.lock
+++ b/docs/ExampleRecipes/037-AsyncApiConsumer/Generated/corvusjson-asyncapi.lock
@@ -1,6 +1,6 @@
 {
   "excludeChannels": [],
-  "generatedAt": "2026-08-18T17:46:41.9091596\u002B00:00",
+  "generatedAt": "2026-08-27T13:14:21.0237299\u002B00:00",
   "generatedFiles": [
     "TurnOnProducer.cs",
     "IReceiveLightMeasurementHandler.cs",
@@ -26,7 +26,7 @@
     "Models/TurnOnOffPayload.WhetherToTurnOnOrOffTheLight.JsonSchema.cs",
     "Models/Corvus__GlobalDeclarations.cs"
   ],
-  "generatorVersion": "1.0.0\u002Ba58eb326f479e3c0b4939480be9299a319ddaf94",
+  "generatorVersion": "1.0.0\u002B68617b47ad47aa32242fdd24a3435adf50cbb969",
   "includeChannels": [],
   "mode": "both",
   "rootNamespace": "Streetlights.Client",

--- a/docs/ExampleRecipes/038-AsyncApiEndToEnd/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.Mutable.cs
+++ b/docs/ExampleRecipes/038-AsyncApiEndToEnd/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.Mutable.cs
@@ -85,6 +85,45 @@ public readonly partial struct LightMeasuredPayload
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
             /// <summary>
             /// Operator ==.
             /// </summary>

--- a/docs/ExampleRecipes/038-AsyncApiEndToEnd/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.cs
+++ b/docs/ExampleRecipes/038-AsyncApiEndToEnd/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.cs
@@ -141,6 +141,45 @@ public readonly partial struct LightMeasuredPayload
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/038-AsyncApiEndToEnd/Generated/corvusjson-asyncapi.lock
+++ b/docs/ExampleRecipes/038-AsyncApiEndToEnd/Generated/corvusjson-asyncapi.lock
@@ -1,6 +1,6 @@
 {
   "excludeChannels": [],
-  "generatedAt": "2026-08-18T17:46:43.2223428\u002B00:00",
+  "generatedAt": "2026-08-27T13:14:27.3680753\u002B00:00",
   "generatedFiles": [
     "TurnOnProducer.cs",
     "IReceiveLightMeasurementHandler.cs",
@@ -26,7 +26,7 @@
     "Models/TurnOnOffPayload.WhetherToTurnOnOrOffTheLight.JsonSchema.cs",
     "Models/Corvus__GlobalDeclarations.cs"
   ],
-  "generatorVersion": "1.0.0\u002Ba58eb326f479e3c0b4939480be9299a319ddaf94",
+  "generatorVersion": "1.0.0\u002B68617b47ad47aa32242fdd24a3435adf50cbb969",
   "includeChannels": [],
   "mode": "both",
   "rootNamespace": "Streetlights.Client",

--- a/docs/ExampleRecipes/039-AsyncApiAuthentication/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.Mutable.cs
+++ b/docs/ExampleRecipes/039-AsyncApiAuthentication/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.Mutable.cs
@@ -85,6 +85,45 @@ public readonly partial struct LightMeasuredPayload
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
             public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+            [MethodImpl(MethodImplOptions.AggressiveInlining)]
+            public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
             /// <summary>
             /// Operator ==.
             /// </summary>

--- a/docs/ExampleRecipes/039-AsyncApiAuthentication/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.cs
+++ b/docs/ExampleRecipes/039-AsyncApiAuthentication/Generated/Models/LightMeasuredPayload.LightIntensityMeasuredInLumens.cs
@@ -141,6 +141,45 @@ public readonly partial struct LightMeasuredPayload
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(LightIntensityMeasuredInLumens value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/039-AsyncApiAuthentication/Generated/corvusjson-asyncapi.lock
+++ b/docs/ExampleRecipes/039-AsyncApiAuthentication/Generated/corvusjson-asyncapi.lock
@@ -1,6 +1,6 @@
 {
   "excludeChannels": [],
-  "generatedAt": "2026-08-18T17:46:44.5593775\u002B00:00",
+  "generatedAt": "2026-08-27T13:14:33.1251201\u002B00:00",
   "generatedFiles": [
     "TurnOnProducer.cs",
     "IReceiveLightMeasurementHandler.cs",
@@ -26,7 +26,7 @@
     "Models/TurnOnOffPayload.WhetherToTurnOnOrOffTheLight.JsonSchema.cs",
     "Models/Corvus__GlobalDeclarations.cs"
   ],
-  "generatorVersion": "1.0.0\u002Ba58eb326f479e3c0b4939480be9299a319ddaf94",
+  "generatorVersion": "1.0.0\u002B68617b47ad47aa32242fdd24a3435adf50cbb969",
   "includeChannels": [],
   "mode": "both",
   "rootNamespace": "Streetlights.Client",

--- a/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/GetPetsLimit.Mutable.cs
+++ b/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/GetPetsLimit.Mutable.cs
@@ -82,6 +82,42 @@ public readonly partial struct GetPetsLimit
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/GetPetsLimit.cs
+++ b/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/GetPetsLimit.cs
@@ -87,6 +87,42 @@ public readonly partial struct GetPetsLimit
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(GetPetsLimit value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/JsonInt32.Mutable.cs
+++ b/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/JsonInt32.Mutable.cs
@@ -77,6 +77,42 @@ public readonly partial struct JsonInt32
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/JsonInt32.cs
+++ b/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/JsonInt32.cs
@@ -82,6 +82,42 @@ public readonly partial struct JsonInt32
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt32 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt32 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt32 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt32 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt32 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt32 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt32 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt32 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/JsonInt64.Mutable.cs
+++ b/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/JsonInt64.Mutable.cs
@@ -74,6 +74,45 @@ public readonly partial struct JsonInt64
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
         public static explicit operator decimal(Mutable value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator sbyte(Mutable value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator byte(Mutable value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator short(Mutable value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ushort(Mutable value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator int(Mutable value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator uint(Mutable value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator ulong(Mutable value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator float(Mutable value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Int128(Mutable value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator UInt128(Mutable value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static explicit operator Half(Mutable value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
         /// <summary>
         /// Operator ==.
         /// </summary>

--- a/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/JsonInt64.cs
+++ b/docs/ExampleRecipes/042-OpenApi20Client/Generated/Models/JsonInt64.cs
@@ -79,6 +79,45 @@ public readonly partial struct JsonInt64
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static explicit operator decimal(JsonInt64 value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator sbyte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out sbyte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator byte(JsonInt64 value) => value._parent.TryGetValue(value._idx, out byte result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator short(JsonInt64 value) => value._parent.TryGetValue(value._idx, out short result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ushort(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ushort result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator int(JsonInt64 value) => value._parent.TryGetValue(value._idx, out int result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator uint(JsonInt64 value) => value._parent.TryGetValue(value._idx, out uint result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator ulong(JsonInt64 value) => value._parent.TryGetValue(value._idx, out ulong result) ? result : throw new FormatException();
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator float(JsonInt64 value) => value._parent.TryGetValue(value._idx, out float result) ? result : throw new FormatException();
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Int128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Int128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator UInt128(JsonInt64 value) => value._parent.TryGetValue(value._idx, out UInt128 result) ? result : throw new FormatException();
+#endif
+
+#if NET
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static explicit operator Half(JsonInt64 value) => value._parent.TryGetValue(value._idx, out Half result) ? result : throw new FormatException();
+#endif
+
     /// <summary>
     /// Operator ==.
     /// </summary>

--- a/docs/ExampleRecipes/042-OpenApi20Client/Generated/corvusjson-openapi.lock
+++ b/docs/ExampleRecipes/042-OpenApi20Client/Generated/corvusjson-openapi.lock
@@ -1,6 +1,6 @@
 {
   "excludePaths": [],
-  "generatedAt": "2026-08-18T17:46:45.9059065\u002B00:00",
+  "generatedAt": "2026-08-27T13:14:39.1865691\u002B00:00",
   "generatedFiles": [
     "ListPetsRequest.cs",
     "ListPetsResponse.cs",
@@ -47,7 +47,7 @@
     "Models/UpdatePetWithFormFormBody.StatusEntity.JsonSchema.cs",
     "Models/Corvus__GlobalDeclarations.cs"
   ],
-  "generatorVersion": "1.0.0\u002Ba58eb326f479e3c0b4939480be9299a319ddaf94",
+  "generatorVersion": "1.0.0\u002B68617b47ad47aa32242fdd24a3435adf50cbb969",
   "includePaths": [],
   "rootNamespace": "Petstore.V2.Client",
   "specFileHash": "10cc3488325cfb61d4a68bc721ede20dcd9b93cb9533a03071189478971208ca",

--- a/docs/website/site/content/Home/Features.md
+++ b/docs/website/site/content/Home/Features.md
@@ -30,7 +30,7 @@ Type-safe `Match()` for `oneOf`/`anyOf` discriminated unions with exhaustive del
 
 ## 🔧 JSON Operations
 
-[JSON Patch (RFC 6902)](https://datatracker.ietf.org/doc/html/rfc6902) with a fluent `PatchBuilder`, [JSON Merge Patch (RFC 7396)](https://datatracker.ietf.org/doc/html/rfc7396) for simple document merging, JSON diff for computing patches between documents, and [JSON Canonicalization (RFC 8785)](https://datatracker.ietf.org/doc/html/rfc8785) for deterministic serialization. All operations work with the zero-allocation mutable document infrastructure.
+[JSON Patch (RFC 6902)](https://datatracker.ietf.org/doc/html/rfc6902) with a fluent `PatchBuilder`, [JSON Merge Patch (RFC 7396)](https://datatracker.ietf.org/doc/html/rfc7396) for simple document merging, JSON diff for computing patches between documents, and [JSON Canonicalization (RFC 8785)](https://datatracker.ietf.org/doc/html/rfc8785) for deterministic serialization. All operations work with the zero-allocation mutable document infrastructure. Elements can also report their own location. `GetJsonPointer()` and the zero-allocation `TryGetJsonPointer()` span overloads derive the [JSON Pointer (RFC 6901)](https://datatracker.ietf.org/doc/html/rfc6901) of any element relative to its document root, which makes it easy to turn query results into patch targets.
 
 ## 🔍 Query Languages
 

--- a/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Conversions.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/CodeGeneratorExtensions.Conversions.cs
@@ -93,6 +93,8 @@ internal static partial class CodeGeneratorExtensions
                         .AppendLineIndent("[MethodImpl(MethodImplOptions.AggressiveInlining)]")
                         .AppendLineIndent("public static explicit operator decimal(", typeName, " value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();");
                 }
+
+                AppendRemainingNumericConversionOperators(generator, typeName, seenConversionOperators);
             }
 
             // Emit explicit operators for formats discovered in composition sub-types (a subschema's
@@ -210,6 +212,8 @@ internal static partial class CodeGeneratorExtensions
                         .AppendLineIndent("[MethodImpl(MethodImplOptions.AggressiveInlining)]")
                         .AppendLineIndent("public static explicit operator decimal(", typeName, " value) => value._parent.TryGetValue(value._idx, out decimal result) ? result : throw new FormatException();");
                 }
+
+                AppendRemainingNumericConversionOperators(generator, typeName, seenConversionOperators);
             }
 
             if ((coreTypes & CoreTypes.Boolean) != 0)
@@ -316,6 +320,55 @@ internal static partial class CodeGeneratorExtensions
                         formats.Add(format);
                     }
                 }
+            }
+        }
+    }
+
+    /// <summary>
+    /// Appends explicit conversion operators for every numeric CLR type not already covered by a
+    /// format-specific or core conversion, so that a direct cast to any numeric type binds a
+    /// user-defined operator (issue #937). Routing such casts through the implicit conversion to
+    /// <c>long</c> both trips IDE0221 and silently truncates out-of-range values; a direct operator
+    /// range-checks via <c>TryGetValue</c> and throws <see cref="FormatException"/> instead.
+    /// </summary>
+    /// <param name="generator">The code generator.</param>
+    /// <param name="typeName">The name of the type for which to emit the operators.</param>
+    /// <param name="seenConversionOperators">The set of conversion operators that have already been generated.</param>
+    private static void AppendRemainingNumericConversionOperators(CodeGenerator generator, string typeName, HashSet<string> seenConversionOperators)
+    {
+        AppendNumericConversionOperator(generator, typeName, seenConversionOperators, "sbyte", "sbyte");
+        AppendNumericConversionOperator(generator, typeName, seenConversionOperators, "byte", "byte");
+        AppendNumericConversionOperator(generator, typeName, seenConversionOperators, "short", "short");
+        AppendNumericConversionOperator(generator, typeName, seenConversionOperators, "ushort", "ushort");
+        AppendNumericConversionOperator(generator, typeName, seenConversionOperators, "int", "int");
+        AppendNumericConversionOperator(generator, typeName, seenConversionOperators, "uint", "uint");
+        AppendNumericConversionOperator(generator, typeName, seenConversionOperators, "ulong", "ulong");
+        AppendNumericConversionOperator(generator, typeName, seenConversionOperators, "float", "float");
+        AppendNumericConversionOperator(generator, typeName, seenConversionOperators, "Int128", "Int128", netOnly: true);
+        AppendNumericConversionOperator(generator, typeName, seenConversionOperators, "UInt128", "UInt128", netOnly: true);
+        AppendNumericConversionOperator(generator, typeName, seenConversionOperators, "Half", "Half", netOnly: true);
+
+        static void AppendNumericConversionOperator(CodeGenerator generator, string typeName, HashSet<string> seenConversionOperators, string key, string clrTypeName, bool netOnly = false)
+        {
+            if (generator.IsCancellationRequested || !seenConversionOperators.Add(key))
+            {
+                return;
+            }
+
+            generator.AppendSeparatorLine();
+
+            if (netOnly)
+            {
+                generator.AppendLine("#if NET");
+            }
+
+            generator
+                .AppendLineIndent("[MethodImpl(MethodImplOptions.AggressiveInlining)]")
+                .AppendLineIndent("public static explicit operator ", clrTypeName, "(", typeName, " value) => value._parent.TryGetValue(value._idx, out ", clrTypeName, " result) ? result : throw new FormatException();");
+
+            if (netOnly)
+            {
+                generator.AppendLine("#endif");
             }
         }
     }

--- a/src/Corvus.Text.Json/Corvus.Text.Json.csproj
+++ b/src/Corvus.Text.Json/Corvus.Text.Json.csproj
@@ -227,10 +227,12 @@
     <Compile Include="Corvus\Text\Json\Document\ParsedJsonDocument.cs" />
     <Compile Include="Corvus\Text\Json\Document\ParsedJsonDocument.Parse.cs" />
     <Compile Include="Corvus\Text\Json\Document\ParsedJsonDocument.SourceLocation.cs" />
+    <Compile Include="Corvus\Text\Json\Document\ParsedJsonDocument.JsonPointer.cs" />
     <Compile Include="Corvus\Text\Json\Document\Internal\JsonDocument.StackRow.cs" />
     <Compile Include="Corvus\Text\Json\Document\Internal\JsonDocument.StackRowStack.cs" />
     <Compile Include="Corvus\Text\Json\Document\ParsedJsonDocument.TryGetProperty.cs" />
     <Compile Include="Corvus\Text\Json\Document\Internal\JsonDocument.cs" />
+    <Compile Include="Corvus\Text\Json\Document\Internal\JsonDocument.JsonPointer.cs" />
     <Compile Include="Corvus\Text\Json\Document\Internal\MetadataDb.cs" />
     <Compile Include="Corvus\Text\Json\Document\Internal\DbRow.cs" />
     <Compile Include="Corvus\Text\Json\Document\JsonDocumentOptions.cs" />
@@ -248,6 +250,7 @@
     <Compile Include="Corvus\Text\Json\Document\JsonElement.cs" />
     <Compile Include="Corvus\Text\Json\Document\JsonElement.Parse.cs" />
     <Compile Include="Corvus\Text\Json\Document\JsonElement.SourceLocation.cs" />
+    <Compile Include="Corvus\Text\Json\Document\JsonElement.JsonPointer.cs" />
     <Compile Include="Corvus\Text\Json\Document\JsonProperty.cs" />
     <Compile Include="Corvus\Text\Json\Document\JsonValueKind.cs" />
     <Compile Include="Corvus\Text\Json\Internal\JsonElementHelpers.DateTime.cs" />

--- a/src/Corvus.Text.Json/Corvus/Text/Json/Document/Internal/IJsonDocument.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/Document/Internal/IJsonDocument.cs
@@ -707,6 +707,28 @@ public interface IJsonDocument : IDisposable
         where TValue : struct, IJsonElement<TValue>;
 
     /// <summary>
+    /// Tries to write the JSON Pointer (RFC 6901) of the element at the specified index,
+    /// relative to the document root, as UTF-8 bytes.
+    /// </summary>
+    /// <param name="index">The index of the element.</param>
+    /// <param name="utf8Destination">The destination for the UTF-8 pointer text.</param>
+    /// <param name="bytesWritten">The number of bytes written on success; 0 on failure.</param>
+    /// <param name="bytesRequired">The total number of bytes the pointer requires, whether or not it fit in the destination.</param>
+    /// <returns><see langword="true"/> if the pointer was written; <see langword="false"/> if the destination was too small.</returns>
+    bool TryGetJsonPointer(int index, Span<byte> utf8Destination, out int bytesWritten, out int bytesRequired);
+
+    /// <summary>
+    /// Tries to write the JSON Pointer (RFC 6901) of the element at the specified index,
+    /// relative to the document root, as UTF-16 characters.
+    /// </summary>
+    /// <param name="index">The index of the element.</param>
+    /// <param name="destination">The destination for the pointer text.</param>
+    /// <param name="charsWritten">The number of characters written on success; 0 on failure.</param>
+    /// <param name="charsRequired">The total number of characters the pointer requires, whether or not it fit in the destination.</param>
+    /// <returns><see langword="true"/> if the pointer was written; <see langword="false"/> if the destination was too small.</returns>
+    bool TryGetJsonPointer(int index, Span<char> destination, out int charsWritten, out int charsRequired);
+
+    /// <summary>
     /// Formats the value to the provided destination span according to the specified format and format provider.
     /// </summary>
     /// <param name="index">The index of the element.</param>

--- a/src/Corvus.Text.Json/Corvus/Text/Json/Document/Internal/JsonDocument.JsonPointer.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/Document/Internal/JsonDocument.JsonPointer.cs
@@ -1,0 +1,441 @@
+// <copyright file="JsonDocument.JsonPointer.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.Buffers;
+using System.Buffers.Text;
+using System.Diagnostics;
+
+namespace Corvus.Text.Json.Internal;
+
+/// <summary>
+/// Derives the JSON Pointer (RFC 6901) of an element relative to the document root
+/// by walking the metadata database from the element back to its ancestors.
+/// </summary>
+public abstract partial class JsonDocument
+{
+    // Segment stack encoding: a value with the sign bit set is an array index
+    // (stored in the low 31 bits); a value with the sign bit clear is the byte
+    // offset of a PropertyName row in the metadata database. Array indices are
+    // bounded by the 28-bit row count and row byte offsets by the maximum array
+    // length, so both fit in 31 bits, and a PropertyName row can never be at
+    // offset 0 (the root row).
+    private const int ArrayIndexSegmentFlag = unchecked((int)0x8000_0000);
+
+    private const int InitialSegmentStackCapacity = 64;
+
+    /// <summary>
+    /// Tries to write the JSON Pointer (RFC 6901) of the element at the specified index,
+    /// relative to the document root, as UTF-8 bytes.
+    /// </summary>
+    /// <param name="index">The index of the element.</param>
+    /// <param name="utf8Destination">The destination for the UTF-8 pointer text.</param>
+    /// <param name="bytesWritten">The number of bytes written on success; 0 on failure.</param>
+    /// <param name="bytesRequired">The total number of bytes the pointer requires, whether or not it fit.</param>
+    /// <returns><see langword="true"/> if the pointer was written; <see langword="false"/> if the destination was too small.</returns>
+    private protected bool TryGetJsonPointerUnsafe(int index, Span<byte> utf8Destination, out int bytesWritten, out int bytesRequired)
+    {
+        int[]? rentedSegments = null;
+        Span<int> segments = stackalloc int[InitialSegmentStackCapacity];
+        try
+        {
+            int segmentCount = CollectJsonPointerSegments(index, ref segments, ref rentedSegments);
+
+            int written = 0;
+            int required = 0;
+            bool fits = true;
+
+            // Segments were collected leaf-first; emit them root-first.
+            for (int i = segmentCount - 1; i >= 0; i--)
+            {
+                required++;
+                if (fits && written < utf8Destination.Length)
+                {
+                    utf8Destination[written++] = (byte)'/';
+                }
+                else
+                {
+                    fits = false;
+                }
+
+                int segment = segments[i];
+                if (segment < 0)
+                {
+                    EmitIndexSegment(segment & ~ArrayIndexSegmentFlag, utf8Destination, ref written, ref required, ref fits);
+                }
+                else
+                {
+                    EmitNameSegment(segment, utf8Destination, ref written, ref required, ref fits);
+                }
+            }
+
+            bytesRequired = required;
+            if (fits)
+            {
+                bytesWritten = written;
+                return true;
+            }
+
+            bytesWritten = 0;
+            return false;
+        }
+        finally
+        {
+            if (rentedSegments is not null)
+            {
+                ArrayPool<int>.Shared.Return(rentedSegments);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Tries to write the JSON Pointer (RFC 6901) of the element at the specified index,
+    /// relative to the document root, as UTF-16 characters.
+    /// </summary>
+    /// <param name="index">The index of the element.</param>
+    /// <param name="destination">The destination for the pointer text.</param>
+    /// <param name="charsWritten">The number of characters written on success; 0 on failure.</param>
+    /// <param name="charsRequired">The total number of characters the pointer requires, whether or not it fit.</param>
+    /// <returns><see langword="true"/> if the pointer was written; <see langword="false"/> if the destination was too small.</returns>
+    private protected bool TryGetJsonPointerUnsafe(int index, Span<char> destination, out int charsWritten, out int charsRequired)
+    {
+        int[]? rentedSegments = null;
+        Span<int> segments = stackalloc int[InitialSegmentStackCapacity];
+        try
+        {
+            int segmentCount = CollectJsonPointerSegments(index, ref segments, ref rentedSegments);
+
+            int written = 0;
+            int required = 0;
+            bool fits = true;
+
+            // Segments were collected leaf-first; emit them root-first.
+            for (int i = segmentCount - 1; i >= 0; i--)
+            {
+                required++;
+                if (fits && written < destination.Length)
+                {
+                    destination[written++] = '/';
+                }
+                else
+                {
+                    fits = false;
+                }
+
+                int segment = segments[i];
+                if (segment < 0)
+                {
+                    EmitIndexSegment(segment & ~ArrayIndexSegmentFlag, destination, ref written, ref required, ref fits);
+                }
+                else
+                {
+                    EmitNameSegment(segment, destination, ref written, ref required, ref fits);
+                }
+            }
+
+            charsRequired = required;
+            if (fits)
+            {
+                charsWritten = written;
+                return true;
+            }
+
+            charsWritten = 0;
+            return false;
+        }
+        finally
+        {
+            if (rentedSegments is not null)
+            {
+                ArrayPool<int>.Shared.Return(rentedSegments);
+            }
+        }
+    }
+
+    /// <summary>
+    /// Walks the metadata database from the element at <paramref name="index"/> back to the
+    /// document root, collecting one segment per ancestry level, leaf-first.
+    /// </summary>
+    /// <param name="index">The index of the element.</param>
+    /// <param name="segments">The segment stack (grown into a rented array when exceeded).</param>
+    /// <param name="rentedSegments">The rented backing array for the segment stack, if any.</param>
+    /// <returns>The number of segments collected.</returns>
+    private int CollectJsonPointerSegments(int index, ref Span<int> segments, ref int[]? rentedSegments)
+    {
+        int count = 0;
+        int cur = index;
+
+        // A PropertyName element designates the property itself; its pointer ends with
+        // the property's name segment, and the walk continues from the containing object.
+        if (cur != 0 && _parsedData.GetJsonTokenType(cur) == JsonTokenType.PropertyName)
+        {
+            PushSegment(ref segments, ref rentedSegments, ref count, cur);
+            cur = FindUnclosedContainerStart(cur - DbRow.Size, out _);
+            Debug.Assert(_parsedData.GetJsonTokenType(cur) == JsonTokenType.StartObject, "A PropertyName row must be contained in an object");
+        }
+
+        while (cur != 0)
+        {
+            int prev = cur - DbRow.Size;
+            if (_parsedData.GetJsonTokenType(prev) == JsonTokenType.PropertyName)
+            {
+                // The parent is an object and the row before the element is its name.
+                PushSegment(ref segments, ref rentedSegments, ref count, prev);
+                cur = FindUnclosedContainerStart(prev - DbRow.Size, out _);
+                Debug.Assert(_parsedData.GetJsonTokenType(cur) == JsonTokenType.StartObject, "A named value must be contained in an object");
+            }
+            else
+            {
+                // The parent is an array; count the sibling values that precede the element.
+                cur = FindUnclosedContainerStart(prev, out int precedingValues);
+                Debug.Assert(_parsedData.GetJsonTokenType(cur) == JsonTokenType.StartArray, "An unnamed value must be contained in an array");
+                PushSegment(ref segments, ref rentedSegments, ref count, precedingValues | ArrayIndexSegmentFlag);
+            }
+        }
+
+        return count;
+    }
+
+    /// <summary>
+    /// Scans backwards from <paramref name="pos"/> to the start row of the container that
+    /// encloses it, skipping complete sibling containers via their End rows. End rows always
+    /// carry a locally-correct row count (external references mirror their full structure),
+    /// so the scan never leaves this metadata database.
+    /// </summary>
+    /// <param name="pos">The byte offset of the row at which to start scanning.</param>
+    /// <param name="precedingValues">The number of complete values skipped before reaching the container start.</param>
+    /// <returns>The byte offset of the enclosing container's start row.</returns>
+    private int FindUnclosedContainerStart(int pos, out int precedingValues)
+    {
+        int count = 0;
+        while (true)
+        {
+            Debug.Assert(pos >= 0, "The scan must terminate at an enclosing container start");
+            DbRow row = _parsedData.Get(pos);
+            JsonTokenType tokenType = row.TokenType;
+            if (tokenType is JsonTokenType.EndObject or JsonTokenType.EndArray)
+            {
+                // Jump over the complete container to the row before its start.
+                pos -= (row.NumberOfRows + 1) * DbRow.Size;
+                count++;
+            }
+            else if (tokenType is JsonTokenType.StartObject or JsonTokenType.StartArray)
+            {
+                // A start row reached directly (not via its end row) is unclosed at this
+                // position, so it is the enclosing container.
+                precedingValues = count;
+                return pos;
+            }
+            else
+            {
+                // A simple value, or a PropertyName row (only encountered when the caller
+                // is scanning inside an object and discards the count).
+                if (tokenType != JsonTokenType.PropertyName)
+                {
+                    count++;
+                }
+
+                pos -= DbRow.Size;
+            }
+        }
+    }
+
+    private static void PushSegment(ref Span<int> segments, ref int[]? rentedSegments, ref int count, int value)
+    {
+        if (count == segments.Length)
+        {
+            int[] newRented = ArrayPool<int>.Shared.Rent(segments.Length * 2);
+            segments.CopyTo(newRented);
+            if (rentedSegments is not null)
+            {
+                ArrayPool<int>.Shared.Return(rentedSegments);
+            }
+
+            rentedSegments = newRented;
+            segments = newRented;
+        }
+
+        segments[count++] = value;
+    }
+
+    private static void EmitIndexSegment(int arrayIndex, Span<byte> destination, ref int written, ref int required, ref bool fits)
+    {
+        Span<byte> digits = stackalloc byte[10];
+        bool formatted = Utf8Formatter.TryFormat(arrayIndex, digits, out int digitCount);
+        Debug.Assert(formatted, "A non-negative int always formats into 10 digits");
+
+        required += digitCount;
+        if (fits && written + digitCount <= destination.Length)
+        {
+            digits.Slice(0, digitCount).CopyTo(destination.Slice(written));
+            written += digitCount;
+        }
+        else
+        {
+            fits = false;
+        }
+    }
+
+    private static void EmitIndexSegment(int arrayIndex, Span<char> destination, ref int written, ref int required, ref bool fits)
+    {
+        Span<byte> digits = stackalloc byte[10];
+        bool formatted = Utf8Formatter.TryFormat(arrayIndex, digits, out int digitCount);
+        Debug.Assert(formatted, "A non-negative int always formats into 10 digits");
+
+        required += digitCount;
+        if (fits && written + digitCount <= destination.Length)
+        {
+            for (int i = 0; i < digitCount; i++)
+            {
+                destination[written + i] = (char)digits[i];
+            }
+
+            written += digitCount;
+        }
+        else
+        {
+            fits = false;
+        }
+    }
+
+    private void EmitNameSegment(int nameRowOffset, Span<byte> destination, ref int written, ref int required, ref bool fits)
+    {
+        DbRow nameRow = _parsedData.Get(nameRowOffset);
+        Debug.Assert(nameRow.TokenType == JsonTokenType.PropertyName, "Name segments must reference PropertyName rows");
+        ReadOnlySpan<byte> raw = GetRawSimpleValueFromRowUnsafe(in nameRow).Span;
+
+        if (!nameRow.HasComplexChildren)
+        {
+            EscapeCopy(raw, destination, ref written, ref required, ref fits);
+            return;
+        }
+
+        byte[]? rented = null;
+        Span<byte> unescapeBuffer = raw.Length <= JsonConstants.StackallocByteThreshold
+            ? stackalloc byte[JsonConstants.StackallocByteThreshold]
+            : (rented = ArrayPool<byte>.Shared.Rent(raw.Length));
+        try
+        {
+            JsonReaderHelper.Unescape(raw, unescapeBuffer, out int unescapedLength);
+            EscapeCopy(unescapeBuffer.Slice(0, unescapedLength), destination, ref written, ref required, ref fits);
+        }
+        finally
+        {
+            if (rented is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rented);
+            }
+        }
+    }
+
+    private void EmitNameSegment(int nameRowOffset, Span<char> destination, ref int written, ref int required, ref bool fits)
+    {
+        DbRow nameRow = _parsedData.Get(nameRowOffset);
+        Debug.Assert(nameRow.TokenType == JsonTokenType.PropertyName, "Name segments must reference PropertyName rows");
+        ReadOnlySpan<byte> raw = GetRawSimpleValueFromRowUnsafe(in nameRow).Span;
+
+        byte[]? rentedUnescape = null;
+        char[]? rentedChars = null;
+        Span<byte> unescapeBuffer = raw.Length <= JsonConstants.StackallocByteThreshold
+            ? stackalloc byte[JsonConstants.StackallocByteThreshold]
+            : (rentedUnescape = ArrayPool<byte>.Shared.Rent(raw.Length));
+
+        // The transcoded name has at most one char per UTF-8 byte, and unescaping
+        // never lengthens the name, so the raw length bounds the char count.
+        Span<char> charBuffer = raw.Length <= JsonConstants.StackallocCharThreshold
+            ? stackalloc char[JsonConstants.StackallocCharThreshold]
+            : (rentedChars = ArrayPool<char>.Shared.Rent(raw.Length));
+        try
+        {
+            scoped ReadOnlySpan<byte> name = raw;
+            if (nameRow.HasComplexChildren)
+            {
+                JsonReaderHelper.Unescape(raw, unescapeBuffer, out int unescapedLength);
+                name = unescapeBuffer.Slice(0, unescapedLength);
+            }
+
+            int charCount = JsonReaderHelper.TranscodeHelper(name, charBuffer);
+            EscapeCopy(charBuffer.Slice(0, charCount), destination, ref written, ref required, ref fits);
+        }
+        finally
+        {
+            if (rentedUnescape is not null)
+            {
+                ArrayPool<byte>.Shared.Return(rentedUnescape);
+            }
+
+            if (rentedChars is not null)
+            {
+                ArrayPool<char>.Shared.Return(rentedChars);
+            }
+        }
+    }
+
+    private static void EscapeCopy(ReadOnlySpan<byte> name, Span<byte> destination, ref int written, ref int required, ref bool fits)
+    {
+        for (int i = 0; i < name.Length; i++)
+        {
+            byte b = name[i];
+            if (b is (byte)'~' or (byte)'/')
+            {
+                required += 2;
+                if (fits && written + 2 <= destination.Length)
+                {
+                    destination[written] = (byte)'~';
+                    destination[written + 1] = b == (byte)'~' ? (byte)'0' : (byte)'1';
+                    written += 2;
+                }
+                else
+                {
+                    fits = false;
+                }
+            }
+            else
+            {
+                required++;
+                if (fits && written < destination.Length)
+                {
+                    destination[written++] = b;
+                }
+                else
+                {
+                    fits = false;
+                }
+            }
+        }
+    }
+
+    private static void EscapeCopy(ReadOnlySpan<char> name, Span<char> destination, ref int written, ref int required, ref bool fits)
+    {
+        for (int i = 0; i < name.Length; i++)
+        {
+            char c = name[i];
+            if (c is '~' or '/')
+            {
+                required += 2;
+                if (fits && written + 2 <= destination.Length)
+                {
+                    destination[written] = '~';
+                    destination[written + 1] = c == '~' ? '0' : '1';
+                    written += 2;
+                }
+                else
+                {
+                    fits = false;
+                }
+            }
+            else
+            {
+                required++;
+                if (fits && written < destination.Length)
+                {
+                    destination[written++] = c;
+                }
+                else
+                {
+                    fits = false;
+                }
+            }
+        }
+    }
+}

--- a/src/Corvus.Text.Json/Corvus/Text/Json/Document/JsonElement.JsonPointer.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/Document/JsonElement.JsonPointer.cs
@@ -1,0 +1,104 @@
+// <copyright file="JsonElement.JsonPointer.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+namespace Corvus.Text.Json;
+
+public readonly partial struct JsonElement
+{
+    /// <summary>
+    /// Tries to write the JSON Pointer (RFC 6901) of this element, relative to the root of its
+    /// backing document, as UTF-8 bytes.
+    /// </summary>
+    /// <param name="utf8Destination">The destination for the UTF-8 pointer text.</param>
+    /// <param name="bytesWritten">When this method returns <see langword="true"/>, the number of bytes written; otherwise 0.</param>
+    /// <returns><see langword="true"/> if the pointer was written; <see langword="false"/> if the
+    /// destination was too small, or this is a default <see cref="JsonElement"/>.</returns>
+    /// <exception cref="ObjectDisposedException">
+    /// The parent <see cref="JsonDocument"/> has been disposed.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// The root element produces the empty pointer. Property names are unescaped and then
+    /// pointer-escaped (<c>~</c> as <c>~0</c>, <c>/</c> as <c>~1</c>) per RFC 6901. This
+    /// operation performs no heap allocation.
+    /// </para>
+    /// <para>
+    /// The pointer is relative to the root of the document that backs this element. In a
+    /// <see cref="JsonWorkspace"/>, an element obtained from another document referenced by a
+    /// builder reports its location within that referenced document.
+    /// </para>
+    /// </remarks>
+    public bool TryGetJsonPointer(Span<byte> utf8Destination, out int bytesWritten)
+    {
+        if (_parent is null)
+        {
+            bytesWritten = 0;
+            return false;
+        }
+
+        return _parent.TryGetJsonPointer(_idx, utf8Destination, out bytesWritten, out _);
+    }
+
+    /// <summary>
+    /// Tries to write the JSON Pointer (RFC 6901) of this element, relative to the root of its
+    /// backing document, as UTF-16 characters.
+    /// </summary>
+    /// <param name="destination">The destination for the pointer text.</param>
+    /// <param name="charsWritten">When this method returns <see langword="true"/>, the number of characters written; otherwise 0.</param>
+    /// <returns><see langword="true"/> if the pointer was written; <see langword="false"/> if the
+    /// destination was too small, or this is a default <see cref="JsonElement"/>.</returns>
+    /// <exception cref="ObjectDisposedException">
+    /// The parent <see cref="JsonDocument"/> has been disposed.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// The root element produces the empty pointer. Property names are unescaped and then
+    /// pointer-escaped (<c>~</c> as <c>~0</c>, <c>/</c> as <c>~1</c>) per RFC 6901. This
+    /// operation performs no heap allocation.
+    /// </para>
+    /// <para>
+    /// The pointer is relative to the root of the document that backs this element. In a
+    /// <see cref="JsonWorkspace"/>, an element obtained from another document referenced by a
+    /// builder reports its location within that referenced document.
+    /// </para>
+    /// </remarks>
+    public bool TryGetJsonPointer(Span<char> destination, out int charsWritten)
+    {
+        if (_parent is null)
+        {
+            charsWritten = 0;
+            return false;
+        }
+
+        return _parent.TryGetJsonPointer(_idx, destination, out charsWritten, out _);
+    }
+
+    /// <summary>
+    /// Gets the JSON Pointer (RFC 6901) of this element, relative to the root of its backing
+    /// document, as a string.
+    /// </summary>
+    /// <returns>The JSON Pointer. The root element produces the empty string.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// This is a default <see cref="JsonElement"/>.
+    /// </exception>
+    /// <exception cref="ObjectDisposedException">
+    /// The parent <see cref="JsonDocument"/> has been disposed.
+    /// </exception>
+    /// <remarks>
+    /// <para>
+    /// Property names are unescaped and then pointer-escaped (<c>~</c> as <c>~0</c>,
+    /// <c>/</c> as <c>~1</c>) per RFC 6901.
+    /// </para>
+    /// <para>
+    /// The pointer is relative to the root of the document that backs this element. In a
+    /// <see cref="JsonWorkspace"/>, an element obtained from another document referenced by a
+    /// builder reports its location within that referenced document.
+    /// </para>
+    /// </remarks>
+    public string GetJsonPointer()
+    {
+        CheckValidInstance();
+        return JsonElementExtensions.GetJsonPointerCore(_parent, _idx);
+    }
+}

--- a/src/Corvus.Text.Json/Corvus/Text/Json/Document/JsonElementExtensions.JsonPointer.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/Document/JsonElementExtensions.JsonPointer.cs
@@ -3,6 +3,7 @@
 // </copyright>
 
 using System.Buffers;
+using System.Diagnostics;
 using Corvus.Text.Json.Internal;
 
 namespace Corvus.Text.Json;
@@ -91,5 +92,113 @@ public static partial class JsonElementExtensions
         where T : struct, IJsonElement<T>
     {
         return TryResolvePointer(element, pointer.AsSpan(), out result);
+    }
+
+    /// <summary>
+    /// Tries to write the JSON Pointer (RFC 6901) of this element, relative to the root of its
+    /// backing document, as UTF-8 bytes.
+    /// </summary>
+    /// <typeparam name="T">The type of the element.</typeparam>
+    /// <param name="element">The element whose pointer to derive.</param>
+    /// <param name="utf8Destination">The destination for the UTF-8 pointer text.</param>
+    /// <param name="bytesWritten">When this method returns <see langword="true"/>, the number of bytes written; otherwise 0.</param>
+    /// <returns><see langword="true"/> if the pointer was written; <see langword="false"/> if the
+    /// destination was too small, or the element is a default instance.</returns>
+    /// <remarks>
+    /// The root element produces the empty pointer. Property names are unescaped and then
+    /// pointer-escaped (<c>~</c> as <c>~0</c>, <c>/</c> as <c>~1</c>) per RFC 6901. This
+    /// operation performs no heap allocation.
+    /// </remarks>
+    [CLSCompliant(false)]
+    public static bool TryGetJsonPointer<T>(this T element, Span<byte> utf8Destination, out int bytesWritten)
+        where T : struct, IJsonElement<T>
+    {
+        if (element.ParentDocument is null)
+        {
+            bytesWritten = 0;
+            return false;
+        }
+
+        element.CheckValidInstance();
+        return element.ParentDocument.TryGetJsonPointer(element.ParentDocumentIndex, utf8Destination, out bytesWritten, out _);
+    }
+
+    /// <summary>
+    /// Tries to write the JSON Pointer (RFC 6901) of this element, relative to the root of its
+    /// backing document, as UTF-16 characters.
+    /// </summary>
+    /// <typeparam name="T">The type of the element.</typeparam>
+    /// <param name="element">The element whose pointer to derive.</param>
+    /// <param name="destination">The destination for the pointer text.</param>
+    /// <param name="charsWritten">When this method returns <see langword="true"/>, the number of characters written; otherwise 0.</param>
+    /// <returns><see langword="true"/> if the pointer was written; <see langword="false"/> if the
+    /// destination was too small, or the element is a default instance.</returns>
+    /// <remarks>
+    /// The root element produces the empty pointer. Property names are unescaped and then
+    /// pointer-escaped (<c>~</c> as <c>~0</c>, <c>/</c> as <c>~1</c>) per RFC 6901. This
+    /// operation performs no heap allocation.
+    /// </remarks>
+    [CLSCompliant(false)]
+    public static bool TryGetJsonPointer<T>(this T element, Span<char> destination, out int charsWritten)
+        where T : struct, IJsonElement<T>
+    {
+        if (element.ParentDocument is null)
+        {
+            charsWritten = 0;
+            return false;
+        }
+
+        element.CheckValidInstance();
+        return element.ParentDocument.TryGetJsonPointer(element.ParentDocumentIndex, destination, out charsWritten, out _);
+    }
+
+    /// <summary>
+    /// Gets the JSON Pointer (RFC 6901) of this element, relative to the root of its backing
+    /// document, as a string.
+    /// </summary>
+    /// <typeparam name="T">The type of the element.</typeparam>
+    /// <param name="element">The element whose pointer to derive.</param>
+    /// <returns>The JSON Pointer. The root element produces the empty string.</returns>
+    /// <exception cref="InvalidOperationException">
+    /// The element is a default instance.
+    /// </exception>
+    /// <remarks>
+    /// Property names are unescaped and then pointer-escaped (<c>~</c> as <c>~0</c>,
+    /// <c>/</c> as <c>~1</c>) per RFC 6901.
+    /// </remarks>
+    [CLSCompliant(false)]
+    public static string GetJsonPointer<T>(this T element)
+        where T : struct, IJsonElement<T>
+    {
+        element.CheckValidInstance();
+        return GetJsonPointerCore(element.ParentDocument, element.ParentDocumentIndex);
+    }
+
+    /// <summary>
+    /// Derives the JSON Pointer of the element at the specified index as a string, trying a
+    /// stack buffer first and renting the exact required size when the pointer is longer.
+    /// </summary>
+    /// <param name="parent">The document backing the element.</param>
+    /// <param name="index">The index of the element.</param>
+    /// <returns>The JSON Pointer.</returns>
+    internal static string GetJsonPointerCore(IJsonDocument parent, int index)
+    {
+        Span<char> buffer = stackalloc char[JsonConstants.StackallocCharThreshold];
+        if (parent.TryGetJsonPointer(index, buffer, out int written, out int required))
+        {
+            return buffer.Slice(0, written).ToString();
+        }
+
+        char[] rented = ArrayPool<char>.Shared.Rent(required);
+        try
+        {
+            bool success = parent.TryGetJsonPointer(index, rented, out written, out _);
+            Debug.Assert(success, "The exact required size must always fit");
+            return rented.AsSpan(0, written).ToString();
+        }
+        finally
+        {
+            ArrayPool<char>.Shared.Return(rented);
+        }
     }
 }

--- a/src/Corvus.Text.Json/Corvus/Text/Json/Document/ParsedJsonDocument.JsonPointer.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/Document/ParsedJsonDocument.JsonPointer.cs
@@ -1,0 +1,24 @@
+// <copyright file="ParsedJsonDocument.JsonPointer.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using Corvus.Text.Json.Internal;
+
+namespace Corvus.Text.Json;
+
+public sealed partial class ParsedJsonDocument<T>
+{
+    /// <inheritdoc />
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<byte> utf8Destination, out int bytesWritten, out int bytesRequired)
+    {
+        CheckNotDisposed();
+        return TryGetJsonPointerUnsafe(index, utf8Destination, out bytesWritten, out bytesRequired);
+    }
+
+    /// <inheritdoc />
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<char> destination, out int charsWritten, out int charsRequired)
+    {
+        CheckNotDisposed();
+        return TryGetJsonPointerUnsafe(index, destination, out charsWritten, out charsRequired);
+    }
+}

--- a/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/Internal/DefaultValueJsonDocument.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/Internal/DefaultValueJsonDocument.cs
@@ -446,6 +446,14 @@ public sealed class DefaultValueJsonDocument(IJsonDocument inner) : IMutableJson
     /// <inheritdoc />
     public bool TryGetLine(int lineNumber, [NotNullWhen(true)] out string? line) => this.inner.TryGetLine(lineNumber, out line);
 
+    /// <inheritdoc />
+    public bool TryGetJsonPointer(int index, Span<byte> utf8Destination, out int bytesWritten, out int bytesRequired)
+        => this.inner.TryGetJsonPointer(index, utf8Destination, out bytesWritten, out bytesRequired);
+
+    /// <inheritdoc />
+    public bool TryGetJsonPointer(int index, Span<char> destination, out int charsWritten, out int charsRequired)
+        => this.inner.TryGetJsonPointer(index, destination, out charsWritten, out charsRequired);
+
     /// <summary>
     /// Does nothing: this facade does not own the wrapped document, so it must not dispose it.
     /// </summary>

--- a/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/Internal/ParsedJsonDocumentBuilder.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/Internal/ParsedJsonDocumentBuilder.cs
@@ -1690,4 +1690,10 @@ public sealed class ParsedJsonDocumentBuilder : JsonDocument, IMutableJsonDocume
 
     /// <inheritdoc />
     bool IJsonDocument.TryGetLine(int lineNumber, [NotNullWhen(true)] out string? line) => throw ConstructionOnly();
+
+    /// <inheritdoc />
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<byte> utf8Destination, out int bytesWritten, out int bytesRequired) => throw ConstructionOnly();
+
+    /// <inheritdoc />
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<char> destination, out int charsWritten, out int charsRequired) => throw ConstructionOnly();
 }

--- a/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/JsonDocumentBuilder.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/DocumentBuilder/JsonDocumentBuilder.cs
@@ -2824,6 +2824,20 @@ public sealed partial class JsonDocumentBuilder<T> : JsonDocument, IMutableJsonD
         return false;
     }
 
+    /// <inheritdoc />
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<byte> utf8Destination, out int bytesWritten, out int bytesRequired)
+    {
+        CheckNotDisposed();
+        return TryGetJsonPointerUnsafe(index, utf8Destination, out bytesWritten, out bytesRequired);
+    }
+
+    /// <inheritdoc />
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<char> destination, out int charsWritten, out int charsRequired)
+    {
+        CheckNotDisposed();
+        return TryGetJsonPointerUnsafe(index, destination, out charsWritten, out charsRequired);
+    }
+
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private void CheckNotDisposed()
     {

--- a/src/Corvus.Text.Json/Corvus/Text/Json/JsonSchema/Internal/FixedJsonValueDocument.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/JsonSchema/Internal/FixedJsonValueDocument.cs
@@ -1245,6 +1245,24 @@ public sealed class FixedJsonValueDocument<T> : IJsonDocument, IWorkspaceManaged
         return false;
     }
 
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<byte> utf8Destination, out int bytesWritten, out int bytesRequired)
+    {
+        // Single-value document: the element is always the root, whose pointer is the empty string.
+        Debug.Assert(index == 0);
+        bytesWritten = 0;
+        bytesRequired = 0;
+        return true;
+    }
+
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<char> destination, out int charsWritten, out int charsRequired)
+    {
+        // Single-value document: the element is always the root, whose pointer is the empty string.
+        Debug.Assert(index == 0);
+        charsWritten = 0;
+        charsRequired = 0;
+        return true;
+    }
+
     public bool TryFormat(int index, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? formatProvider)
     {
         Debug.Assert(index == 0);

--- a/src/Corvus.Text.Json/Corvus/Text/Json/JsonSchema/Internal/FixedStringJsonDocument.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/JsonSchema/Internal/FixedStringJsonDocument.cs
@@ -755,6 +755,24 @@ public sealed class FixedStringJsonDocument<T> : IJsonDocument
         return false;
     }
 
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<byte> utf8Destination, out int bytesWritten, out int bytesRequired)
+    {
+        // Single-value document: the element is always the root, whose pointer is the empty string.
+        Debug.Assert(index == 0);
+        bytesWritten = 0;
+        bytesRequired = 0;
+        return true;
+    }
+
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<char> destination, out int charsWritten, out int charsRequired)
+    {
+        // Single-value document: the element is always the root, whose pointer is the empty string.
+        Debug.Assert(index == 0);
+        charsWritten = 0;
+        charsRequired = 0;
+        return true;
+    }
+
     public bool TryFormat(int index, Span<char> destination, out int charsWritten, ReadOnlySpan<char> format, IFormatProvider? formatProvider)
     {
         Debug.Assert(index == 0);

--- a/src/Corvus.Text.Json/Corvus/Text/Json/JsonSchema/Internal/ValuelessJsonDocument.cs
+++ b/src/Corvus.Text.Json/Corvus/Text/Json/JsonSchema/Internal/ValuelessJsonDocument.cs
@@ -589,6 +589,24 @@ public sealed class ValuelessJsonDocument<T> : IJsonDocument
         return false;
     }
 
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<byte> utf8Destination, out int bytesWritten, out int bytesRequired)
+    {
+        // Single-value document: the element is always the root, whose pointer is the empty string.
+        Debug.Assert(index == 0);
+        bytesWritten = 0;
+        bytesRequired = 0;
+        return true;
+    }
+
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<char> destination, out int charsWritten, out int charsRequired)
+    {
+        // Single-value document: the element is always the root, whose pointer is the empty string.
+        Debug.Assert(index == 0);
+        charsWritten = 0;
+        charsRequired = 0;
+        return true;
+    }
+
     /// <summary>Tries to format the value into a character span.</summary>
     /// <param name="index">The element index (always 0).</param>
     /// <param name="destination">The destination span.</param>

--- a/tests/Corvus.Text.Json.JsonPath.Tests/JsonPointerLocationTests.cs
+++ b/tests/Corvus.Text.Json.JsonPath.Tests/JsonPointerLocationTests.cs
@@ -1,0 +1,62 @@
+// <copyright file="JsonPointerLocationTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.JsonPath.Tests;
+
+/// <summary>
+/// Tests for retrieving the location of JSONPath query results as JSON Pointers
+/// relative to the queried document root (the issue #942 scenario).
+/// </summary>
+[TestClass]
+public class JsonPointerLocationTests
+{
+    private const string StoreDocument = """
+        {"store":{"book":[{"title":"A","price":10},{"title":"B","price":5}]}}
+        """;
+
+    [TestMethod]
+    public void QueryNodes_FilteredResult_ReportsItsPointerFromRoot()
+    {
+        using ParsedJsonDocument<JsonElement> dataDoc = ParsedJsonDocument<JsonElement>.Parse(StoreDocument);
+
+        using JsonPathResult result = JsonPathEvaluator.Default.QueryNodes(
+            "$.store.book[?@.price < 10].title",
+            dataDoc.RootElement);
+
+        Assert.AreEqual(1, result.Count);
+        Assert.AreEqual("/store/book/1/title", result[0].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void QueryNodes_DescendantResults_ReportDistinctPointers()
+    {
+        using ParsedJsonDocument<JsonElement> dataDoc = ParsedJsonDocument<JsonElement>.Parse(StoreDocument);
+
+        using JsonPathResult result = JsonPathEvaluator.Default.QueryNodes(
+            "$..price",
+            dataDoc.RootElement);
+
+        Assert.AreEqual(2, result.Count);
+        Assert.AreEqual("/store/book/0/price", result[0].GetJsonPointer());
+        Assert.AreEqual("/store/book/1/price", result[1].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void QueryNodes_PointersResolveBackToTheMatchedValues()
+    {
+        using ParsedJsonDocument<JsonElement> dataDoc = ParsedJsonDocument<JsonElement>.Parse(StoreDocument);
+
+        using JsonPathResult result = JsonPathEvaluator.Default.QueryNodes(
+            "$..price",
+            dataDoc.RootElement);
+
+        for (int i = 0; i < result.Count; i++)
+        {
+            Assert.IsTrue(dataDoc.RootElement.TryResolvePointer(result[i].GetJsonPointer(), out JsonElement resolved));
+            Assert.AreEqual(result[i].GetInt32(), resolved.GetInt32());
+        }
+    }
+}

--- a/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
+++ b/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
@@ -333,6 +333,7 @@
     <Compile Include="JsonElementParseTests.cs" />
     <Compile Include="JsonPointerExtensionTests.cs" />
     <Compile Include="JsonElementGetJsonPointerTests.cs" />
+    <Compile Include="NumericCastOperatorTests.cs" />
     <Compile Include="JsonElementWriteTests.cs" />
     <Compile Include="JsonEncodedTextTests.cs" />
     <Compile Include="JsonGuidTestData.cs" />

--- a/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
+++ b/tests/Corvus.Text.Json.Tests/Corvus.Text.Json.Tests.csproj
@@ -332,6 +332,7 @@
     <Compile Include="JsonElementNumericBoundaryTests.cs" />
     <Compile Include="JsonElementParseTests.cs" />
     <Compile Include="JsonPointerExtensionTests.cs" />
+    <Compile Include="JsonElementGetJsonPointerTests.cs" />
     <Compile Include="JsonElementWriteTests.cs" />
     <Compile Include="JsonEncodedTextTests.cs" />
     <Compile Include="JsonGuidTestData.cs" />

--- a/tests/Corvus.Text.Json.Tests/DummyDocument.cs
+++ b/tests/Corvus.Text.Json.Tests/DummyDocument.cs
@@ -319,4 +319,10 @@ internal class DummyDocument : IJsonDocument
 
     bool IJsonDocument.TryGetLine(int lineNumber, [NotNullWhen(true)] out string? line)
     { line = null; return false; }
+
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<byte> utf8Destination, out int bytesWritten, out int bytesRequired)
+    { bytesWritten = 0; bytesRequired = 0; return true; }
+
+    bool IJsonDocument.TryGetJsonPointer(int index, Span<char> destination, out int charsWritten, out int charsRequired)
+    { charsWritten = 0; charsRequired = 0; return true; }
 }

--- a/tests/Corvus.Text.Json.Tests/JsonElementGetJsonPointerTests.cs
+++ b/tests/Corvus.Text.Json.Tests/JsonElementGetJsonPointerTests.cs
@@ -1,0 +1,350 @@
+// <copyright file="JsonElementGetJsonPointerTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System;
+using System.Text;
+using Corvus.Text.Json.Internal;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.Tests;
+
+/// <summary>
+/// Tests for deriving the JSON Pointer (RFC 6901) of an element relative to its document root
+/// via <see cref="JsonElement.GetJsonPointer"/> and the TryGetJsonPointer span overloads.
+/// </summary>
+[TestClass]
+public class JsonElementGetJsonPointerTests
+{
+    private const string Rfc6901ExampleDocument = """
+        {
+            "foo": ["bar", "baz"],
+            "": 0,
+            "a/b": 1,
+            "c%d": 2,
+            "e^f": 3,
+            "g|h": 4,
+            "i\\j": 5,
+            "k\"l": 6,
+            " ": 7,
+            "m~n": 8
+        }
+        """;
+
+    private const string StoreDocument = """
+        {"store":{"book":[{"title":"A","price":10},{"title":"B","price":5}]}}
+        """;
+
+    [TestMethod]
+    public void RootElement_ProducesEmptyPointer()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(Rfc6901ExampleDocument);
+        Assert.AreEqual(string.Empty, doc.RootElement.GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void RootScalarDocument_ProducesEmptyPointer()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("42");
+        Assert.AreEqual(string.Empty, doc.RootElement.GetJsonPointer());
+    }
+
+    [TestMethod]
+    [DataRow("/foo")]
+    [DataRow("/foo/0")]
+    [DataRow("/foo/1")]
+    [DataRow("/")]
+    [DataRow("/a~1b")]
+    [DataRow("/c%d")]
+    [DataRow("/e^f")]
+    [DataRow("/g|h")]
+    [DataRow("/i\\j")]
+    [DataRow("/k\"l")]
+    [DataRow("/ ")]
+    [DataRow("/m~0n")]
+    public void Rfc6901ExamplePointers_RoundTripThroughResolveAndGet(string pointer)
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(Rfc6901ExampleDocument);
+        Assert.IsTrue(doc.RootElement.TryResolvePointer(pointer, out JsonElement resolved));
+        Assert.AreEqual(pointer, resolved.GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void NestedElement_ProducesFullPathFromRoot()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(StoreDocument);
+        JsonElement title = doc.RootElement["store"u8]["book"u8][1]["title"u8];
+        Assert.AreEqual("/store/book/1/title", title.GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void ContainerElement_ProducesItsOwnPointer()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(StoreDocument);
+        JsonElement book = doc.RootElement["store"u8]["book"u8];
+        Assert.AreEqual("/store/book", book.GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void ElementAfterContainerSiblings_CountsThemAsSingleValues()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(
+            """[{"a":1},[2,3],"x",{"b":{"c":[4]}},5]""");
+        Assert.AreEqual("/4", doc.RootElement[4].GetJsonPointer());
+        Assert.AreEqual("/3/b/c/0", doc.RootElement[3]["b"u8]["c"u8][0].GetJsonPointer());
+        Assert.AreEqual("/1/1", doc.RootElement[1][1].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void ObjectValueAfterContainerProperties_WalksOverThem()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(
+            """{"a":{"b":1},"c":[2,3],"d":4}""");
+        Assert.AreEqual("/d", doc.RootElement["d"u8].GetJsonPointer());
+        Assert.AreEqual("/c/1", doc.RootElement["c"u8][1].GetJsonPointer());
+        Assert.AreEqual("/a/b", doc.RootElement["a"u8]["b"u8].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void MultiDigitArrayIndex_FormatsAllDigits()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(
+            "[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14]");
+        Assert.AreEqual("/12", doc.RootElement[12].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void EscapedPropertyName_IsUnescapedBeforePointerEscaping()
+    {
+        // The parsed property names are "a\nb" (a real newline) and "café" (via é).
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(
+            """{"a\nb":{"café":1}}""");
+        Assert.AreEqual("/a\nb/café", doc.RootElement["a\nb"]["café"].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void PropertyNameContainingSlashAndTilde_AppliesPointerEscaping()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(
+            """{"~/":1}""");
+        Assert.AreEqual("/~0~1", doc.RootElement["~/"].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void JsonEscapedPropertyNameContainingSlashAndTilde_UnescapesThenPointerEscapes()
+    {
+        // The parsed property name is "~/" written with JSON \u escapes, so the
+        // metadata row carries the requires-unescaping flag.
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(
+            "{\"\\u007e\\u002f\":1}");
+        Assert.AreEqual("/~0~1", doc.RootElement["~/"].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void NonAsciiPropertyName_RoundTripsInBothEncodings()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(
+            """{"日本語":[null,{"emoji 🎉":true}]}""");
+        JsonElement element = doc.RootElement["日本語"][1]["emoji 🎉"];
+
+        Assert.AreEqual("/日本語/1/emoji 🎉", element.GetJsonPointer());
+
+        Span<byte> utf8Buffer = stackalloc byte[128];
+        Assert.IsTrue(element.TryGetJsonPointer(utf8Buffer, out int bytesWritten));
+        Assert.AreEqual("/日本語/1/emoji 🎉", Encoding.UTF8.GetString(utf8Buffer.Slice(0, bytesWritten).ToArray()));
+
+        Span<char> charBuffer = stackalloc char[128];
+        Assert.IsTrue(element.TryGetJsonPointer(charBuffer, out int charsWritten));
+        Assert.AreEqual("/日本語/1/emoji 🎉", charBuffer.Slice(0, charsWritten).ToString());
+    }
+
+    [TestMethod]
+    public void Utf8Destination_ExactSizeSucceeds_OneByteShortFails()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(StoreDocument);
+        JsonElement title = doc.RootElement["store"u8]["book"u8][0]["title"u8];
+
+        int exactLength = Encoding.UTF8.GetByteCount("/store/book/0/title");
+        Span<byte> exact = stackalloc byte[exactLength];
+        Assert.IsTrue(title.TryGetJsonPointer(exact, out int bytesWritten));
+        Assert.AreEqual(exactLength, bytesWritten);
+
+        Span<byte> short1 = stackalloc byte[exactLength - 1];
+        Assert.IsFalse(title.TryGetJsonPointer(short1, out bytesWritten));
+        Assert.AreEqual(0, bytesWritten);
+    }
+
+    [TestMethod]
+    public void CharDestination_ExactSizeSucceeds_OneCharShortFails()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(StoreDocument);
+        JsonElement title = doc.RootElement["store"u8]["book"u8][0]["title"u8];
+
+        Span<char> exact = stackalloc char["/store/book/0/title".Length];
+        Assert.IsTrue(title.TryGetJsonPointer(exact, out int charsWritten));
+        Assert.AreEqual("/store/book/0/title".Length, charsWritten);
+
+        Span<char> short1 = stackalloc char["/store/book/0/title".Length - 1];
+        Assert.IsFalse(title.TryGetJsonPointer(short1, out charsWritten));
+        Assert.AreEqual(0, charsWritten);
+    }
+
+    [TestMethod]
+    public void EmptyDestination_SucceedsForRoot()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("{}");
+        Assert.IsTrue(doc.RootElement.TryGetJsonPointer(Span<byte>.Empty, out int bytesWritten));
+        Assert.AreEqual(0, bytesWritten);
+        Assert.IsTrue(doc.RootElement.TryGetJsonPointer(Span<char>.Empty, out int charsWritten));
+        Assert.AreEqual(0, charsWritten);
+    }
+
+    [TestMethod]
+    public void DefaultElement_TryReturnsFalse_GetThrows()
+    {
+        JsonElement element = default;
+        Assert.IsFalse(element.TryGetJsonPointer(new byte[16], out int bytesWritten));
+        Assert.AreEqual(0, bytesWritten);
+        Assert.IsFalse(element.TryGetJsonPointer(new char[16], out int charsWritten));
+        Assert.AreEqual(0, charsWritten);
+        Assert.ThrowsExactly<InvalidOperationException>(() => element.GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void DisposedDocument_Throws()
+    {
+        ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("""{"a":1}""");
+        JsonElement element = doc.RootElement["a"u8];
+        doc.Dispose();
+        Assert.ThrowsExactly<ObjectDisposedException>(() => element.GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void PointerLongerThanStackBuffer_UsesExactSizedRetry()
+    {
+        string longName = new string('x', 300);
+        string json = string.Concat("{\"", longName, "\":{\"inner\":1}}");
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(json);
+        Assert.AreEqual($"/{longName}/inner", doc.RootElement[longName]["inner"].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void DepthBeyondSegmentStackCapacity_GrowsAndSucceeds()
+    {
+        const int Depth = 100;
+        var options = new JsonDocumentOptions { MaxDepth = Depth + 8 };
+        string json = string.Concat(new string('[', Depth), "7", new string(']', Depth));
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(json, options);
+
+        JsonElement element = doc.RootElement;
+        for (int i = 0; i < Depth; i++)
+        {
+            element = element[0];
+        }
+
+        string expected = string.Concat(System.Linq.Enumerable.Repeat("/0", Depth));
+        Assert.AreEqual(expected, element.GetJsonPointer());
+        Assert.IsTrue(doc.RootElement.TryResolvePointer(expected, out JsonElement resolved));
+        Assert.AreEqual(7, resolved.GetInt32());
+    }
+
+    [TestMethod]
+    public void PropertyNameElement_ProducesThePropertyPointer()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(
+            """{"a":{"b":1},"c":2}""");
+        JsonElement value = doc.RootElement["c"u8];
+        IJsonElement valueAccessor = value;
+        JsonElement nameElement = valueAccessor.ParentDocument.GetPropertyName(valueAccessor.ParentDocumentIndex);
+        Assert.AreEqual("/c", nameElement.GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void ParseValueElement_IsItsOwnRoot()
+    {
+        using ParsedJsonDocument<JsonElement> outer = ParsedJsonDocument<JsonElement>.Parse(
+            """{"a":{"b":1}}""");
+        using ParsedJsonDocument<JsonElement> clone = ParsedJsonDocument<JsonElement>.Parse("""{"b":1}""");
+        Assert.AreEqual(string.Empty, clone.RootElement.GetJsonPointer());
+        Assert.AreEqual("/b", clone.RootElement["b"u8].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void ExtensionOverloads_WorkForJsonElement()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(StoreDocument);
+        JsonElement price = doc.RootElement["store"u8]["book"u8][1]["price"u8];
+
+        Assert.AreEqual("/store/book/1/price", JsonElementExtensions.GetJsonPointer(price));
+
+        Span<byte> utf8Buffer = stackalloc byte[64];
+        Assert.IsTrue(JsonElementExtensions.TryGetJsonPointer(price, utf8Buffer, out int bytesWritten));
+        Assert.AreEqual("/store/book/1/price", Encoding.UTF8.GetString(utf8Buffer.Slice(0, bytesWritten).ToArray()));
+
+        Span<char> charBuffer = stackalloc char[64];
+        Assert.IsTrue(JsonElementExtensions.TryGetJsonPointer(price, charBuffer, out int charsWritten));
+        Assert.AreEqual("/store/book/1/price", charBuffer.Slice(0, charsWritten).ToString());
+    }
+
+    [TestMethod]
+    public void BuilderDocument_LocalAndDynamicValues_ProducePointers()
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+        using ParsedJsonDocument<JsonElement> sourceDoc = ParsedJsonDocument<JsonElement>.Parse(
+            """{"a":{"b":[1,2]}}""");
+        using JsonDocumentBuilder<JsonElement.Mutable> builder = sourceDoc.RootElement.CreateBuilder(workspace);
+        JsonElement.Mutable root = builder.RootElement;
+        root.SetProperty("z", 42);
+
+        JsonElement.Mutable z = root["z"];
+        Assert.AreEqual("/z", z.GetJsonPointer());
+
+        Span<byte> utf8Buffer = stackalloc byte[16];
+        Assert.IsTrue(z.TryGetJsonPointer(utf8Buffer, out int bytesWritten));
+        Assert.AreEqual("/z", Encoding.UTF8.GetString(utf8Buffer.Slice(0, bytesWritten).ToArray()));
+    }
+
+    [TestMethod]
+    public void BuilderDocument_ValueAfterExternalContainer_WalksOverMirroredRows()
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+        using ParsedJsonDocument<JsonElement> external = ParsedJsonDocument<JsonElement>.Parse(
+            """{"p":[10,20]}""");
+        using ParsedJsonDocument<JsonElement> sourceDoc = ParsedJsonDocument<JsonElement>.Parse("{}");
+        using JsonDocumentBuilder<JsonElement.Mutable> builder = sourceDoc.RootElement.CreateBuilder(workspace);
+        JsonElement.Mutable root = builder.RootElement;
+        root.SetProperty("ext", external.RootElement);
+        root.SetProperty("z", 1);
+
+        // The walk from "z" crosses the mirrored external container rows via its End row.
+        Assert.AreEqual("/z", root["z"].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void FrozenBuilderDocument_ProducesPointers()
+    {
+        using JsonWorkspace workspace = JsonWorkspace.Create();
+        using ParsedJsonDocument<JsonElement> external = ParsedJsonDocument<JsonElement>.Parse(
+            """{"p":[10,20]}""");
+        using ParsedJsonDocument<JsonElement> sourceDoc = ParsedJsonDocument<JsonElement>.Parse("{}");
+        using JsonDocumentBuilder<JsonElement.Mutable> builder = sourceDoc.RootElement.CreateBuilder(workspace);
+        JsonElement.Mutable root = builder.RootElement;
+        root.SetProperty("ext", external.RootElement);
+        root.SetProperty("z", 1);
+
+        JsonElement frozenRoot = root.Freeze();
+        Assert.AreEqual("/ext/p/1", frozenRoot["ext"u8]["p"u8][1].GetJsonPointer());
+    }
+
+    [TestMethod]
+    public void PointerRoundTrip_ResolvesToTheSameValue()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse(
+            """{"a":[{"m~n":{"x/y":[true,false,{"":null}]}}]}""");
+        JsonElement element = doc.RootElement["a"u8][0]["m~n"]["x/y"][2][""];
+        string pointer = element.GetJsonPointer();
+        Assert.AreEqual("/a/0/m~0n/x~1y/2/", pointer);
+        Assert.IsTrue(doc.RootElement.TryResolvePointer(pointer, out JsonElement resolved));
+        Assert.AreEqual(JsonValueKind.Null, resolved.ValueKind);
+    }
+}

--- a/tests/Corvus.Text.Json.Tests/NumericCastOperatorTests.cs
+++ b/tests/Corvus.Text.Json.Tests/NumericCastOperatorTests.cs
@@ -1,0 +1,115 @@
+// <copyright file="NumericCastOperatorTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System;
+using Corvus.Text.Json.Tests.GeneratedModels.Draft202012;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Corvus.Text.Json.Tests;
+
+/// <summary>
+/// Tests for the direct numeric cast operators on generated numeric types (issue #937).
+/// Every cast to a numeric CLR type must bind a user-defined operator directly, so an
+/// out-of-range value throws <see cref="FormatException"/> rather than being silently
+/// truncated by routing through the implicit conversion to <see langword="long"/>.
+/// </summary>
+[TestClass]
+public class NumericCastOperatorTests
+{
+    [TestMethod]
+    public void FormatType_CastToOwnFormatType_ReturnsValue()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("42");
+        JsonUInt16 value = doc.RootElement;
+        Assert.AreEqual((ushort)42, (ushort)value);
+    }
+
+    [TestMethod]
+    public void FormatType_CastToNarrowerType_InRange_ReturnsValue()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("42");
+        JsonUInt16 value = doc.RootElement;
+        Assert.AreEqual((byte)42, (byte)value);
+        Assert.AreEqual((sbyte)42, (sbyte)value);
+    }
+
+    [TestMethod]
+    public void FormatType_CastToNarrowerType_OutOfRange_Throws()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("300");
+        JsonUInt16 value = doc.RootElement;
+        Assert.ThrowsExactly<FormatException>(() => _ = (byte)value);
+    }
+
+    [TestMethod]
+    public void FormatType_CastToWiderTypes_ReturnsValue()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("300");
+        JsonUInt16 value = doc.RootElement;
+        Assert.AreEqual((short)300, (short)value);
+        Assert.AreEqual(300, (int)value);
+        Assert.AreEqual(300U, (uint)value);
+        Assert.AreEqual(300UL, (ulong)value);
+        Assert.AreEqual(300L, (long)value);
+        Assert.AreEqual(300f, (float)value);
+        Assert.AreEqual(300d, (double)value);
+        Assert.AreEqual(300m, (decimal)value);
+    }
+
+    [TestMethod]
+    public void PlainInteger_CastToUShort_OutOfRange_Throws()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("70000");
+        JsonInteger value = doc.RootElement;
+        Assert.ThrowsExactly<FormatException>(() => _ = (ushort)value);
+    }
+
+    [TestMethod]
+    public void PlainInteger_CastToInt_OutOfRange_Throws()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("3000000000");
+        JsonInteger value = doc.RootElement;
+        Assert.ThrowsExactly<FormatException>(() => _ = (int)value);
+    }
+
+    [TestMethod]
+    public void PlainInteger_NegativeValue_CastToUnsigned_Throws()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("-5");
+        JsonInteger value = doc.RootElement;
+        Assert.ThrowsExactly<FormatException>(() => _ = (uint)value);
+        Assert.ThrowsExactly<FormatException>(() => _ = (ulong)value);
+        Assert.ThrowsExactly<FormatException>(() => _ = (byte)value);
+    }
+
+    [TestMethod]
+    public void PlainInteger_InRangeCasts_ReturnValue()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("42");
+        JsonInteger value = doc.RootElement;
+        Assert.AreEqual((sbyte)42, (sbyte)value);
+        Assert.AreEqual((byte)42, (byte)value);
+        Assert.AreEqual((short)42, (short)value);
+        Assert.AreEqual((ushort)42, (ushort)value);
+        Assert.AreEqual(42, (int)value);
+        Assert.AreEqual(42U, (uint)value);
+        Assert.AreEqual(42L, (long)value);
+        Assert.AreEqual(42UL, (ulong)value);
+        Assert.AreEqual(42f, (float)value);
+        Assert.AreEqual(42d, (double)value);
+        Assert.AreEqual(42m, (decimal)value);
+    }
+
+#if NET
+    [TestMethod]
+    public void PlainInteger_NetOnlyCasts_ReturnValue()
+    {
+        using ParsedJsonDocument<JsonElement> doc = ParsedJsonDocument<JsonElement>.Parse("42");
+        JsonInteger value = doc.RootElement;
+        Assert.AreEqual((Int128)42, (Int128)value);
+        Assert.AreEqual((UInt128)42, (UInt128)value);
+        Assert.AreEqual((Half)42, (Half)value);
+    }
+#endif
+}


### PR DESCRIPTION
Two changes, one per commit, released together as 5.5.0.

## Fix #942: derive an element's JSON Pointer from the metadata database

`JsonElement`, `JsonElement.Mutable`, and every generated type (via `IJsonElement<T>` extension methods) can now report their location relative to the document root as an RFC 6901 JSON Pointer:

- `bool TryGetJsonPointer(Span<byte> utf8Destination, out int bytesWritten)` and the `Span<char>` twin are zero allocation (MemoryDiagnoser benchmark included: 0 B for both span overloads).
- `string GetJsonPointer()` is the convenience wrapper (a stack buffer first, then one exact-size rented retry driven by a required-length out parameter on the internal seam).

The pointer is derived by walking the metadata database backwards from the element to its ancestors. End rows always carry a locally-correct row count (external references mirror their full row structure), so the walk never leaves the element's own database and skips sibling containers in O(1). Property names are unescaped and then pointer-escaped (`~` → `~0`, `/` → `~1`). The root element produces the empty pointer; single-value synthetic documents do likewise.

This closes the loop for the issue's use case: JSONPath query results can report their locations as patch targets, and the acceptance tests cover exactly that scenario.

## Fix #937: emit the full numeric cast matrix on generated numeric types

Generated numeric types now emit explicit conversion operators for `sbyte`, `byte`, `short`, `ushort`, `int`, `uint`, `ulong`, and `float` (plus `Int128`/`UInt128`/`Half` under `#if NET`), alongside the existing implicit `long`/`double` and format-specific conversions, in both the single-numeric-domain and union emission paths. Every numeric cast binds a user-defined operator directly, so IDE0221 no longer fires, `(ulong)` on a plain integer type is no longer ambiguous, and the .NET-only numeric types become castable. This restores the V4 conversion surface.

**Breaking (hence 5.5.0):** lossy casts previously routed through implicit `long` and silently truncated (`(byte)` on 300 gave 44). The direct operators are range-checked and throw `FormatException` for out-of-range or non-integral values, matching V4. `GitVersion.yml` floor moved to 5.5 and VERSIONHISTORY.md carries the 5.5.0 entry.

## Verification

- Full `Corvus.Text.Json.slnx` build: 0 warnings, 0 errors (after each change).
- Full filtered test suite: 94,460 passed, 0 failed, including 37 new pointer tests, 3 JSONPath acceptance tests, and 9 cast-matrix tests (which compile-failed or behavior-failed before the fix).
- ExampleRecipes regenerated with the Release CLI; all 12 affected recipes run (9 to completion, 3 servers start cleanly); code-sample catalog check green.
- AsyncAPI playground solution builds clean; docs website capability card added for the pointer API.
- Not included per direction: benchmark model regeneration (`B/`/`C/` and `benchmarks/*/Generated`). The pre-existing `src/Corvus.Text.Json.AsyncApi26|30/Generated` drift (flagged under #939) widens slightly and remains outstanding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fMWB9opbgcQ2JGzqxVYZA
