### PR TITLE
Fix #949: hoisted property-map name collisions in generated model validation (5.5.2)

### DIFF
--- a/VERSIONHISTORY.md
+++ b/VERSIONHISTORY.md
@@ -1,5 +1,15 @@
 # Version History
 
+## V5.5.2
+
+V5.5.2 fixes a defect in the typed generated models that can make validation fail in both directions when a property name is declared in more than one composed schema scope. There are no new features and no breaking changes.
+
+### Bug fixes
+
+- **A property declared in both a schema's `properties` and its `$ref` or `allOf` target validates in every scope.** When a generated type hoists a composed `$ref` or `allOf` branch's property validation into its own object enumeration (which happens when the composition contributes four or more properties), the property-name lookup mapped each name to a single dispatch site, with local and hoisted entries indexed independently and no deduplication by name. A name declared both locally and in a hoisted branch, or in two hoisted branches, therefore reached only one of its validation sites, and whichever site lost the lookup was silently skipped: its `required` tracking never saw the property, so a present property was reported as "Required property not present" (the false rejection reported in the issue), and its property subschema was never evaluated, so an instance violating, for example, a `const` on the shared name was accepted. The lookup and every switch that consumes it are now built from a single dispatch plan with one entry per distinct property name, whose case executes the local match and every hoisted branch body. Compositions below the hoisting threshold and the standalone evaluator were not affected, and emitted code is unchanged for schemas with no shared names. See [#949](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/949).
+
+- **A type hoisting branches from both `$ref` and `allOf` compiles and dispatches correctly.** Branch-scoped identifiers in the hoisted validation code were derived from the branch's position within its own keyword alone, so a type composing hoistable branches from two keywords (for example a `$ref` sibling of an `allOf`) emitted colliding fields and locals that failed to compile, and the shared property-name lookup's indices did not line up with each keyword group's own dispatch switch. Identifiers are now disambiguated across keyword groups, and each group's switch carries its entries' indices from the shared plan. See [#949](https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/949).
+
 ## V5.5.1
 
 V5.5.1 fixes two defects in the standalone schema evaluator surface, one of which can make a generated evaluator validate incorrectly in both directions. There are no new features and no breaking changes.

--- a/src/Corvus.Text.Json.CodeGeneration/ValidationHandlers/ObjectChildHandlers/HoistedAllOfPropertyValidationHandler.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/ValidationHandlers/ObjectChildHandlers/HoistedAllOfPropertyValidationHandler.cs
@@ -128,8 +128,9 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
             int totalHoistedProperties = branchMetadataList.Sum(b => b.Properties.Count);
             if (totalHoistedProperties >= MinHoistedPropertiesForMap)
             {
-                EmitPropertyIndexMap(generator, branchMetadataList, localEntries: null);
-                typeDeclaration.SetMetadata(StandaloneMapBuiltKey, true);
+                UnifiedMapInfo plan = BuildDispatchPlan(branchMetadataList, localEntries: null);
+                EmitPropertyIndexMap(generator, plan, "TryGetHoistedPropertyIndex");
+                typeDeclaration.SetMetadata(StandaloneMapBuiltKey, plan);
             }
         }
 
@@ -323,11 +324,14 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
                     .AppendLineIndent("using UnescapedUtf8JsonString objectValidation_unescapedPropertyName = parentDocument.GetPropertyNameUnescaped(objectValidation_currentIndex);");
 
         // Emit per-property matching for each branch
-        bool useMap = typeDeclaration.TryGetMetadata(StandaloneMapBuiltKey, out bool standaloneMapBuilt) && standaloneMapBuilt;
+        bool useMap = typeDeclaration.TryGetMetadata(StandaloneMapBuiltKey, out UnifiedMapInfo? standalonePlan) && standalonePlan is not null;
 
         if (useMap)
         {
-            // Map-based dispatch
+            // Map-based dispatch. The map is shared across every keyword group's loop, so each
+            // loop's switch carries only the map indices whose sites belong to its own group; a
+            // name owned solely by another group falls through this switch and is handled by
+            // that group's loop.
             string matchIndexVar = generator.GetUniqueVariableNameInScope("matchIndex");
             generator
                 .AppendSeparatorLine()
@@ -338,18 +342,31 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
                     .AppendLineIndent("{")
                     .PushIndent();
 
-            int flatIndex = 0;
-            foreach (HoistedBranchMetadata branchMeta in keywordBranches)
+            foreach (UnifiedMapEntry entry in standalonePlan!.Entries)
             {
-                foreach (HoistedPropertyMetadata propMeta in branchMeta.Properties)
+                bool caseOpened = false;
+                foreach ((HoistedBranchMetadata branchMeta, HoistedPropertyMetadata propMeta) in entry.HoistedSites)
                 {
-                    generator.AppendLineIndent("case ", flatIndex.ToString(), ":");
-                    generator.PushIndent();
+                    if (branchMeta.KeywordName != keywordName)
+                    {
+                        continue;
+                    }
+
+                    if (!caseOpened)
+                    {
+                        generator.AppendLineIndent("case ", entry.MapIndex.ToString(), ":");
+                        generator.PushIndent();
+                        caseOpened = true;
+                    }
+
                     EmitHoistedPropertySwitchCaseBody(generator, branchMeta, propMeta);
+                }
+
+                if (caseOpened)
+                {
                     generator
                         .AppendLineIndent("break;")
                         .PopIndent();
-                    flatIndex++;
                 }
             }
 
@@ -413,23 +430,65 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
     }
 
     /// <summary>
+    /// Builds the dispatch plan shared by the property index map and every switch that consumes
+    /// it: one entry per distinct JSON property name, carrying the local property site (if any)
+    /// and every hoisted branch site for that name. A name declared both locally and in one or
+    /// more hoisted branches gets a single map index whose case executes all of its sites; the
+    /// map lookup can only ever resolve a name to one index, so per-site entries would leave all
+    /// but one site unreachable.
+    /// </summary>
+    /// <param name="hoistedBranches">The hoisted branch metadata.</param>
+    /// <param name="localEntries">Optional local property entries for the unified map (null for standalone).</param>
+    /// <returns>The dispatch plan.</returns>
+    internal static UnifiedMapInfo BuildDispatchPlan(
+        List<HoistedBranchMetadata> hoistedBranches,
+        List<UnifiedMapLocalEntry>? localEntries)
+    {
+        List<UnifiedMapEntry> entries = [];
+        Dictionary<string, UnifiedMapEntry> entriesByName = new(StringComparer.Ordinal);
+
+        if (localEntries is not null)
+        {
+            foreach (UnifiedMapLocalEntry local in localEntries)
+            {
+                UnifiedMapEntry entry = new(entries.Count, local.JsonPropertyName, local, []);
+                entries.Add(entry);
+                entriesByName.Add(local.JsonPropertyName, entry);
+            }
+        }
+
+        foreach (HoistedBranchMetadata branchMeta in hoistedBranches)
+        {
+            foreach (HoistedPropertyMetadata propMeta in branchMeta.Properties)
+            {
+                if (!entriesByName.TryGetValue(propMeta.JsonPropertyName, out UnifiedMapEntry? entry))
+                {
+                    entry = new(entries.Count, propMeta.JsonPropertyName, null, []);
+                    entries.Add(entry);
+                    entriesByName.Add(propMeta.JsonPropertyName, entry);
+                }
+
+                entry.HoistedSites.Add((branchMeta, propMeta));
+            }
+        }
+
+        return new UnifiedMapInfo(entries);
+    }
+
+    /// <summary>
     /// Emits the property index map (PropertySchemaMatchers&lt;MatchIndex&gt;) as static class members.
     /// </summary>
     /// <param name="generator">The code generator.</param>
-    /// <param name="hoistedBranches">The hoisted branch metadata.</param>
-    /// <param name="localEntries">Optional local property entries for unified map (null for standalone).</param>
+    /// <param name="plan">The dispatch plan built by <see cref="BuildDispatchPlan"/>.</param>
+    /// <param name="tryGetName">The name of the lookup method to emit.</param>
     internal static void EmitPropertyIndexMap(
         CodeGenerator generator,
-        List<HoistedBranchMetadata> hoistedBranches,
-        List<UnifiedMapLocalEntry>? localEntries)
+        UnifiedMapInfo plan,
+        string tryGetName)
     {
         string jsonPropertyNamesClassName = generator.JsonPropertyNamesClassName();
         string matchersName = generator.GetUniqueStaticReadOnlyPropertyNameInScope("HoistedMatchers");
         string builderName = generator.GetUniqueStaticReadOnlyPropertyNameInScope("HoistedMatchersBuilder");
-
-        string tryGetName = localEntries is not null
-            ? "TryGetUnifiedPropertyIndex"
-            : "TryGetHoistedPropertyIndex";
 
         generator
             .AppendSeparatorLine()
@@ -439,28 +498,18 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
                 .AppendLineIndent("return new PropertySchemaMatchers<MatchIndex>([")
                 .PushIndent();
 
-        int index = 0;
-
-        // Local entries first (parent-hosted unified map)
-        if (localEntries is not null)
+        foreach (UnifiedMapEntry entry in plan.Entries)
         {
-            foreach (UnifiedMapLocalEntry local in localEntries)
+            if (entry.Local is UnifiedMapLocalEntry local)
             {
                 generator
-                    .AppendLineIndent("(static () => ", jsonPropertyNamesClassName, ".", local.PropertyDotnetName, "Utf8, new MatchIndex(", index.ToString(), ")),");
-                index++;
+                    .AppendLineIndent("(static () => ", jsonPropertyNamesClassName, ".", local.PropertyDotnetName, "Utf8, new MatchIndex(", entry.MapIndex.ToString(), ")),");
             }
-        }
-
-        // Hoisted entries
-        foreach (HoistedBranchMetadata branchMeta in hoistedBranches)
-        {
-            foreach (HoistedPropertyMetadata propMeta in branchMeta.Properties)
+            else
             {
-                string propertyJsonName = SymbolDisplay.FormatLiteral(propMeta.JsonPropertyName, true);
+                string propertyJsonName = SymbolDisplay.FormatLiteral(entry.JsonPropertyName, true);
                 generator
-                    .AppendLineIndent("(static () => ", propertyJsonName, "u8, new MatchIndex(", index.ToString(), ")),");
-                index++;
+                    .AppendLineIndent("(static () => ", propertyJsonName, "u8, new MatchIndex(", entry.MapIndex.ToString(), ")),");
             }
         }
 
@@ -560,18 +609,14 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
 
     /// <summary>
     /// Emits the unified switch covering both local and hoisted properties for the parent-hosted case.
+    /// A plan entry whose name has both a local site and hoisted sites gets one case that executes
+    /// the local match first and then every hoisted branch body.
     /// </summary>
     private static CodeGenerator EmitUnifiedSwitch(
         CodeGenerator generator,
         TypeDeclaration typeDeclaration,
         UnifiedMapInfo unifiedMap)
     {
-        if (!typeDeclaration.TryGetMetadata(HoistedBranchMetadataKey, out List<HoistedBranchMetadata>? branchMetadataList) ||
-            branchMetadataList is null)
-        {
-            return generator;
-        }
-
         string matchIndexVar = generator.GetUniqueVariableNameInScope("matchIndex");
         generator
             .AppendSeparatorLine()
@@ -582,42 +627,34 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
                 .AppendLineIndent("{")
                 .PushIndent();
 
-        // Local property cases
-        foreach (UnifiedMapLocalEntry local in unifiedMap.LocalEntries)
+        foreach (UnifiedMapEntry entry in unifiedMap.Entries)
         {
-            generator.AppendLineIndent("case ", local.MapIndex.ToString(), ":");
+            generator.AppendLineIndent("case ", entry.MapIndex.ToString(), ":");
             generator.PushIndent();
 
-            PropertiesValidationHandler.AppendLocalPropertyDirectCall(generator, typeDeclaration, local.MethodName);
+            if (entry.Local is UnifiedMapLocalEntry local)
+            {
+                PropertiesValidationHandler.AppendLocalPropertyDirectCall(generator, typeDeclaration, local.MethodName);
+
+                generator
+                    .AppendSeparatorLine()
+                    .AppendLineIndent("if (!context.HasCollector && !context.IsMatch)")
+                    .AppendLineIndent("{")
+                    .PushIndent()
+                        .AppendLineIndent("return;")
+                    .PopIndent()
+                    .AppendLineIndent("}")
+                    .AppendSeparatorLine();
+            }
+
+            foreach ((HoistedBranchMetadata branchMeta, HoistedPropertyMetadata propMeta) in entry.HoistedSites)
+            {
+                EmitHoistedPropertySwitchCaseBody(generator, branchMeta, propMeta);
+            }
 
             generator
-                .AppendSeparatorLine()
-                .AppendLineIndent("if (!context.HasCollector && !context.IsMatch)")
-                .AppendLineIndent("{")
-                .PushIndent()
-                    .AppendLineIndent("return;")
-                .PopIndent()
-                .AppendLineIndent("}")
-                .AppendSeparatorLine()
                 .AppendLineIndent("break;")
                 .PopIndent();
-        }
-
-        // Hoisted property cases
-        int hoistedBaseIndex = unifiedMap.LocalEntries.Count;
-        int flatIndex = hoistedBaseIndex;
-        foreach (HoistedBranchMetadata branchMeta in branchMetadataList)
-        {
-            foreach (HoistedPropertyMetadata propMeta in branchMeta.Properties)
-            {
-                generator.AppendLineIndent("case ", flatIndex.ToString(), ":");
-                generator.PushIndent();
-                EmitHoistedPropertySwitchCaseBody(generator, branchMeta, propMeta);
-                generator
-                    .AppendLineIndent("break;")
-                    .PopIndent();
-                flatIndex++;
-            }
         }
 
         generator
@@ -645,6 +682,11 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
 
         List<HoistedBranchMetadata>? result = null;
 
+        // Branch-scoped identifiers are derived from the per-keyword branch index alone, so two
+        // keyword groups (e.g. $ref and allOf) can both own a branch 0; track the slots handed
+        // out so a later group's branch gets a disambiguated slot instead of a colliding one.
+        HashSet<string> usedBranchSlots = new(StringComparer.Ordinal);
+
         foreach (IAllOfSubschemaValidationKeyword keyword in subschemaDictionary.Keys)
         {
             IReadOnlyCollection<TypeDeclaration> subschemaTypes = subschemaDictionary[keyword];
@@ -660,7 +702,7 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
 
                     HoistedBranchMetadata branchMeta = BuildBranchMetadata(
                         generator, keyword.Keyword, i, reducedType.ReducedType,
-                        targetTypeName, jsonSchemaClassName, evalPathPropName);
+                        targetTypeName, jsonSchemaClassName, evalPathPropName, usedBranchSlots);
 
                     result ??= [];
                     result.Add(branchMeta);
@@ -708,10 +750,18 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
         TypeDeclaration reducedType,
         string targetTypeName,
         string jsonSchemaClassName,
-        string evalPathPropertyName)
+        string evalPathPropertyName,
+        HashSet<string> usedBranchSlots)
     {
-        string contextName = $"hoistedAllOf{branchIndex}_context";
-        string requiredBitsName = $"hoistedAllOf{branchIndex}_requiredBits";
+        string branchSlot = $"hoistedAllOf{branchIndex}";
+        int slotDisambiguator = 1;
+        while (!usedBranchSlots.Add(branchSlot))
+        {
+            branchSlot = $"hoistedAllOf{branchIndex}_{slotDisambiguator++}";
+        }
+
+        string contextName = $"{branchSlot}_context";
+        string requiredBitsName = $"{branchSlot}_requiredBits";
 
         List<HoistedPropertyMetadata> properties = [];
         foreach (PropertyDeclaration property in reducedType.PropertyDeclarations)
@@ -721,7 +771,7 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
                 continue;
             }
 
-            string propEvalPathName = generator.GetPropertyNameInScope($"HoistedAllOf{branchIndex}_{property.DotnetPropertyName()}SchemaEvaluationPath");
+            string propEvalPathName = generator.GetUniqueStaticReadOnlyPropertyNameInScope($"HoistedAllOf{branchIndex}_{property.DotnetPropertyName()}SchemaEvaluationPath");
             string propReducedTypeName = property.ReducedPropertyType.FullyQualifiedDotnetTypeName();
             string propJsonSchemaClassName = generator.JsonSchemaClassName(propReducedTypeName);
 
@@ -749,8 +799,8 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
             uint bitValue = 1U << currentBitShift;
             string bitName = generator.GetUniqueStaticReadOnlyPropertyNameInScope($"HoistedAllOf{branchIndex}_RequiredBitFor", suffix: property.JsonPropertyName, rootScope: generator.JsonSchemaClassScope());
             string offsetName = generator.GetUniqueStaticReadOnlyPropertyNameInScope($"HoistedAllOf{branchIndex}_RequiredOffsetFor", suffix: property.JsonPropertyName, rootScope: generator.JsonSchemaClassScope());
-            string presentName = generator.GetStaticReadOnlyFieldNameInScope(property.JsonPropertyName, prefix: $"HoistedAllOf{branchIndex}_RequiredProperty", suffix: "Present");
-            string notPresentName = generator.GetStaticReadOnlyFieldNameInScope(property.JsonPropertyName, prefix: $"HoistedAllOf{branchIndex}_RequiredProperty", suffix: "NotPresent");
+            string presentName = generator.GetUniqueStaticReadOnlyPropertyNameInScope(property.JsonPropertyName, prefix: $"HoistedAllOf{branchIndex}_RequiredProperty", suffix: "Present");
+            string notPresentName = generator.GetUniqueStaticReadOnlyPropertyNameInScope(property.JsonPropertyName, prefix: $"HoistedAllOf{branchIndex}_RequiredProperty", suffix: "NotPresent");
 
             string requiredKeyword = property.RequiredKeyword is IKeyword k ? k.Keyword : "required";
 
@@ -981,27 +1031,46 @@ internal sealed class HoistedAllOfPropertyValidationHandler : IChildObjectProper
 
     internal sealed class UnifiedMapInfo
     {
-        public UnifiedMapInfo(List<UnifiedMapLocalEntry> localEntries)
+        public UnifiedMapInfo(List<UnifiedMapEntry> entries)
         {
-            LocalEntries = localEntries;
+            Entries = entries;
         }
 
-        public List<UnifiedMapLocalEntry> LocalEntries { get; }
+        public List<UnifiedMapEntry> Entries { get; }
     }
 
-    internal sealed class UnifiedMapLocalEntry
+    internal sealed class UnifiedMapEntry
     {
-        public UnifiedMapLocalEntry(int mapIndex, string methodName, string propertyDotnetName)
+        public UnifiedMapEntry(int mapIndex, string jsonPropertyName, UnifiedMapLocalEntry? local, List<(HoistedBranchMetadata Branch, HoistedPropertyMetadata Property)> hoistedSites)
         {
             MapIndex = mapIndex;
-            MethodName = methodName;
-            PropertyDotnetName = propertyDotnetName;
+            JsonPropertyName = jsonPropertyName;
+            Local = local;
+            HoistedSites = hoistedSites;
         }
 
         public int MapIndex { get; }
 
+        public string JsonPropertyName { get; }
+
+        public UnifiedMapLocalEntry? Local { get; }
+
+        public List<(HoistedBranchMetadata Branch, HoistedPropertyMetadata Property)> HoistedSites { get; }
+    }
+
+    internal sealed class UnifiedMapLocalEntry
+    {
+        public UnifiedMapLocalEntry(string methodName, string propertyDotnetName, string jsonPropertyName)
+        {
+            MethodName = methodName;
+            PropertyDotnetName = propertyDotnetName;
+            JsonPropertyName = jsonPropertyName;
+        }
+
         public string MethodName { get; }
 
         public string PropertyDotnetName { get; }
+
+        public string JsonPropertyName { get; }
     }
 }

--- a/src/Corvus.Text.Json.CodeGeneration/ValidationHandlers/ObjectChildHandlers/PropertiesValidationHandler.cs
+++ b/src/Corvus.Text.Json.CodeGeneration/ValidationHandlers/ObjectChildHandlers/PropertiesValidationHandler.cs
@@ -83,7 +83,7 @@ public class PropertiesValidationHandler : IChildObjectPropertyValidationHandler
             return generator;
         }
 
-        List<(string, string)> propertyAndMethodNames = [];
+        List<(string PropertyName, string MethodName, string JsonPropertyName)> propertyAndMethodNames = [];
 
         string propertyValidatorDelegateName = generator.GetOrEmitNamedTypeInRootNamespace("PropertiesValidationHandler_NamedPropertyValidator", BuildValidatorDelegateKey(typeDeclaration, children), (generator, globalName) =>
         {
@@ -99,7 +99,7 @@ public class PropertiesValidationHandler : IChildObjectPropertyValidationHandler
 
             string methodName = generator.GetUniqueStaticReadOnlyPropertyNameInScope("Match", suffix: propertyName);
 
-            propertyAndMethodNames.Add((propertyName, methodName));
+            propertyAndMethodNames.Add((propertyName, methodName, property.JsonPropertyName));
 
             bool requiresAddLocalEvaluatedProperty = children.Any(c => c.WillEmitCodeFor(typeDeclaration) && c.EvaluatesProperty(property));
 
@@ -118,18 +118,20 @@ public class PropertiesValidationHandler : IChildObjectPropertyValidationHandler
 
         if (shouldBuildUnifiedMap)
         {
-            // Build a unified map containing both local and hoisted property names
+            // Build a unified map containing both local and hoisted property names, merged by
+            // JSON property name so a name declared in both scopes dispatches to a single case
+            // that runs every site.
             List<HoistedAllOfPropertyValidationHandler.UnifiedMapLocalEntry> localEntries = [];
-            int index = 0;
-            foreach ((string propertyName, string methodName) in propertyAndMethodNames)
+            foreach ((string propertyName, string methodName, string jsonPropertyName) in propertyAndMethodNames)
             {
-                localEntries.Add(new HoistedAllOfPropertyValidationHandler.UnifiedMapLocalEntry(index, methodName, propertyName));
-                index++;
+                localEntries.Add(new HoistedAllOfPropertyValidationHandler.UnifiedMapLocalEntry(methodName, propertyName, jsonPropertyName));
             }
 
-            HoistedAllOfPropertyValidationHandler.EmitPropertyIndexMap(generator, hoistedBranches!, localEntries);
+            HoistedAllOfPropertyValidationHandler.UnifiedMapInfo unifiedMap =
+                HoistedAllOfPropertyValidationHandler.BuildDispatchPlan(hoistedBranches!, localEntries);
 
-            var unifiedMap = new HoistedAllOfPropertyValidationHandler.UnifiedMapInfo(localEntries);
+            HoistedAllOfPropertyValidationHandler.EmitPropertyIndexMap(generator, unifiedMap, "TryGetUnifiedPropertyIndex");
+
             typeDeclaration.SetMetadata(HoistedAllOfPropertyValidationHandler.UnifiedMapMetadataKey, unifiedMap);
         }
         else
@@ -302,7 +304,7 @@ file static class PropertiesValidationHandlerExtensions
         return generator;
     }
 
-    public static CodeGenerator BuildPropertyValidatorMap(this CodeGenerator generator, TypeDeclaration typeDeclaration, List<INamedPropertyChildHandler> children, List<(string propertyName, string methodName)> propertyAndMethodNames, string propertyValidatorDelegateName)
+    public static CodeGenerator BuildPropertyValidatorMap(this CodeGenerator generator, TypeDeclaration typeDeclaration, List<INamedPropertyChildHandler> children, List<(string PropertyName, string MethodName, string JsonPropertyName)> propertyAndMethodNames, string propertyValidatorDelegateName)
     {
         string jsonPropertyNamesClassName = generator.JsonPropertyNamesClassName();
 
@@ -320,7 +322,7 @@ file static class PropertiesValidationHandlerExtensions
                     .AppendLineIndent("return new PropertySchemaMatchers<", propertyValidatorDelegateName, ">([")
                     .PushIndent();
 
-            foreach ((string propertyName, string methodName) in propertyAndMethodNames)
+            foreach ((string propertyName, string methodName, string _) in propertyAndMethodNames)
             {
                 generator
                         .AppendLineIndent("(static () => ", jsonPropertyNamesClassName, ".", propertyName, "Utf8, ", methodName, "),");
@@ -359,7 +361,7 @@ file static class PropertiesValidationHandlerExtensions
                 .AppendLineIndent("{")
                 .PushIndent();
 
-            foreach ((string propertyName, string methodName) in propertyAndMethodNames)
+            foreach ((string propertyName, string methodName, string _) in propertyAndMethodNames)
             {
                 generator
                         .AppendSeparatorLine()

--- a/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/NestedRequiredDoubleEvaluationTests.cs
+++ b/tests/Corvus.Text.Json.EvaluatorTestSuite.Tests/NestedRequiredDoubleEvaluationTests.cs
@@ -1,0 +1,477 @@
+// <copyright file="NestedRequiredDoubleEvaluationTests.cs" company="Endjin Limited">
+// Copyright (c) Endjin Limited. All rights reserved.
+// </copyright>
+
+using System.Reflection;
+using System.Threading.Tasks;
+using Corvus.Text.Json;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using TestUtilities;
+
+namespace Corvus.Text.Json.EvaluatorTestSuite.Tests;
+
+/// <summary>
+/// Repro tests for https://github.com/corvus-dotnet/Corvus.JsonSchema/issues/949.
+/// A property declared <c>required</c> both in a schema and in the schema it
+/// references via <c>$ref</c> must validate once per scope against the same
+/// instance, and both evaluations must succeed when the property is present.
+/// </summary>
+[TestClass]
+public class NestedRequiredDoubleEvaluationTests
+{
+    /// <summary>
+    /// Minimal shape: the child schema declares <c>required: [type]</c> and also
+    /// references a base schema that declares <c>required: [type]</c>.
+    /// </summary>
+    private const string MinimalOverlappingRequiredSchema =
+        """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://example.com/base",
+            "type": "object",
+            "required": ["type"],
+            "properties": {
+                "type": { "const": "IpConnection" }
+            },
+            "$defs": {
+                "base": {
+                    "$id": "https://example.com/base",
+                    "type": "object",
+                    "required": ["type"],
+                    "properties": {
+                        "type": { "type": "string" }
+                    }
+                }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The reporter's shape: a wrapper schema whose property references a child
+    /// schema, which itself references a base schema; both child and base declare
+    /// <c>required</c> for the same property, and the child adds one of its own.
+    /// </summary>
+    private const string WrappedOverlappingRequiredSchema =
+        """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "connection": { "$ref": "https://example.com/child" }
+            },
+            "$defs": {
+                "child": {
+                    "$id": "https://example.com/child",
+                    "type": "object",
+                    "$ref": "https://example.com/base",
+                    "required": ["hostname", "type"],
+                    "properties": {
+                        "type": { "const": "IpConnection" },
+                        "hostname": { "type": "string" },
+                        "port": { "type": "integer" }
+                    }
+                },
+                "base": {
+                    "$id": "https://example.com/base",
+                    "type": "object",
+                    "required": ["type"],
+                    "properties": {
+                        "type": { "type": "string" },
+                        "timeout_ms": { "type": "integer", "minimum": 0 },
+                        "cooldown_ms": { "type": "integer", "minimum": 0 },
+                        "cooldown_id": { "type": "string" }
+                    }
+                }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// The reporter's child schema also constrains unevaluated properties, which switches
+    /// the generated object validation onto the evaluated-property tracking path.
+    /// </summary>
+    private const string UnevaluatedPropertiesOverlappingRequiredSchema =
+        """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "connection": { "$ref": "https://example.com/child" }
+            },
+            "$defs": {
+                "child": {
+                    "$id": "https://example.com/child",
+                    "type": "object",
+                    "$ref": "https://example.com/base",
+                    "unevaluatedProperties": false,
+                    "required": ["hostname", "type"],
+                    "properties": {
+                        "type": { "const": "IpConnection" },
+                        "hostname": { "type": "string" },
+                        "port": { "type": "integer" }
+                    }
+                },
+                "base": {
+                    "$id": "https://example.com/base",
+                    "type": "object",
+                    "required": ["type"],
+                    "properties": {
+                        "type": { "type": "string" },
+                        "timeout_ms": { "type": "integer", "minimum": 0 },
+                        "cooldown_ms": { "type": "integer", "minimum": 0 },
+                        "cooldown_id": { "type": "string" }
+                    }
+                }
+            }
+        }
+        """;
+
+    [TestMethod]
+    public async Task OverlappingRequired_UnevaluatedPropertiesRefChain_PresentPropertiesAreAccepted()
+    {
+        CompiledEvaluator evaluator = await GenerateAsync(UnevaluatedPropertiesOverlappingRequiredSchema, "issue949UnevaluatedOverlappingRequired.json");
+
+        AssertEvaluates(
+            evaluator,
+            /*lang=json*/ """{"connection": {"type": "IpConnection", "hostname": "10.0.0.228", "cooldown_id": "evcc", "port": 7070, "timeout_ms": 2000, "cooldown_ms": 1250}}""",
+            expected: true,
+            "All required properties are present in both scopes, so it must be valid.");
+        AssertEvaluates(
+            evaluator,
+            /*lang=json*/ """{"connection": {"hostname": "10.0.0.228"}}""",
+            expected: false,
+            "'type' is absent from the connection object, so it must be invalid.");
+    }
+
+    [TestMethod]
+    public async Task OverlappingRequired_MinimalRefChain_PresentPropertyIsAccepted()
+    {
+        CompiledEvaluator evaluator = await GenerateAsync(MinimalOverlappingRequiredSchema, "issue949MinimalOverlappingRequired.json");
+
+        AssertEvaluates(evaluator, /*lang=json*/ """{"type": "IpConnection"}""", expected: true, "'type' is present and satisfies both scopes' constraints, so it must be valid.");
+        AssertEvaluates(evaluator, /*lang=json*/ """{}""", expected: false, "'type' is absent, so it must be invalid.");
+        AssertEvaluates(evaluator, /*lang=json*/ """{"type": "SerialConnection"}""", expected: false, "'type' does not match the const, so it must be invalid.");
+    }
+
+    [TestMethod]
+    public async Task OverlappingRequired_WrappedRefChain_PresentPropertiesAreAccepted()
+    {
+        CompiledEvaluator evaluator = await GenerateAsync(WrappedOverlappingRequiredSchema, "issue949WrappedOverlappingRequired.json");
+
+        AssertEvaluates(
+            evaluator,
+            /*lang=json*/ """{"connection": {"type": "IpConnection", "hostname": "10.0.0.228", "cooldown_id": "evcc", "port": 7070, "timeout_ms": 2000, "cooldown_ms": 1250}}""",
+            expected: true,
+            "All required properties are present in both scopes, so it must be valid.");
+        AssertEvaluates(
+            evaluator,
+            /*lang=json*/ """{"connection": {"hostname": "10.0.0.228"}}""",
+            expected: false,
+            "'type' is absent from the connection object, so it must be invalid.");
+        AssertEvaluates(
+            evaluator,
+            /*lang=json*/ """{"connection": {"type": "IpConnection"}}""",
+            expected: false,
+            "'hostname' is absent from the connection object, so it must be invalid.");
+    }
+
+    /// <summary>
+    /// False-acceptance twin: the base declares 'type' with a constraint the instance
+    /// violates (maxLength), but is not required there. The hoisted property subschema
+    /// must still be applied even though the child also declares 'type'.
+    /// </summary>
+    private const string OverlappingPropertyStricterBaseSchema =
+        """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "connection": { "$ref": "https://example.com/child" }
+            },
+            "$defs": {
+                "child": {
+                    "$id": "https://example.com/child",
+                    "type": "object",
+                    "$ref": "https://example.com/base",
+                    "required": ["hostname", "type"],
+                    "properties": {
+                        "type": { "const": "IpConnection" },
+                        "hostname": { "type": "string" },
+                        "port": { "type": "integer" }
+                    }
+                },
+                "base": {
+                    "$id": "https://example.com/base",
+                    "type": "object",
+                    "properties": {
+                        "type": { "type": "string", "maxLength": 5 },
+                        "timeout_ms": { "type": "integer", "minimum": 0 },
+                        "cooldown_ms": { "type": "integer", "minimum": 0 },
+                        "cooldown_id": { "type": "string" }
+                    }
+                }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// False-acceptance repro: 'type' is declared in both scopes but required in neither
+    /// beyond hostname; whichever duplicate map entry loses the lookup has its property
+    /// subschema silently skipped, so the child's const must still be enforced.
+    /// </summary>
+    private const string OverlappingPropertyConstNotRequiredSchema =
+        """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "type": "object",
+            "properties": {
+                "connection": { "$ref": "https://example.com/child" }
+            },
+            "$defs": {
+                "child": {
+                    "$id": "https://example.com/child",
+                    "type": "object",
+                    "$ref": "https://example.com/base",
+                    "required": ["hostname"],
+                    "properties": {
+                        "type": { "const": "IpConnection" },
+                        "hostname": { "type": "string" },
+                        "port": { "type": "integer" }
+                    }
+                },
+                "base": {
+                    "$id": "https://example.com/base",
+                    "type": "object",
+                    "properties": {
+                        "type": { "type": "string", "maxLength": 5 },
+                        "timeout_ms": { "type": "integer", "minimum": 0 },
+                        "cooldown_ms": { "type": "integer", "minimum": 0 },
+                        "cooldown_id": { "type": "string" }
+                    }
+                }
+            }
+        }
+        """;
+
+    [TestMethod]
+    public async Task GeneratedTypes_WrappedRefChain_ChildConstOnOverlappingProperty_StillApplies()
+    {
+        await AssertGeneratedTypeEvaluates(
+            OverlappingPropertyConstNotRequiredSchema,
+            "issue949OverlappingPropertyConstNotRequired.json",
+            /*lang=json*/ """{"connection": {"type": "abc", "hostname": "10.0.0.228", "port": 7070}}""",
+            expected: false,
+            "'abc' violates the child schema's const for 'type', so it must be invalid.");
+    }
+
+    [TestMethod]
+    public async Task GeneratedTypes_MinimalRefChain_OverlappingRequired_PresentPropertyIsAccepted()
+    {
+        await AssertGeneratedTypeEvaluates(
+            MinimalOverlappingRequiredSchema,
+            "issue949MinimalOverlappingRequired.json",
+            /*lang=json*/ """{"type": "IpConnection"}""",
+            expected: true,
+            "'type' is present and satisfies both scopes' constraints, so it must be valid.");
+    }
+
+    [TestMethod]
+    public async Task GeneratedTypes_WrappedRefChain_OverlappingRequired_PresentPropertiesAreAccepted()
+    {
+        await AssertGeneratedTypeEvaluates(
+            WrappedOverlappingRequiredSchema,
+            "issue949WrappedOverlappingRequired.json",
+            /*lang=json*/ """{"connection": {"type": "IpConnection", "hostname": "10.0.0.228", "cooldown_id": "evcc", "port": 7070, "timeout_ms": 2000, "cooldown_ms": 1250}}""",
+            expected: true,
+            "All required properties are present in both scopes, so it must be valid.");
+    }
+
+    [TestMethod]
+    public async Task GeneratedTypes_WrappedRefChain_UnevaluatedProperties_PresentPropertiesAreAccepted()
+    {
+        await AssertGeneratedTypeEvaluates(
+            UnevaluatedPropertiesOverlappingRequiredSchema,
+            "issue949UnevaluatedOverlappingRequired.json",
+            /*lang=json*/ """{"connection": {"type": "IpConnection", "hostname": "10.0.0.228", "cooldown_id": "evcc", "port": 7070, "timeout_ms": 2000, "cooldown_ms": 1250}}""",
+            expected: true,
+            "All required properties are present in both scopes, so it must be valid.");
+    }
+
+    [TestMethod]
+    public async Task GeneratedTypes_WrappedRefChain_MissingRequiredProperty_IsRejected()
+    {
+        await AssertGeneratedTypeEvaluates(
+            WrappedOverlappingRequiredSchema,
+            "issue949WrappedOverlappingRequired.json",
+            /*lang=json*/ """{"connection": {"hostname": "10.0.0.228"}}""",
+            expected: false,
+            "'type' is absent from the connection object, so it must be invalid.");
+    }
+
+    [TestMethod]
+    public async Task GeneratedTypes_WrappedRefChain_HoistedPropertySubschemaStillApplies()
+    {
+        await AssertGeneratedTypeEvaluates(
+            OverlappingPropertyStricterBaseSchema,
+            "issue949OverlappingPropertyStricterBase.json",
+            /*lang=json*/ """{"connection": {"type": "IpConnection", "hostname": "10.0.0.228", "port": 7070}}""",
+            expected: false,
+            "'IpConnection' violates the base schema's maxLength for 'type', so it must be invalid.");
+    }
+
+    /// <summary>
+    /// Standalone loop (no local object keywords on the parent): two allOf branches share a
+    /// property name, so the shared hoisted map must dispatch that name to both branch bodies.
+    /// </summary>
+    private const string StandaloneCrossBranchCollisionSchema =
+        """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "allOf": [
+                { "$ref": "https://example.com/a" },
+                { "$ref": "https://example.com/b" }
+            ],
+            "$defs": {
+                "a": {
+                    "$id": "https://example.com/a",
+                    "type": "object",
+                    "required": ["common"],
+                    "properties": {
+                        "common": { "type": "string" },
+                        "p1": { "type": "integer" },
+                        "p2": { "type": "integer" }
+                    }
+                },
+                "b": {
+                    "$id": "https://example.com/b",
+                    "type": "object",
+                    "properties": {
+                        "common": { "type": "string", "maxLength": 5 },
+                        "p3": { "type": "string" }
+                    }
+                }
+            }
+        }
+        """;
+
+    /// <summary>
+    /// Standalone loop with two hoisted keyword groups ($ref and allOf): the shared map's
+    /// indices must line up with each group's own switch, or one group dispatches into the
+    /// wrong case body.
+    /// </summary>
+    private const string StandaloneTwoKeywordGroupsSchema =
+        """
+        {
+            "$schema": "https://json-schema.org/draft/2020-12/schema",
+            "$ref": "https://example.com/a",
+            "allOf": [
+                { "$ref": "https://example.com/b" }
+            ],
+            "$defs": {
+                "a": {
+                    "$id": "https://example.com/a",
+                    "type": "object",
+                    "required": ["common"],
+                    "properties": {
+                        "common": { "type": "string" },
+                        "p1": { "type": "integer" },
+                        "p2": { "type": "integer" }
+                    }
+                },
+                "b": {
+                    "$id": "https://example.com/b",
+                    "type": "object",
+                    "properties": {
+                        "common": { "type": "string", "maxLength": 5 },
+                        "p3": { "type": "string" }
+                    }
+                }
+            }
+        }
+        """;
+
+    [TestMethod]
+    public async Task GeneratedTypes_StandaloneLoop_CrossBranchCollision_BothBranchesApply()
+    {
+        await AssertGeneratedTypeEvaluates(
+            StandaloneCrossBranchCollisionSchema,
+            "issue949StandaloneCrossBranchCollision.json",
+            /*lang=json*/ """{"common": "ok"}""",
+            expected: true,
+            "'common' is present and satisfies both branches, so it must be valid.");
+
+        await AssertGeneratedTypeEvaluates(
+            StandaloneCrossBranchCollisionSchema,
+            "issue949StandaloneCrossBranchCollision.json",
+            /*lang=json*/ """{"common": "toolong!!"}""",
+            expected: false,
+            "'toolong!!' violates the second branch's maxLength for 'common', so it must be invalid.");
+
+        await AssertGeneratedTypeEvaluates(
+            StandaloneCrossBranchCollisionSchema,
+            "issue949StandaloneCrossBranchCollision.json",
+            /*lang=json*/ """{"p1": 1}""",
+            expected: false,
+            "'common' is absent, so the first branch's required must fail.");
+    }
+
+    [TestMethod]
+    public async Task GeneratedTypes_StandaloneLoop_TwoKeywordGroups_DispatchTheRightBodies()
+    {
+        await AssertGeneratedTypeEvaluates(
+            StandaloneTwoKeywordGroupsSchema,
+            "issue949StandaloneTwoKeywordGroups.json",
+            /*lang=json*/ """{"common": "ok", "p1": 42, "p2": 7, "p3": "hi"}""",
+            expected: true,
+            "Every property satisfies its own subschema in both groups, so it must be valid.");
+
+        await AssertGeneratedTypeEvaluates(
+            StandaloneTwoKeywordGroupsSchema,
+            "issue949StandaloneTwoKeywordGroups.json",
+            /*lang=json*/ """{"common": "ok", "p1": 42, "p3": 12}""",
+            expected: false,
+            "'p3' violates the allOf branch's string type, so it must be invalid.");
+    }
+
+    private static async Task AssertGeneratedTypeEvaluates(string schemaText, string virtualFilename, string instanceJson, bool expected, string message)
+    {
+        Corvus.Text.Json.Validator.DynamicJsonType type = await TestJsonSchemaCodeGenerator.GenerateTypeForVirtualFile(
+            virtualFilename,
+            schemaText,
+            "Corvus.Text.Json.EvaluatorTestSuite.Tests.NestedRequiredDoubleEvaluationTypes",
+            "./someFakePath",
+            Corvus.Json.CodeGeneration.Draft202012.VocabularyAnalyser.DefaultVocabulary,
+            validateFormat: false,
+            optionalAsNullable: false,
+            useImplicitOperatorString: false,
+            addExplicitUsings: true,
+            Assembly.GetExecutingAssembly());
+
+        Corvus.Text.Json.Validator.DynamicJsonElement instance = type.ParseInstance(instanceJson);
+        Assert.AreEqual(expected, instance.EvaluateSchema(), $"[Generated types] {message}");
+
+        using JsonSchemaResultsCollector collector = JsonSchemaResultsCollector.CreateUnrented(JsonSchemaResultsLevel.Verbose);
+        Assert.AreEqual(expected, instance.EvaluateSchema(collector), $"[Generated types, verbose collector] {message}");
+    }
+
+    private static void AssertEvaluates(CompiledEvaluator evaluator, string instanceJson, bool expected, string message)
+    {
+        using var doc = ParsedJsonDocument<JsonElement>.Parse(instanceJson);
+        Assert.AreEqual(expected, evaluator.Evaluate(doc.RootElement), $"{message} Generated code:{System.Environment.NewLine}{evaluator.GeneratedCode}");
+
+        using JsonSchemaResultsCollector collector = JsonSchemaResultsCollector.CreateUnrented(JsonSchemaResultsLevel.Verbose);
+        Assert.AreEqual(expected, evaluator.Evaluate(doc.RootElement, collector), $"[With verbose collector] {message} Generated code:{System.Environment.NewLine}{evaluator.GeneratedCode}");
+    }
+
+    private static ValueTask<CompiledEvaluator> GenerateAsync(string schemaText, string virtualFilename)
+    {
+        return TestEvaluatorHelper.GenerateEvaluatorForVirtualFileAsync(
+            virtualFilename,
+            schemaText,
+            "Corvus.Text.Json.EvaluatorTestSuite.Tests.NestedRequiredDoubleEvaluation",
+            "./someFakePath",
+            Corvus.Json.CodeGeneration.Draft202012.VocabularyAnalyser.DefaultVocabulary,
+            validateFormat: false,
+            Assembly.GetExecutingAssembly());
+    }
+}


### PR DESCRIPTION
Fixes #949.

## The defect

The unified property map built for hoisted `$ref`/`allOf` composition (active when a composition contributes 4 or more properties) indexed local and hoisted entries independently, with no deduplication by JSON property name. The hash lookup resolves a name to exactly one index, so a name declared in both the local `properties` and a hoisted branch (or in two hoisted branches) left one dispatch site unreachable. Whichever site lost the lookup was silently skipped:

- its `required` tracking bit was never set, so a present property was reported as "Required property not present" (the false rejection in the issue report, reproduced against the reporter's log line for line), and
- its property subschema was never evaluated, producing proven false accepts (for example a `const` on the shared name not enforced).

## The fix

The map and every switch that consumes it now iterate a single dispatch plan with one entry per distinct JSON property name, carrying the local site plus every hoisted site; a shared name's case executes the local match first and then each hoisted branch body. The standalone loop (no parent object keywords) keys its per-keyword-group switches off the same plan, which also fixes index misalignment between the shared map and each group's locally numbered switch.

En route, test coverage exposed a further pre-existing defect: branch-scoped identifiers were derived from the per-keyword branch index alone, so a type hoisting branches from both `$ref` and `allOf` emitted colliding fields and locals that failed to compile. Identifiers are now disambiguated across keyword groups.

Emitted code is byte-identical for schemas with no shared names. The standalone evaluator surface was already correct and is unchanged.

## Verification

- Revert/fail, reapply/pass: all five genuine repros fail on the old generator; 11/11 tests in `NestedRequiredDoubleEvaluationTests.cs` pass with the fix (wrapped `$ref` chain with overlapping `required`, `unevaluatedProperties` variant, `const` false-accept, standalone cross-branch collision, standalone two keyword groups, plus standalone-evaluator twins).
- Full solution build: 0 warnings. Full test suite: 94,479 passed, 0 failed (net10.0; the net481 halves cannot launch on the Linux dev box, which is pre-existing and covered by CI on Windows).
- Checked-in generated code scanned for colliding maps: AsyncApi26/30, all example recipes, and the playgrounds are unaffected. The Ui5Manifest benchmark `Input*` models do carry the collision baked in; per the benchmark baseline policy, `B/` is untouched and the `C/` regeneration is left to the separate benchmark regeneration pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016fMWB9opbgcQ2JGzqxVYZA